### PR TITLE
feat: 世界線表示bubbleで世界選択と遷移機能を実装 

### DIFF
--- a/apps/bublys-os/app/bubble-ui/BubblesUI/domain/bubbleRoutes.tsx
+++ b/apps/bublys-os/app/bubble-ui/BubblesUI/domain/bubbleRoutes.tsx
@@ -122,9 +122,18 @@ const UserDeleteConfirmBubble: BubbleContentRenderer = ({ bubble }) => {
 
 const MemoBubble: BubbleContentRenderer = ({ bubble }) => {
   const memoId = bubble.name.replace("memos/", "");
+  const { openBubble } = useContext(BubblesContext);
+  const handleOpenWorldLineView = () => {
+    openBubble(`memos/${memoId}/history`, bubble.id);
+  };
 
   return (
-    <MemoWorldLineManager memoId={memoId}>
+    <MemoWorldLineManager 
+      memoId={memoId} 
+      isBubbleMode={false} 
+      onOpenWorldLineView={handleOpenWorldLineView} 
+      onCloseWorldLineView={() => {}}
+    >
       <MemoWorldLineIntegration memoId={memoId} />
     </MemoWorldLineManager>
   );
@@ -210,10 +219,24 @@ const UserGroupBubble: BubbleContentRenderer = ({ bubble }) => {
   return <UserGroupDetail groupId={groupId} onOpenUser={handleOpenUser} />;
 };
 
-const WorldLinesBubble: BubbleContentRenderer = ({ bubble }) => {
-  return <WorldLineView<Bubble>
-    renderWorldState={(_worldState: Bubble, _onWorldStateChange: (worldState: Bubble) => void) => <div>World Line</div>}
-  />
+const MemoWorldLinesBubble: BubbleContentRenderer = ({ bubble }) => {
+  const memoId = bubble.name.replace("memos/", "").replace("/history", "");
+  const dispatch = useAppDispatch();
+  const handleCloseWorldLineView = () => {
+    dispatch(deleteProcessBubble(bubble.id));
+    dispatch(removeBubble(bubble.id));
+  };
+  
+  return (
+    <MemoWorldLineManager 
+      memoId={memoId} 
+      isBubbleMode={true} 
+      onOpenWorldLineView={() => {}} 
+      onCloseWorldLineView={handleCloseWorldLineView}
+    >
+      <MemoWorldLineIntegration memoId={memoId} />
+    </MemoWorldLineManager>
+  );
 };
 
 const routes: BubbleRoute[] = [
@@ -238,8 +261,8 @@ const routes: BubbleRoute[] = [
   { pattern: /^users\/[^/]+\/delete-confirm$/, type: "user-delete-confirm", Component: UserDeleteConfirmBubble },
   { pattern: /^users\/[^/]+$/, type: "user", Component: UserBubble },
   { pattern: /^memos$/, type: "memos", Component: MemosBubble },
-  { pattern: /^memos\/.+$/, type: "memo", Component: MemoBubble },
-  { pattern: /^world-lines\/.+$/, type: "world-lines", Component: WorldLinesBubble },
+  { pattern: /^memos\/[^/]+$/, type: "memo", Component: MemoBubble },
+  { pattern: /^memos\/[^/]+\/history$/, type: "world-lines", Component: MemoWorldLinesBubble },
   { pattern: /^iframes\/.+$/, type: "iframe", Component: ({ bubble }) => {
     const appId = bubble.name.replace("iframes/", "");
     return (<IframeBubble appId={appId} />);

--- a/apps/bublys-os/app/bubble-ui/BubblesUI/domain/bubbleRoutes.tsx
+++ b/apps/bublys-os/app/bubble-ui/BubblesUI/domain/bubbleRoutes.tsx
@@ -32,6 +32,8 @@ import { addUser } from "@bublys-org/state-management";
 import { User } from "@/app/users/domain/User.domain";
 import { selectBubblesRelationByOpeneeId, deleteProcessBubble, removeBubble } from "@bublys-org/bubbles-ui-state";
 import { Memo } from "@/app/world-line/Memo/domain/Memo";
+import { MemoWorldLineManager } from "@/app/world-line/integrations/MemoWorldLineManager";
+import { MemoWorldLineIntegration } from "@/app/world-line/integrations/MemoWorldLineIntegration";
 
 // 各バブルのコンポーネント
 const UsersBubble: BubbleContentRenderer = ({ bubble }) => {
@@ -123,61 +125,73 @@ const MemoBubble: BubbleContentRenderer = ({ bubble }) => {
   const memoId = bubble.name.replace("memos/", "");
   const { openBubble } = useContext(BubblesContext);
 
-  const MemoBubbleContent = () => {
-    const apexWorld = useAppSelector(selectApexWorld(memoId));
-    const currentWorldLine = useAppSelector((state) => state.worldLine.worldLines[memoId]);
-    const dispatch = useAppDispatch();
-
-    const handleMemoChange = (newMemo: Memo) => {
-      if (!currentWorldLine) return;
-
-      const newWorldId = crypto.randomUUID();
-      const newWorld = {
-        id: newWorldId,
-        world: {
-          worldId: newWorldId,
-          parentWorldId: currentWorldLine.apexWorldId,
-          worldState: serializeMemo(newMemo),
-        },
-      };
-
-      const newWorldLine: WorldLineState = {
-        worlds: [...currentWorldLine.worlds, newWorld],
-        apexWorldId: newWorldId,
-        rootWorldId: currentWorldLine.rootWorldId,
-      };
-
-      dispatch(updateState({
-        objectId: memoId,
-        newWorldLine,
-        operation: 'updateMemo'
-      }));
-    };
-
-    if (!apexWorld || !apexWorld.worldState) {
-      return <div>メモが見つかりません</div>;
-    }
-
-    const memo = deserializeMemo(apexWorld.worldState);
 
     return (
-      <div>
-        <MemoTitle
-          memo={memo}
-          onSetAuthor={(userId) => handleMemoChange(memo.setAuthor(userId))}
-          onOpenAuthor={(userId, url) => openBubble(url, bubble.id)}
-        />
-        <MemoEditor
-          memoId={memoId}
-          memo={memo}
-          onMemoChange={handleMemoChange}
-        />
-      </div>
+      <MemoWorldLineManager memoId={memoId}>
+        <MemoWorldLineIntegration memoId={memoId} />
+      </MemoWorldLineManager>
     );
-  };
-
-  return <MemoBubbleContent />;
 };
+
+// const MemoBubble: BubbleContentRenderer = ({ bubble }) => {
+//   const memoId = bubble.name.replace("memos/", "");
+//   const { openBubble } = useContext(BubblesContext);
+
+//   const MemoBubbleContent = () => {
+//     const apexWorld = useAppSelector(selectApexWorld(memoId));
+//     const currentWorldLine = useAppSelector((state) => state.worldLine.worldLines[memoId]);
+//     const dispatch = useAppDispatch();
+
+//     const handleMemoChange = (newMemo: Memo) => {
+//       if (!currentWorldLine) return;
+
+//       const newWorldId = crypto.randomUUID();
+//       const newWorld = {
+//         id: newWorldId,
+//         world: {
+//           worldId: newWorldId,
+//           parentWorldId: currentWorldLine.apexWorldId,
+//           worldState: serializeMemo(newMemo),
+//         },
+//       };
+
+//       const newWorldLine: WorldLineState = {
+//         worlds: [...currentWorldLine.worlds, newWorld],
+//         apexWorldId: newWorldId,
+//         rootWorldId: currentWorldLine.rootWorldId,
+//       };
+
+//       dispatch(updateState({
+//         objectId: memoId,
+//         newWorldLine,
+//         operation: 'updateMemo'
+//       }));
+//     };
+
+//     if (!apexWorld || !apexWorld.worldState) {
+//       return <div>メモが見つかりません</div>;
+//     }
+
+//     const memo = deserializeMemo(apexWorld.worldState);
+
+//     return (
+//       <div>
+//         <MemoTitle
+//           memo={memo}
+//           onSetAuthor={(userId) => handleMemoChange(memo.setAuthor(userId))}
+//           onOpenAuthor={(userId, url) => openBubble(url, bubble.id)}
+//         />
+//         <MemoEditor
+//           memoId={memoId}
+//           memo={memo}
+//           onMemoChange={handleMemoChange}
+//         />
+//       </div>
+//     );
+//   };
+
+//   return <MemoBubbleContent />;
+// };
 
 const MemosBubble: BubbleContentRenderer = ({ bubble }) => {
   const { openBubble } = useContext(BubblesContext);

--- a/apps/bublys-os/app/bubble-ui/BubblesUI/domain/bubbleRoutes.tsx
+++ b/apps/bublys-os/app/bubble-ui/BubblesUI/domain/bubbleRoutes.tsx
@@ -1,6 +1,6 @@
 "use client";
 import { BubbleContentRenderer } from "../ui/BubbleContentRenderer";
-import { registerBubbleTypeResolver } from "@bublys-org/bubbles-ui";
+import { Bubble, registerBubbleTypeResolver } from "@bublys-org/bubbles-ui";
 import { useContext } from "react";
 
 export type BubbleRoute = {
@@ -25,15 +25,14 @@ import { UserCreateFormView } from "@/app/users/ui/UserCreateFormView";
 import { IframeBubble } from "../ui/bubbles/IframeBubble";
 import { UserDeleteConfirm } from "@/app/users/feature/UserDeleteConfirm";
 import { BubblesContext } from "./BubblesContext";
-import { useAppDispatch, useAppSelector, selectApexWorld, updateState } from "@bublys-org/state-management";
-import { deserializeMemo, serializeMemo } from "@/app/world-line/Memo/feature/MemoManager";
-import { WorldLineState } from "@bublys-org/state-management";
+import { useAppDispatch, useAppSelector } from "@bublys-org/state-management";
 import { addUser } from "@bublys-org/state-management";
 import { User } from "@/app/users/domain/User.domain";
 import { selectBubblesRelationByOpeneeId, deleteProcessBubble, removeBubble } from "@bublys-org/bubbles-ui-state";
 import { Memo } from "@/app/world-line/Memo/domain/Memo";
 import { MemoWorldLineManager } from "@/app/world-line/integrations/MemoWorldLineManager";
 import { MemoWorldLineIntegration } from "@/app/world-line/integrations/MemoWorldLineIntegration";
+import { WorldLineView } from "@/app/world-line/WorldLine/ui/WorldLineView";
 
 // 各バブルのコンポーネント
 const UsersBubble: BubbleContentRenderer = ({ bubble }) => {
@@ -123,14 +122,12 @@ const UserDeleteConfirmBubble: BubbleContentRenderer = ({ bubble }) => {
 
 const MemoBubble: BubbleContentRenderer = ({ bubble }) => {
   const memoId = bubble.name.replace("memos/", "");
-  const { openBubble } = useContext(BubblesContext);
 
-
-    return (
-      <MemoWorldLineManager memoId={memoId}>
-        <MemoWorldLineIntegration memoId={memoId} />
-      </MemoWorldLineManager>
-    );
+  return (
+    <MemoWorldLineManager memoId={memoId}>
+      <MemoWorldLineIntegration memoId={memoId} />
+    </MemoWorldLineManager>
+  );
 };
 
 // const MemoBubble: BubbleContentRenderer = ({ bubble }) => {
@@ -213,6 +210,12 @@ const UserGroupBubble: BubbleContentRenderer = ({ bubble }) => {
   return <UserGroupDetail groupId={groupId} onOpenUser={handleOpenUser} />;
 };
 
+const WorldLinesBubble: BubbleContentRenderer = ({ bubble }) => {
+  return <WorldLineView<Bubble>
+    renderWorldState={(_worldState: Bubble, _onWorldStateChange: (worldState: Bubble) => void) => <div>World Line</div>}
+  />
+};
+
 const routes: BubbleRoute[] = [
   { pattern: /^mob$/, type: "mob", Component: ({ bubble }) => <MobBubble bubble={bubble} /> },
   {
@@ -236,6 +239,7 @@ const routes: BubbleRoute[] = [
   { pattern: /^users\/[^/]+$/, type: "user", Component: UserBubble },
   { pattern: /^memos$/, type: "memos", Component: MemosBubble },
   { pattern: /^memos\/.+$/, type: "memo", Component: MemoBubble },
+  { pattern: /^world-lines\/.+$/, type: "world-lines", Component: WorldLinesBubble },
   { pattern: /^iframes\/.+$/, type: "iframe", Component: ({ bubble }) => {
     const appId = bubble.name.replace("iframes/", "");
     return (<IframeBubble appId={appId} />);

--- a/apps/bublys-os/app/bubble-ui/page.tsx
+++ b/apps/bublys-os/app/bubble-ui/page.tsx
@@ -1,9 +1,12 @@
 "use client";
 
+import { FocusedObjectProvider } from "../world-line/WorldLine/domain/FocusedObjectContext";
 import { BubblesUI } from "./BubblesUI/feature/BubblesUI";
 
 export default function Index() {
   return (
-    <BubblesUI />
+    <FocusedObjectProvider>
+      <BubblesUI />
+    </FocusedObjectProvider>
   );
 }

--- a/apps/bublys-os/app/world-line/WorldLine/feature/WorldLineManager.tsx
+++ b/apps/bublys-os/app/world-line/WorldLine/feature/WorldLineManager.tsx
@@ -20,6 +20,7 @@ interface WorldLineManagerProps<TWorldState> {
   serialize: (state: TWorldState) => any;
   deserialize: (data: any) => TWorldState;
   createInitialWorldState: () => TWorldState;
+  isBubbleMode?: boolean;  // bubbleモードの場合、初期状態で3Dビューを表示
 }
 
 export function WorldLineManager<TWorldState>({ 
@@ -27,7 +28,8 @@ export function WorldLineManager<TWorldState>({
   objectId,
   serialize,
   deserialize,
-  createInitialWorldState 
+  createInitialWorldState,
+  isBubbleMode = false
 }: WorldLineManagerProps<TWorldState>) {
   const dispatch = useAppDispatch();
   const { focusedObjectId } = useFocusedObject();
@@ -40,7 +42,8 @@ export function WorldLineManager<TWorldState>({
   const worldLine = worldLineState ? WorldLine.fromJson<TWorldState>(worldLineState, deserialize) : null;
   const apexWorld = apexWorldState ? World.fromJson<TWorldState>(apexWorldState, deserialize) : null;
 
-  const [isModalOpen, setIsModalOpen] = useState(false);
+  // bubbleモードの場合、初期状態で3Dビューを表示
+  const [isModalOpen, setIsModalOpen] = useState(isBubbleMode);
   const [isInitializing, setIsInitializing] = useState(false);
 
   // 初期化ハンドラー

--- a/apps/bublys-os/app/world-line/WorldLine/feature/WorldLineManager.tsx
+++ b/apps/bublys-os/app/world-line/WorldLine/feature/WorldLineManager.tsx
@@ -20,7 +20,9 @@ interface WorldLineManagerProps<TWorldState> {
   serialize: (state: TWorldState) => any;
   deserialize: (data: any) => TWorldState;
   createInitialWorldState: () => TWorldState;
-  isBubbleMode?: boolean;  // bubbleモードの場合、初期状態で3Dビューを表示
+  onOpenWorldLineView?: () => void;
+  onCloseWorldLineView?: () => void;
+  isBubbleMode: boolean;
 }
 
 export function WorldLineManager<TWorldState>({ 
@@ -29,7 +31,9 @@ export function WorldLineManager<TWorldState>({
   serialize,
   deserialize,
   createInitialWorldState,
-  isBubbleMode = false
+  onOpenWorldLineView,
+  onCloseWorldLineView,
+  isBubbleMode,
 }: WorldLineManagerProps<TWorldState>) {
   const dispatch = useAppDispatch();
   const { focusedObjectId } = useFocusedObject();
@@ -144,15 +148,17 @@ export function WorldLineManager<TWorldState>({
 
   // 全ての世界線を表示（Ctrl+Z）
   const showAllWorldLinesHandler = useCallback(() => {
-      if (!worldLine) return;
+    if (!worldLine) return;
     
     updateWorldLine(worldLine, 'showAllWorldLines');
-    setIsModalOpen(true);
-  }, [worldLine, updateWorldLine]);
+
+    onOpenWorldLineView?.();
+  }, [worldLine, updateWorldLine, onOpenWorldLineView]);
 
   // モーダルを閉じる
   const closeModal = useCallback(() => {
     setIsModalOpen(false);
+    onCloseWorldLineView?.();
   }, []);
 
   // ヘルパー関数

--- a/apps/bublys-os/app/world-line/WorldLine/ui/WorldLineView.tsx
+++ b/apps/bublys-os/app/world-line/WorldLine/ui/WorldLineView.tsx
@@ -1,4 +1,4 @@
-import { useContext, useMemo, useState } from 'react';
+import { useContext, useMemo, useState, useRef, useEffect } from 'react';
 import { WorldLineContext } from '../domain/WorldLineContext';
 import { World } from '../domain/World';
 
@@ -21,6 +21,7 @@ function InitializeButton({ onInitialize, disabled = false }: { onInitialize: ()
 
 // 3D WorldView コンポーネント
 interface WorldView3DProps<TWorldState> {
+  containerSize: { width: number; height: number };
   worlds: World<TWorldState>[];
   apexWorldId: string | null;
   onWorldSelect: (worldId: string) => void;
@@ -31,6 +32,7 @@ interface WorldView3DProps<TWorldState> {
 }
 
 function WorldView3D<TWorldState>({
+  containerSize,
   worlds,
   apexWorldId,
   onWorldSelect,
@@ -42,11 +44,11 @@ function WorldView3D<TWorldState>({
   const [hoveredWorldId, setHoveredWorldId] = useState<string | null>(null);
   
   // 消失点（バニシングポイント）- 画面中央上部に配置
-  const vanishingPoint = { x: window.innerWidth * 0.5, y: window.innerHeight * 0.2 };
+  const vanishingPoint = { x: containerSize.width * 0.5, y: containerSize.height * 0.2 };
   // 現在の世界の位置（画面中央やや下）
   const apexPosition = { 
-    x: window.innerWidth * 0.5, 
-    y: window.innerHeight * 0.7 
+    x: containerSize.width * 0.5, 
+    y: containerSize.height * 0.7 
   };
   
   // 各世界線のHEAD（子を持たない世界）を特定
@@ -136,7 +138,7 @@ function WorldView3D<TWorldState>({
         
         // 各世界線を横に広げる（中央を基準に均等配置）
         if (headPos && headPos.total > 1) {
-          const spreadWidth = Math.min(window.innerWidth * 0.6, 800);
+          const spreadWidth = Math.min(containerSize.width * 0.4, containerSize.width);
           const offset = ((headPos.index - (headPos.total - 1) / 2) / headPos.total) * spreadWidth * ratio;
           x += offset;
         }
@@ -294,7 +296,7 @@ function WorldView3D<TWorldState>({
                   transform: `translate(-50%, -50%) translateZ(${adjustedZ}px) scale(${scale}) rotateX(20deg)`,
                   transformOrigin: 'center center',
                   transformStyle: 'preserve-3d',
-                  width: '380px',
+                  width: `${containerSize.width * 0.4}px`,
                   minHeight: '120px',
                   padding: '1.5rem',
                   backgroundColor: isFocused
@@ -375,7 +377,7 @@ function WorldView3D<TWorldState>({
                       left: '50%',
                       top: '50%',
                       transform: `translate(-50%, -50%) rotateX(20deg)`,
-                      width: '380px',
+                      width: `${containerSize.width * 0.4}px`,
                       minHeight: '120px',
                       padding: '1.5rem',
                       backgroundColor: worldLineColor?.bg || 'rgba(255, 255, 255, 0.98)',
@@ -427,6 +429,24 @@ export function WorldLineView<TWorldState>({ renderWorldState }: WorldLineViewPr
     isInitialized,
   } = useContext(WorldLineContext);
 
+  const containerRef = useRef<HTMLDivElement>(null);
+  const [containerSize, setContainerSize] = useState({ width: 500, height: 400 });
+
+  useEffect(() => {
+    const updateSize = () => {
+      if (containerRef.current) {
+        setContainerSize({
+          width: containerRef.current.clientWidth,
+          height: containerRef.current.clientHeight,
+        });
+      }
+    };
+
+    updateSize();
+    window.addEventListener('resize', updateSize);
+    return () => window.removeEventListener('resize', updateSize);
+  }, [isModalOpen]);
+
   const handleWorldSelect = (worldId: string) => {
     setApex(worldId);
     closeModal();
@@ -447,7 +467,7 @@ export function WorldLineView<TWorldState>({ renderWorldState }: WorldLineViewPr
         <div style={{ maxWidth: '1200px', margin: '0 auto', padding: '2rem', width: '100%' }}>
           <div style={{ marginBottom: '1rem' }}>
             <div style={{ marginTop: '1rem' }}>
-              {renderWorldState(apexWorld.worldState as TWorldState, grow)}
+              {renderWorldState(apexWorld.worldState, grow)}
             </div>
           </div>
         </div>
@@ -455,19 +475,20 @@ export function WorldLineView<TWorldState>({ renderWorldState }: WorldLineViewPr
 
       {/* 3D世界線ビュー（Ctrl+Zで表示） */}
       {isInitialized && isModalOpen && (
-        <div style={{ 
-          position: 'fixed',
-          top: 0,
-          left: 0,
-          right: 0,
-          bottom: 0,
-          backgroundColor: 'rgba(0, 0, 0, 0.05)',
-          zIndex: 1000,
-          display: 'flex',
-          flexDirection: 'column',
-        }}>
+        <div 
+          ref={containerRef}
+          style={{ 
+            width: `${containerSize.width}px`,
+            height: `${containerSize.height}px`,
+            backgroundColor: 'rgba(0, 0, 0, 0.05)',
+            zIndex: 1000,
+            display: 'flex',
+            flexDirection: 'column',
+          }}
+        >
           <div style={{ flex: 1, overflow: 'hidden' }}>
             <WorldView3D
+              containerSize={containerSize}
               worlds={getAllWorlds()}
               apexWorldId={apexWorldId}
               onWorldSelect={handleWorldSelect}

--- a/apps/bublys-os/app/world-line/integrations/MemoWorldLineManager.tsx
+++ b/apps/bublys-os/app/world-line/integrations/MemoWorldLineManager.tsx
@@ -14,11 +14,13 @@ import { Memo } from '../Memo/domain/Memo';
 interface MemoWorldLineManagerProps {
   children: React.ReactNode;
   memoId: string;
+  isBubbleMode?: boolean;
 }
 
 export function MemoWorldLineManager({ 
   children, 
-  memoId
+  memoId,
+  isBubbleMode = false
 }: MemoWorldLineManagerProps) {
   return (
     <WorldLineManager<Memo>
@@ -26,6 +28,7 @@ export function MemoWorldLineManager({
       serialize={serializeMemo}
       deserialize={deserializeMemo}
       createInitialWorldState={() => createInitialMemo()}
+      isBubbleMode={isBubbleMode}
     >
       {children}
     </WorldLineManager>

--- a/apps/bublys-os/app/world-line/integrations/MemoWorldLineManager.tsx
+++ b/apps/bublys-os/app/world-line/integrations/MemoWorldLineManager.tsx
@@ -14,13 +14,17 @@ import { Memo } from '../Memo/domain/Memo';
 interface MemoWorldLineManagerProps {
   children: React.ReactNode;
   memoId: string;
-  isBubbleMode?: boolean;
+  isBubbleMode: boolean;
+  onOpenWorldLineView: () => void;
+  onCloseWorldLineView: () => void;
 }
 
 export function MemoWorldLineManager({ 
   children, 
   memoId,
-  isBubbleMode = false
+  isBubbleMode = false,
+  onOpenWorldLineView,
+  onCloseWorldLineView
 }: MemoWorldLineManagerProps) {
   return (
     <WorldLineManager<Memo>
@@ -28,6 +32,8 @@ export function MemoWorldLineManager({
       serialize={serializeMemo}
       deserialize={deserializeMemo}
       createInitialWorldState={() => createInitialMemo()}
+      onOpenWorldLineView={onOpenWorldLineView}
+      onCloseWorldLineView={onCloseWorldLineView}
       isBubbleMode={isBubbleMode}
     >
       {children}


### PR DESCRIPTION
- WorldLineManagerにisBubbleModeプロパティを追加
  - bubbleモード時、初期状態で3Dビューを表示
- MemoWorldLineManagerにisBubbleModeプロパティを追加
- WorldLineViewで世界選択時にsetApexとcloseModalを呼び出して遷移
- WorldLineViewでコンテナサイズを動的に取得する機能を追加
- 3Dビューのサイズ調整（幅0.6→0.4、高さ600→400）