### PR TITLE
feat(world-line): WorldObjectを導入し、複数コンポーネント管理の拡張性を向上

### DIFF
--- a/apps/bublys-os/app/world-line/Counter/domain/Counter.ts
+++ b/apps/bublys-os/app/world-line/Counter/domain/Counter.ts
@@ -39,3 +39,4 @@ export class Counter {
     return new Counter(json.value || 0);
   }
 }
+

--- a/apps/bublys-os/app/world-line/Counter/feature/CounterManager.tsx
+++ b/apps/bublys-os/app/world-line/Counter/feature/CounterManager.tsx
@@ -1,0 +1,48 @@
+import { Counter } from '../domain/Counter';
+
+/**
+ * Counter用のWorldState型定義
+ */
+export interface CounterWorldState {
+  counters: Map<string, Counter>;
+}
+
+/**
+ * CounterWorldStateのシリアライズ
+ */
+export function serializeCounterWorldState(state: CounterWorldState): any {
+  return {
+    counters: Array.from(state.counters.entries()).map(([id, counter]) => ({
+      id,
+      counter: counter.toJson()
+    })),
+  };
+}
+
+/**
+ * CounterWorldStateのデシリアライズ
+ */
+export function deserializeCounterWorldState(data: any): CounterWorldState {
+  const counters = new Map<string, Counter>();
+  
+  if (data?.counters && Array.isArray(data.counters)) {
+    for (const { id, counter } of data.counters) {
+      counters.set(id, Counter.fromJson(counter));
+    }
+  }
+  
+  return { counters };
+}
+
+/**
+ * Counter用の初期WorldStateを作成
+ */
+export function createInitialCounterWorldState(): CounterWorldState {
+  const initialCounters = new Map<string, Counter>([
+    ['counter-1', new Counter(100)],
+    ['counter-2', new Counter(200)]
+  ]);
+  
+  return { counters: initialCounters };
+}
+

--- a/apps/bublys-os/app/world-line/Counter/ui/CounterView.tsx
+++ b/apps/bublys-os/app/world-line/Counter/ui/CounterView.tsx
@@ -68,3 +68,4 @@ export function CounterView({ counter, onCounterChange }: CounterViewProps) {
     </div>
   );
 }
+

--- a/apps/bublys-os/app/world-line/CounterWorldLineGitManager.tsx
+++ b/apps/bublys-os/app/world-line/CounterWorldLineGitManager.tsx
@@ -1,0 +1,30 @@
+'use client';
+import React from 'react';
+import { WorldLineGitManager } from './WorldLineGit/feature/WorldLineGitManager';
+import { 
+  CounterWorldState, 
+  serializeCounterWorldState, 
+  deserializeCounterWorldState,
+  createInitialCounterWorldState
+} from './Counter/feature/CounterManager';
+
+/**
+ * CounterとWorldLineGitを統合するマネージャーコンポーネント
+ * WorldLineGitManagerに具体的な型（CounterWorldState）を適用
+ */
+interface CounterWorldLineGitManagerProps {
+  children: React.ReactNode;
+}
+
+export function CounterWorldLineGitManager({ children }: CounterWorldLineGitManagerProps) {
+  return (
+    <WorldLineGitManager<CounterWorldState>
+      serialize={serializeCounterWorldState}
+      deserialize={deserializeCounterWorldState}
+      createInitialWorldState={createInitialCounterWorldState}
+    >
+      {children}
+    </WorldLineGitManager>
+  );
+}
+

--- a/apps/bublys-os/app/world-line/WorldLineGit/WorldLineGit-ClassDiagram.md
+++ b/apps/bublys-os/app/world-line/WorldLineGit/WorldLineGit-ClassDiagram.md
@@ -1,0 +1,384 @@
+# WorldLineGit クラス図
+
+## 概要
+WorldLineGitは、Gitのような分岐構造を持つ世界線管理システムです。各世界（World）はWorldObjectを通じて複数のコンポーネント（現在はCounter）を管理し、世界の変更は新しい世界の作成として表現されます。WorldObjectという中間層を設けることで、Counterだけでなく、BubblesUIなど他のコンポーネントも簡単に追加できる拡張性の高い設計となっています。
+
+---
+
+## クラス図 (Mermaid)
+
+```mermaid
+classDiagram
+    %% ドメインクラス
+    class Counter {
+        +number value
+        +countUp() Counter
+        +countDown() Counter
+        +toJson() object
+        +fromJson(json)$ Counter
+    }
+
+    class WorldObject {
+        <<interface>>
+        +Map~string,Counter~ counters
+    }
+
+    class World {
+        +string worldId
+        +string|null parentWorldId
+        +WorldObject worldObject
+        +string currentWorldLineId
+        +updateCounter(counterId, newCounter) World
+        +addCounter(counterId, counter) World
+        +removeCounter(counterId) World
+        +updateCurrentWorldLineId(newWorldLineId) World
+        +toJson() object
+        +fromJson(json)$ World
+    }
+
+    class WorldLineGit {
+        +Map~string,World~ worlds
+        +string|null headWorldId
+        +string|null rootWorldId
+        +addWorld(world) WorldLineGit
+        +getHeadWorld() World|null
+        +getWorld(worldId) World|null
+        +getWorldHistory(worldId) World[]
+        +checkoutForUndo(worldId) WorldLineGit
+        +checkout(worldId) WorldLineGit
+        +createBranch(fromWorldId) WorldLineGit
+        +getAllWorlds() World[]
+        +getWorldTree() object
+        +getWorldsByWorldLineId(worldLineId) World[]
+        +toJson() object
+        +fromJson(json)$ WorldLineGit
+    }
+
+    %% コンテキスト
+    class WorldLineGitContextType {
+        +World|null currentWorld
+        +string|null currentWorldId
+        +updateCounter(counterId, newCounter) void
+        +checkout(worldId) void
+        +undo() void
+        +showAllWorldLines() void
+        +initialize() void
+        +getAllWorlds() World[]
+        +getWorldTree() object
+        +boolean isModalOpen
+        +closeModal() void
+        +boolean isInitializing
+        +boolean isInitialized
+    }
+
+    %% マネージャーコンポーネント
+    class WorldLineGitManager {
+        -WorldLineGit|null worldLineGit
+        -World|null currentWorld
+        -boolean isModalOpen
+        -boolean isInitializing
+        +initializeHandler() void
+        +updateCounterHandler(counterId, newCounter) void
+        +checkoutHandler(worldId) void
+        +undoHandler() void
+        +showAllWorldLinesHandler() void
+        +closeModal() void
+        +getAllWorlds() World[]
+        +getWorldTree() object
+        -updateWorldLineGit(newWorldLineGit, operation) void
+    }
+
+    %% UIコンポーネント
+    class CounterView {
+        +Counter counter
+        +onCounterChange(newCounter) void
+        +handleCountUp() void
+        +handleCountDown() void
+    }
+
+    class CreateTreeView {
+        +World[] creates
+        +string|null currentCreateId
+        +onCreateSelect(createId) void
+        +object createTree
+        +renderCreateNode(create, level) JSX
+    }
+
+    class WorldLineGitView {
+        +handleWorldSelect(worldId) void
+    }
+
+    %% 関係性
+    World "1" *-- "1" WorldObject : contains
+    WorldObject "1" *-- "*" Counter : contains
+    WorldLineGit "1" *-- "*" World : manages
+    
+    WorldLineGitManager ..> WorldLineGit : uses
+    WorldLineGitManager ..> World : uses
+    WorldLineGitManager ..> Counter : uses
+    WorldLineGitManager ..|> WorldLineGitContextType : provides
+    
+    WorldLineGitView ..> WorldLineGitContextType : consumes
+    WorldLineGitView ..> CounterView : uses
+    WorldLineGitView ..> CreateTreeView : uses
+    
+    CounterView ..> Counter : displays
+    CreateTreeView ..> World : displays
+```
+
+---
+
+## クラス詳細
+
+### ドメイン層
+
+#### Counter
+**責務**: カウンター値の管理と不変性の保持
+
+- `value: number` - カウンター値
+- `countUp(): Counter` - カウンターを1増加（新しいインスタンスを返す）
+- `countDown(): Counter` - カウンターを1減少（新しいインスタンスを返す）
+- `toJson(): object` - JSON形式に変換
+- `fromJson(json): Counter` - JSONから復元
+
+**不変性**: すべての操作は新しいインスタンスを返します。
+
+---
+
+#### WorldObject
+**責務**: 世界内のすべてのコンポーネントを含むコンテナ
+
+- `counters: Map<string, Counter>` - この世界の複数のカウンター
+- 将来の拡張用フィールド（例: `bubblesUI?: BubblesUI`）
+
+**拡張性**: このインターフェースに新しいフィールドを追加することで、Worldクラスを変更せずに新しいコンポーネントタイプをサポートできます。
+
+---
+
+#### World
+**責務**: 世界の状態を表現し、世界線の概念を含む。WorldObjectを通じて複数のコンポーネントを管理する。
+
+- `worldId: string` - 世界の一意なID
+- `parentWorldId: string | null` - 親世界のID（分岐元）
+- `worldObject: WorldObject` - この世界に含まれるすべてのコンポーネント
+- `currentWorldLineId: string` - 現在の世界線ID
+- `updateCounter(counterId, newCounter): World` - 特定のカウンターを更新した新しい世界を作成
+- `addCounter(counterId, counter): World` - 新しいカウンターを追加した新しい世界を作成
+- `removeCounter(counterId): World` - カウンターを削除した新しい世界を作成
+- `updateCurrentWorldLineId(newWorldLineId): World` - 世界線IDを更新
+- `toJson(): object` - JSON形式に変換（worldObjectを含む）
+- `fromJson(json): World` - JSONから復元（worldObject形式と旧形式の両方をサポート）
+
+**不変性**: すべての更新操作は新しいWorldインスタンスを返します。
+
+**拡張性**: WorldObjectという中間層を設けることで、Worldクラス自体を変更せずに新しいコンポーネントタイプを追加できます。
+
+---
+
+#### WorldLineGit
+**責務**: 世界のコレクションを管理し、Git風のバージョン管理を提供
+
+- `worlds: Map<string, World>` - すべての世界を格納
+- `headWorldId: string | null` - 現在の世界（HEAD）のID
+- `rootWorldId: string | null` - ルート世界のID
+- `addWorld(world): WorldLineGit` - 新しい世界を追加
+- `getHeadWorld(): World | null` - 現在の世界を取得
+- `getWorld(worldId): World | null` - 指定された世界を取得
+- `getWorldHistory(worldId): World[]` - 世界の履歴を取得
+- `checkoutForUndo(worldId): WorldLineGit` - undo用チェックアウト（世界線ID変更なし）
+- `checkout(worldId): WorldLineGit` - 指定された世界にチェックアウト
+- `createBranch(fromWorldId): WorldLineGit` - 新しいブランチを作成
+- `getAllWorlds(): World[]` - すべての世界を取得
+- `getWorldTree(): object` - 世界のツリー構造を取得
+- `getWorldsByWorldLineId(worldLineId): World[]` - 特定の世界線の世界を取得
+- `toJson(): object` - JSON形式に変換
+- `fromJson(json): WorldLineGit` - JSONから復元
+
+**不変性**: すべての操作は新しいWorldLineGitインスタンスを返します。
+
+---
+
+### コンテキスト層
+
+#### WorldLineGitContextType
+**責務**: Reactコンポーネント間で状態とアクションを共有
+
+**状態**:
+- `currentWorld: World | null` - 現在の世界
+- `currentWorldId: string | null` - 現在の世界ID
+- `isModalOpen: boolean` - モーダル表示状態
+- `isInitializing: boolean` - 初期化中フラグ
+- `isInitialized: boolean` - 初期化済みフラグ
+
+**アクション**:
+- `updateCounter(counterId, newCounter): void` - 特定のカウンターを更新
+- `checkout(worldId): void` - 指定された世界にチェックアウト
+- `undo(): void` - 現在の世界線で子要素に移動（Ctrl+Shift+Z）
+- `showAllWorldLines(): void` - すべての世界線を表示（Ctrl+Z）
+- `initialize(): void` - 初期化（2つのCounterを含む初期世界を作成）
+- `getAllWorlds(): World[]` - すべての世界を取得
+- `getWorldTree(): object` - 世界ツリーを取得
+- `closeModal(): void` - モーダルを閉じる
+
+---
+
+### フィーチャー層
+
+#### WorldLineGitManager
+**責務**: WorldLineGitの状態管理とRedux統合
+
+**主要機能**:
+- Redux状態の購読と更新
+- ドメインオブジェクトの変換（JSON ↔ ドメインオブジェクト）
+- キーボードショートカットの処理
+  - `Ctrl+Z`: すべての世界線を表示
+  - `Ctrl+Shift+Z`: 現在の世界線で次の世界に移動（undo）
+- WorldLineGitContextの値を提供
+
+**状態管理ロジック**:
+- カウンター更新時、子要素がある場合は新しい世界線IDを生成
+- 子要素がない場合は現在の世界線で継続
+
+---
+
+### UI層
+
+#### CounterView
+**責務**: カウンターの表示と操作
+
+- `counter: Counter` - 表示するカウンター
+- `onCounterChange(newCounter): void` - カウンター変更時のコールバック
+- `handleCountUp()` - カウントアップボタンのハンドラー
+- `handleCountDown()` - カウントダウンボタンのハンドラー
+
+---
+
+#### CreateTreeView
+**責務**: 世界のツリー構造を視覚化
+
+- `creates: World[]` - 表示する世界のリスト
+- `currentCreateId: string | null` - 現在選択されている世界ID
+- `onCreateSelect(createId): void` - 世界選択時のコールバック
+- `createTree: object` - 世界のツリー構造
+- `renderCreateNode(create, level)` - 世界ノードを再帰的にレンダリング
+
+---
+
+#### WorldLineGitView
+**責務**: メインのビューコンポーネント
+
+**表示要素**:
+- 初期化ボタン（未初期化時）
+- 現在の世界のカウンター（初期化済み時）
+- 世界ツリー（Ctrl+Zで表示）
+
+---
+
+## アーキテクチャパターン
+
+### 階層構造
+```
+UI層 (WorldLineGitView, CounterView, CreateTreeView)
+    ↓ (Context経由)
+Feature層 (WorldLineGitManager)
+    ↓ (Redux経由)
+Domain層 (WorldLineGit, World, Counter)
+```
+
+### データフロー
+1. **ユーザー操作** → UI層
+2. **アクション実行** → Feature層（Context経由）
+3. **ドメインロジック実行** → Domain層
+4. **状態更新** → Redux
+5. **再レンダリング** → UI層
+
+### 不変性パターン
+すべてのドメインクラス（Counter, World, WorldLineGit）は不変であり、更新操作は常に新しいインスタンスを返します。これにより：
+- 予測可能な状態管理
+- タイムトラベルデバッグの実現
+- Redux統合の簡素化
+
+---
+
+## 世界線の概念
+
+### 世界線とは
+- 各世界は`currentWorldLineId`を持つ
+- 同じ世界線IDを持つ世界は連続した一つの時間軸を表す
+- 分岐が発生すると新しい世界線IDが生成される
+
+### 分岐のルール
+- 子要素がない世界でカウンターを変更 → 同じ世界線で継続
+- 子要素がある世界でカウンターを変更 → 新しい世界線を作成
+
+### キーボードショートカット
+- **Ctrl+Z**: すべての世界線をモーダルで表示
+- **Ctrl+Shift+Z**: 現在の世界線で次の世界に移動（redo的な動作）
+
+---
+
+## Redux統合
+
+WorldLineGitManagerは以下のRedux機能を使用：
+- `useAppSelector`: 状態の購読
+- `useAppDispatch`: アクションのディスパッチ
+- `selectWorldLineGit`: WorldLineGit状態の選択
+- `selectHeadWorld`: 現在の世界の選択
+- `initialize`: 初期化アクション
+- `updateState`: 状態更新アクション
+
+---
+
+## 使用例
+
+```typescript
+// 初期化（2つのCounterを含む初期世界を作成）
+initialize();
+
+// 特定のカウンターを増加
+const counter1 = currentWorld.worldObject.counters.get('counter-1');
+if (counter1) {
+  const newCounter = counter1.countUp();
+  updateCounter('counter-1', newCounter);
+}
+
+// 別のカウンターを減少
+const counter2 = currentWorld.worldObject.counters.get('counter-2');
+if (counter2) {
+  const newCounter = counter2.countDown();
+  updateCounter('counter-2', newCounter);
+}
+
+// 過去の世界にチェックアウト
+checkout(someWorldId);
+
+// 現在の世界線で次の世界に移動
+undo();
+
+// すべての世界線を表示
+showAllWorldLines();
+
+// 全てのCounterを取得
+const allCounters = Array.from(currentWorld.worldObject.counters.entries());
+allCounters.forEach(([id, counter]) => {
+  console.log(`${id}: ${counter.value}`);
+});
+```
+
+---
+
+## まとめ
+
+WorldLineGitは、以下の特徴を持つ洗練された世界線管理システムです：
+
+1. **不変性**: すべてのドメインオブジェクトが不変
+2. **Git風の操作**: checkout, undo, branch作成など
+3. **世界線の概念**: 並行する複数の時間軸を管理
+4. **WorldObject設計**: 中間層としてWorldObjectを導入し、拡張性を確保
+5. **複数コンポーネント対応**: 一つの世界に複数のコンポーネント（現在はCounter）を含む
+6. **高い拡張性**: WorldObjectに新しいフィールドを追加するだけで、BubblesUIなど他のコンポーネントをサポート可能
+7. **React統合**: Context APIとReduxを活用
+8. **キーボードショートカット**: 直感的な操作
+9. **ツリー視覚化**: 世界の親子関係を視覚的に表示
+10. **後方互換性**: 旧形式のデータもサポート
+

--- a/apps/bublys-os/app/world-line/WorldLineGit/domain/World.ts
+++ b/apps/bublys-os/app/world-line/WorldLineGit/domain/World.ts
@@ -1,90 +1,34 @@
-import { Counter } from './Counter';
-
 /**
- * WorldObject 型定義
- * 世界の中に存在するすべてのコンポーネントを含む
- * 将来的には bubblesUI などのコンポーネントも追加可能
- */
-export interface WorldObject {
-  counters: Map<string, Counter>;
-  // 将来の拡張用
-  // bubblesUI?: BubblesUI;
-  // otherComponent?: OtherComponent;
-}
-
-/**
- * World クラス
+ * World クラス（ジェネリック版）
  * 世界の状態を表現し、世界線の概念を含む
- * worldObjectを通じて複数のコンポーネントを管理する
+ * 任意の型のWorldStateを管理可能
  */
-export class World {
+export class World<TWorldState = any> {
   public readonly worldId: string;
   public readonly parentWorldId: string | null;
-  public readonly worldObject: WorldObject; // 世界内のすべてのコンポーネント
+  public readonly worldState: TWorldState;
   public readonly currentWorldLineId: string;
 
   constructor(
     worldId: string,
-    parentWorldId: string | null = null,
-    worldObject: WorldObject = { counters: new Map() },
-    currentWorldLineId: string = ''
+    parentWorldId: string | null,
+    worldState: TWorldState,
+    currentWorldLineId: string
   ) {
     this.worldId = worldId;
     this.parentWorldId = parentWorldId;
-    this.worldObject = worldObject;
-    this.currentWorldLineId = currentWorldLineId || worldId; // デフォルトは自身のID
+    this.worldState = worldState;
+    this.currentWorldLineId = currentWorldLineId || worldId;
   }
 
   /**
-   * 特定のカウンターを更新した新しい世界を作成
+   * WorldStateを更新した新しい世界を作成
    */
-  public updateCounter(counterId: string, newCounter: Counter): World {
-    const newCounters = new Map(this.worldObject.counters);
-    newCounters.set(counterId, newCounter);
-    
-    return new World(
+  public updateWorldState(newWorldState: TWorldState): World<TWorldState> {
+    return new World<TWorldState>(
       crypto.randomUUID(),
       this.worldId,
-      {
-        ...this.worldObject,
-        counters: newCounters,
-      },
-      this.currentWorldLineId
-    );
-  }
-
-  /**
-   * 新しいカウンターを追加した新しい世界を作成
-   */
-  public addCounter(counterId: string, counter: Counter = new Counter()): World {
-    const newCounters = new Map(this.worldObject.counters);
-    newCounters.set(counterId, counter);
-    
-    return new World(
-      crypto.randomUUID(),
-      this.worldId,
-      {
-        ...this.worldObject,
-        counters: newCounters,
-      },
-      this.currentWorldLineId
-    );
-  }
-
-  /**
-   * カウンターを削除した新しい世界を作成
-   */
-  public removeCounter(counterId: string): World {
-    const newCounters = new Map(this.worldObject.counters);
-    newCounters.delete(counterId);
-    
-    return new World(
-      crypto.randomUUID(),
-      this.worldId,
-      {
-        ...this.worldObject,
-        counters: newCounters,
-      },
+      newWorldState,
       this.currentWorldLineId
     );
   }
@@ -92,63 +36,44 @@ export class World {
   /**
    * 現在の世界線IDを更新した新しい世界を作成
    */
-  public updateCurrentWorldLineId(newWorldLineId: string): World {
-    return new World(
+  public updateCurrentWorldLineId(newWorldLineId: string): World<TWorldState> {
+    return new World<TWorldState>(
       this.worldId,
       this.parentWorldId,
-      this.worldObject,
+      this.worldState,
       newWorldLineId
     );
   }
 
   /**
    * JSON形式に変換
+   * worldStateのシリアライズは呼び出し側の責任
    */
-  public toJson(): object {
+  public toJson(worldStateSerializer?: (state: TWorldState) => any): object {
     return {
       worldId: this.worldId,
       parentWorldId: this.parentWorldId,
-      worldObject: {
-        counters: Array.from(this.worldObject.counters.entries()).map(([id, counter]) => ({
-          id,
-          counter: counter.toJson()
-        })),
-      },
+      worldState: worldStateSerializer ? worldStateSerializer(this.worldState) : this.worldState,
       currentWorldLineId: this.currentWorldLineId,
     };
   }
 
   /**
    * JSONからWorldインスタンスを作成
+   * worldStateのデシリアライズは呼び出し側の責任
    */
-  public static fromJson(json: any): World {
-    const counters = new Map<string, Counter>();
+  public static fromJson<TWorldState>(
+    json: any,
+    worldStateDeserializer?: (data: any) => TWorldState
+  ): World<TWorldState> {
+    const worldState = worldStateDeserializer 
+      ? worldStateDeserializer(json.worldState || json.worldObject) 
+      : (json.worldState || json.worldObject);
     
-    // 新しい形式（worldObject.counters）
-    if (json.worldObject?.counters && Array.isArray(json.worldObject.counters)) {
-      for (const { id, counter } of json.worldObject.counters) {
-        counters.set(id, Counter.fromJson(counter));
-      }
-    }
-    // 中間形式（直接counters）- 後方互換性
-    else if (json.counters && Array.isArray(json.counters)) {
-      for (const { id, counter } of json.counters) {
-        counters.set(id, Counter.fromJson(counter));
-      }
-    }
-    // 旧形式（単一counter）- 後方互換性
-    else if (json.counter) {
-      counters.set('counter-0', Counter.fromJson(json.counter));
-    }
-    
-    const worldObject: WorldObject = {
-      counters,
-    };
-    
-    return new World(
-      json.worldId || json.commitId || '', // 後方互換性のためcommitIdもサポート
+    return new World<TWorldState>(
+      json.worldId || json.commitId || '',
       json.parentWorldId || json.parentCommitId || null,
-      worldObject,
+      worldState,
       json.currentWorldLineId || json.worldId || json.commitId || ''
     );
   }

--- a/apps/bublys-os/app/world-line/WorldLineGit/domain/World.ts
+++ b/apps/bublys-os/app/world-line/WorldLineGit/domain/World.ts
@@ -1,35 +1,90 @@
 import { Counter } from './Counter';
 
 /**
+ * WorldObject 型定義
+ * 世界の中に存在するすべてのコンポーネントを含む
+ * 将来的には bubblesUI などのコンポーネントも追加可能
+ */
+export interface WorldObject {
+  counters: Map<string, Counter>;
+  // 将来の拡張用
+  // bubblesUI?: BubblesUI;
+  // otherComponent?: OtherComponent;
+}
+
+/**
  * World クラス
  * 世界の状態を表現し、世界線の概念を含む
+ * worldObjectを通じて複数のコンポーネントを管理する
  */
 export class World {
   public readonly worldId: string;
   public readonly parentWorldId: string | null;
-  public readonly counter: Counter;
+  public readonly worldObject: WorldObject; // 世界内のすべてのコンポーネント
   public readonly currentWorldLineId: string;
 
   constructor(
     worldId: string,
     parentWorldId: string | null = null,
-    counter: Counter = new Counter(),
+    worldObject: WorldObject = { counters: new Map() },
     currentWorldLineId: string = ''
   ) {
     this.worldId = worldId;
     this.parentWorldId = parentWorldId;
-    this.counter = counter;
+    this.worldObject = worldObject;
     this.currentWorldLineId = currentWorldLineId || worldId; // デフォルトは自身のID
   }
 
   /**
-   * カウンターを更新した新しい世界を作成
+   * 特定のカウンターを更新した新しい世界を作成
    */
-  public updateCounter(newCounter: Counter): World {
+  public updateCounter(counterId: string, newCounter: Counter): World {
+    const newCounters = new Map(this.worldObject.counters);
+    newCounters.set(counterId, newCounter);
+    
     return new World(
       crypto.randomUUID(),
       this.worldId,
-      newCounter,
+      {
+        ...this.worldObject,
+        counters: newCounters,
+      },
+      this.currentWorldLineId
+    );
+  }
+
+  /**
+   * 新しいカウンターを追加した新しい世界を作成
+   */
+  public addCounter(counterId: string, counter: Counter = new Counter()): World {
+    const newCounters = new Map(this.worldObject.counters);
+    newCounters.set(counterId, counter);
+    
+    return new World(
+      crypto.randomUUID(),
+      this.worldId,
+      {
+        ...this.worldObject,
+        counters: newCounters,
+      },
+      this.currentWorldLineId
+    );
+  }
+
+  /**
+   * カウンターを削除した新しい世界を作成
+   */
+  public removeCounter(counterId: string): World {
+    const newCounters = new Map(this.worldObject.counters);
+    newCounters.delete(counterId);
+    
+    return new World(
+      crypto.randomUUID(),
+      this.worldId,
+      {
+        ...this.worldObject,
+        counters: newCounters,
+      },
       this.currentWorldLineId
     );
   }
@@ -41,7 +96,7 @@ export class World {
     return new World(
       this.worldId,
       this.parentWorldId,
-      this.counter,
+      this.worldObject,
       newWorldLineId
     );
   }
@@ -53,7 +108,12 @@ export class World {
     return {
       worldId: this.worldId,
       parentWorldId: this.parentWorldId,
-      counter: this.counter.toJson(),
+      worldObject: {
+        counters: Array.from(this.worldObject.counters.entries()).map(([id, counter]) => ({
+          id,
+          counter: counter.toJson()
+        })),
+      },
       currentWorldLineId: this.currentWorldLineId,
     };
   }
@@ -62,10 +122,33 @@ export class World {
    * JSONからWorldインスタンスを作成
    */
   public static fromJson(json: any): World {
+    const counters = new Map<string, Counter>();
+    
+    // 新しい形式（worldObject.counters）
+    if (json.worldObject?.counters && Array.isArray(json.worldObject.counters)) {
+      for (const { id, counter } of json.worldObject.counters) {
+        counters.set(id, Counter.fromJson(counter));
+      }
+    }
+    // 中間形式（直接counters）- 後方互換性
+    else if (json.counters && Array.isArray(json.counters)) {
+      for (const { id, counter } of json.counters) {
+        counters.set(id, Counter.fromJson(counter));
+      }
+    }
+    // 旧形式（単一counter）- 後方互換性
+    else if (json.counter) {
+      counters.set('counter-0', Counter.fromJson(json.counter));
+    }
+    
+    const worldObject: WorldObject = {
+      counters,
+    };
+    
     return new World(
       json.worldId || json.commitId || '', // 後方互換性のためcommitIdもサポート
       json.parentWorldId || json.parentCommitId || null,
-      Counter.fromJson(json.counter || {}),
+      worldObject,
       json.currentWorldLineId || json.worldId || json.commitId || ''
     );
   }

--- a/apps/bublys-os/app/world-line/WorldLineGit/domain/WorldLineGitContext.ts
+++ b/apps/bublys-os/app/world-line/WorldLineGit/domain/WorldLineGitContext.ts
@@ -1,23 +1,23 @@
 import { createContext } from "react";
 import { World } from "./World";
-import { Counter } from "./Counter";
 
 /**
- * WorldLineGitContext の型定義
+ * WorldLineGitContext の型定義（ジェネリック版）
+ * 任意のWorldStateを管理可能
  */
-export type WorldLineGitContextType = {
-  currentWorld: World | null;
+export type WorldLineGitContextType<TWorldState = any> = {
+  currentWorld: World<TWorldState> | null;
   currentWorldId: string | null;
 
   // アクション
-  updateCounter: (counterId: string, newCounter: Counter) => void;
+  updateWorldState: (newWorldState: TWorldState) => void;
   checkout: (worldId: string) => void;
   undo: () => void; // Ctrl+Shift+Z: 現在の世界線で子要素に移動
   showAllWorldLines: () => void; // Ctrl+z: 全ての世界線を表示
   initialize: () => void; // 初期化
   
   // ヘルパー関数
-  getAllWorlds: () => World[];
+  getAllWorlds: () => World<TWorldState>[];
   getWorldTree: () => { [worldId: string]: string[] };
   
   // モーダル関連
@@ -32,12 +32,12 @@ export type WorldLineGitContextType = {
 /**
  * WorldLineGitContext のデフォルト値
  */
-export const WorldLineGitContext = createContext<WorldLineGitContextType>({
+export const WorldLineGitContext = createContext<WorldLineGitContextType<any>>({
   currentWorld: null,
   currentWorldId: null,
 
-  updateCounter: () => {
-    console.warn("updateCounter not implemented");
+  updateWorldState: () => {
+    console.warn("updateWorldState not implemented");
   },
   checkout: () => {
     console.warn("checkout not implemented");

--- a/apps/bublys-os/app/world-line/WorldLineGit/domain/WorldLineGitContext.ts
+++ b/apps/bublys-os/app/world-line/WorldLineGit/domain/WorldLineGitContext.ts
@@ -10,7 +10,7 @@ export type WorldLineGitContextType = {
   currentWorldId: string | null;
 
   // アクション
-  updateCounter: (newCounter: Counter) => void;
+  updateCounter: (counterId: string, newCounter: Counter) => void;
   checkout: (worldId: string) => void;
   undo: () => void; // Ctrl+Shift+Z: 現在の世界線で子要素に移動
   showAllWorldLines: () => void; // Ctrl+z: 全ての世界線を表示

--- a/apps/bublys-os/app/world-line/WorldLineGit/feature/WorldLineGitManager.tsx
+++ b/apps/bublys-os/app/world-line/WorldLineGit/feature/WorldLineGitManager.tsx
@@ -39,11 +39,16 @@ export function WorldLineGitManager({ children }: WorldLineGitManagerProps) {
     setIsInitializing(true);
     
     try {
-      // 初期状態でルート世界を作成
+      // 初期状態でルート世界を作成（2つのCounterを含む）
+      const initialCounters = new Map<string, Counter>([
+        ['counter-1', new Counter(100)],
+        ['counter-2', new Counter(200)]
+      ]);
+      
       const rootWorld = new World(
         crypto.randomUUID(),
         null,
-        new Counter(100),
+        { counters: initialCounters },
         crypto.randomUUID()
       );
       const initialWorldLineGit = new WorldLineGit(
@@ -71,7 +76,7 @@ export function WorldLineGitManager({ children }: WorldLineGitManagerProps) {
   }, [dispatch]);
 
   // カウンターを更新して新しい世界を作成
-  const updateCounterHandler = useCallback((newCounter: Counter) => {
+  const updateCounterHandler = useCallback((counterId: string, newCounter: Counter) => {
     if (!currentWorld || !worldLineGit) return;
     // 現在の世界に子要素が存在するかチェック
     const worldTree = worldLineGit.getWorldTree();
@@ -84,10 +89,10 @@ export function WorldLineGitManager({ children }: WorldLineGitManagerProps) {
       const newWorldLineId = crypto.randomUUID();
       newWorld = currentWorld
         .updateCurrentWorldLineId(newWorldLineId)
-        .updateCounter(newCounter);
+        .updateCounter(counterId, newCounter);
     } else {
       // 子要素が存在しない場合：現在の世界線でカウンターを更新
-      newWorld = currentWorld.updateCounter(newCounter);
+      newWorld = currentWorld.updateCounter(counterId, newCounter);
     }
     
     // 新しい世界を追加してWorldLineGitを更新

--- a/apps/bublys-os/app/world-line/WorldLineGit/ui/CreateTreeView.tsx
+++ b/apps/bublys-os/app/world-line/WorldLineGit/ui/CreateTreeView.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { World } from '../domain/World';
 
 interface CreateTreeViewProps {
-  creates: World[];
+  creates: World<any>[];
   currentCreateId: string | null;
   onCreateSelect: (createId: string) => void;
   createTree: { [createId: string]: string[] };
@@ -14,9 +14,18 @@ export function CreateTreeView({
   onCreateSelect, 
   createTree 
 }: CreateTreeViewProps) {
-  const renderCreateNode = (create: World, level: number = 0) => {
+  const renderCreateNode = (create: World<any>, level: number = 0) => {
     const isCurrent = create.worldId === currentCreateId;
     const children = createTree[create.worldId] || [];
+    
+    // WorldStateの表示（CounterWorldStateの場合）
+    let stateDisplay = 'State: -';
+    if (create.worldState?.counters) {
+      const countersArray = Array.from(create.worldState.counters.entries()) as [string, any][];
+      stateDisplay = `Counters: ${countersArray
+        .map(([id, counter]) => `${id}: ${counter.value}`)
+        .join(', ')}`;
+    }
     
     return (
       <div key={create.worldId} style={{ marginLeft: `${level * 20}px` }}>
@@ -36,9 +45,7 @@ export function CreateTreeView({
             {create.worldId.substring(0, 8)}...
           </div>
           <div style={{ color: '#666', fontSize: '0.8rem' }}>
-            Counters: {Array.from(create.worldObject.counters.entries())
-              .map(([id, counter]) => `${id}: ${counter.value}`)
-              .join(', ')}
+            {stateDisplay}
           </div>
           <div style={{ color: '#999', fontSize: '0.7rem' }}>
             WorldLine: {create.currentWorldLineId.substring(0, 8)}...

--- a/apps/bublys-os/app/world-line/WorldLineGit/ui/CreateTreeView.tsx
+++ b/apps/bublys-os/app/world-line/WorldLineGit/ui/CreateTreeView.tsx
@@ -36,7 +36,9 @@ export function CreateTreeView({
             {create.worldId.substring(0, 8)}...
           </div>
           <div style={{ color: '#666', fontSize: '0.8rem' }}>
-            Counter: {create.counter.value}
+            Counters: {Array.from(create.worldObject.counters.entries())
+              .map(([id, counter]) => `${id}: ${counter.value}`)
+              .join(', ')}
           </div>
           <div style={{ color: '#999', fontSize: '0.7rem' }}>
             WorldLine: {create.currentWorldLineId.substring(0, 8)}...

--- a/apps/bublys-os/app/world-line/WorldLineGit/ui/WorldLineGitView.tsx
+++ b/apps/bublys-os/app/world-line/WorldLineGit/ui/WorldLineGitView.tsx
@@ -119,10 +119,30 @@ export function WorldLineGitView() {
             </div>
           </div>
           
-          <CounterView
-            counter={currentWorld.counter}
-            onCounterChange={updateCounter}
-          />
+          {/* 複数のカウンターを表示 */}
+          <div style={{ display: 'flex', flexDirection: 'column', gap: '1rem' }}>
+            {Array.from(currentWorld.worldObject.counters.entries()).map(([counterId, counter]) => (
+              <div key={counterId} style={{
+                backgroundColor: '#f8f9fa',
+                padding: '1rem',
+                borderRadius: '8px',
+                border: '2px solid #e9ecef'
+              }}>
+                <div style={{ 
+                  fontSize: '0.9rem', 
+                  fontWeight: 'bold', 
+                  color: '#495057',
+                  marginBottom: '0.5rem'
+                }}>
+                  {counterId}
+                </div>
+                <CounterView
+                  counter={counter}
+                  onCounterChange={(newCounter) => updateCounter(counterId, newCounter)}
+                />
+              </div>
+            ))}
+          </div>
         </div>
       )}
 

--- a/apps/bublys-os/app/world-line/WorldLineGit/ui/WorldLineGitView.tsx
+++ b/apps/bublys-os/app/world-line/WorldLineGit/ui/WorldLineGitView.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { useContext } from 'react';
 import { WorldLineGitContext } from '../domain/WorldLineGitContext';
-import { CounterView } from './CounterView';
+import { CounterView } from '../../Counter/ui/CounterView';
 import { CreateTreeView } from './CreateTreeView';
 
 // InitializeButtonコンポーネントを直接定義
@@ -72,7 +72,7 @@ export function WorldLineGitView() {
   const {
     currentWorld,
     currentWorldId,
-    updateCounter,
+    updateWorldState,
     checkout,
     getAllWorlds,
     getWorldTree,
@@ -121,7 +121,7 @@ export function WorldLineGitView() {
           
           {/* 複数のカウンターを表示 */}
           <div style={{ display: 'flex', flexDirection: 'column', gap: '1rem' }}>
-            {Array.from(currentWorld.worldObject.counters.entries()).map(([counterId, counter]) => (
+            {(Array.from(currentWorld.worldState.counters.entries()) as [string, any][]).map(([counterId, counter]) => (
               <div key={counterId} style={{
                 backgroundColor: '#f8f9fa',
                 padding: '1rem',
@@ -138,7 +138,11 @@ export function WorldLineGitView() {
                 </div>
                 <CounterView
                   counter={counter}
-                  onCounterChange={(newCounter) => updateCounter(counterId, newCounter)}
+                  onCounterChange={(newCounter) => {
+                    const newCounters = new Map(currentWorld.worldState.counters);
+                    newCounters.set(counterId, newCounter);
+                    updateWorldState({ counters: newCounters });
+                  }}
                 />
               </div>
             ))}

--- a/apps/bublys-os/app/world-line/page.tsx
+++ b/apps/bublys-os/app/world-line/page.tsx
@@ -1,11 +1,11 @@
 'use client';
-import { WorldLineGitManager } from './WorldLineGit/feature/WorldLineGitManager';
+import { CounterWorldLineGitManager } from './CounterWorldLineGitManager';
 import { WorldLineGitView } from './WorldLineGit/ui/WorldLineGitView';
 
 export default function Index() {
   return (
-    <WorldLineGitManager>
+    <CounterWorldLineGitManager>
       <WorldLineGitView />
-    </WorldLineGitManager>
+    </CounterWorldLineGitManager>
   );
 }

--- a/bublys-libs/state-management/src/lib/slices/world-slice.ts
+++ b/bublys-libs/state-management/src/lib/slices/world-slice.ts
@@ -2,9 +2,15 @@ import { createSlice } from "@reduxjs/toolkit";
 import type { PayloadAction } from "@reduxjs/toolkit";
 import type { RootState } from "../store.js";
 
-// シリアライズ可能な状態の型定義
+/**
+ * WorldLineGitState - シリアライズ可能な状態の型定義
+ * ジェネリックな設計により、任意のWorldState型を管理可能
+ * 
+ * world: any は WorldLineGit<TWorldState>.toJson() の結果を格納
+ * 実際の型はアプリケーション層で定義される（例：CounterWorldState）
+ */
 export interface WorldLineGitState {
-  worlds: Array<{ id: string; world: any }>; // WorldLineGit.fromJson()が期待する形式
+  worlds: Array<{ id: string; world: any }>; // world.worldState に任意の型が含まれる
   headWorldId: string | null;
   rootWorldId: string | null;
 }


### PR DESCRIPTION
WorldLineGitを汎用バージョン管理システムとして設計し直し、
Counterなどの具体的なドメインオブジェクトから完全に独立させた。

## 主な変更

### ドメイン層
- World<TWorldState>をジェネリック化
  - WorldObjectを削除し、任意のWorldStateを管理可能に
  - Counter特有メソッド（updateCounter等）を削除
  - 汎用的なupdateWorldState()を追加

- WorldLineGit<TWorldState>をジェネリック化
  - 任意の型のWorldStateを持つWorldを管理
  - シリアライズ/デシリアライズを呼び出し側の責任に

- WorldLineGitContext<TWorldState>をジェネリック化
  - updateCounterをupdateWorldStateに変更

### ディレクトリ構造
- Counter/を独立ディレクトリとして新規作成
  - domain/Counter.ts: ドメインロジック
  - feature/CounterManager.tsx: Counter特有のロジック
  - ui/CounterView.tsx: Counter UI

- WorldLineGit/からCounter依存を完全削除
  - domain/Counter.ts → 削除
  - ui/CounterView.tsx → 削除

### Feature層
- Counter/feature/CounterManager.tsx を作成
  - CounterWorldState型定義
  - シリアライズ/デシリアライズ関数
  - 初期状態作成関数

- WorldLineGitManager<TWorldState>を完全にジェネリック化
  - serialize/deserialize/createInitialWorldState を外部から注入
  - Counter依存を完全削除

### 統合層
- CounterWorldLineGitManager.tsxを作成
  - CounterとWorldLineGitを統合する薄いレイヤー
  - WorldLineGitManager<CounterWorldState>として具体型を適用

### その他
- state-management/world-slice.tsのコメントを更新
  - ジェネリックな設計であることを明記

## アーキテクチャの利点
- WorldLineGitは任意のドメイン（Timer等）に対応可能
- 新しいドメイン追加時にWorldLineGitの変更不要
- 完全な関心の分離を実現"