### PR TITLE
feat: 配置理由の記録・表示（Issue #35 / F-3-1〜F-3-3）

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2572,6 +2572,10 @@
       "resolved": "sekaisen-igo-bubly/sekaisen-igo-model",
       "link": true
     },
+    "node_modules/@bublys-org/shift-puzzle-libs": {
+      "resolved": "shift-puzzle-bubly/shift-puzzle-libs",
+      "link": true
+    },
     "node_modules/@bublys-org/shift-puzzle-model": {
       "resolved": "shift-puzzle-bubly/shift-puzzle-model",
       "link": true
@@ -28328,6 +28332,16 @@
       "version": "0.0.1",
       "dependencies": {
         "@swc/helpers": "~0.5.11"
+      }
+    },
+    "shift-puzzle-bubly/shift-puzzle-libs": {
+      "name": "@bublys-org/shift-puzzle-libs",
+      "version": "0.0.1",
+      "dependencies": {
+        "@bublys-org/bubbles-ui": "*",
+        "@bublys-org/shift-puzzle-model": "*",
+        "@bublys-org/state-management": "*",
+        "tslib": "^2.3.0"
       }
     },
     "shift-puzzle-bubly/shift-puzzle-model": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -2572,6 +2572,10 @@
       "resolved": "sekaisen-igo-bubly/sekaisen-igo-model",
       "link": true
     },
+    "node_modules/@bublys-org/shift-puzzle-app": {
+      "resolved": "shift-puzzle-bubly/shift-puzzle-app",
+      "link": true
+    },
     "node_modules/@bublys-org/shift-puzzle-libs": {
       "resolved": "shift-puzzle-bubly/shift-puzzle-libs",
       "link": true
@@ -28334,6 +28338,22 @@
         "@swc/helpers": "~0.5.11"
       }
     },
+    "shift-puzzle-bubly/shift-puzzle-app": {
+      "name": "@bublys-org/shift-puzzle-app",
+      "version": "0.0.1",
+      "dependencies": {
+        "@bublys-org/bubbles-ui": "*",
+        "@bublys-org/shift-puzzle-libs": "*",
+        "@bublys-org/shift-puzzle-model": "*",
+        "@bublys-org/state-management": "*",
+        "modern-normalize": "^3.0.1",
+        "react": "19.0.0",
+        "react-dom": "19.0.0",
+        "react-redux": "^9.2.0",
+        "redux-persist": "^6.0.0",
+        "styled-components": "5.3.6"
+      }
+    },
     "shift-puzzle-bubly/shift-puzzle-libs": {
       "name": "@bublys-org/shift-puzzle-libs",
       "version": "0.0.1",
@@ -28402,6 +28422,126 @@
     "users-libs": {
       "name": "@bublys-org/users-libs",
       "version": "0.0.1"
+    },
+    "node_modules/@next/swc-darwin-arm64": {
+      "version": "16.1.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-16.1.6.tgz",
+      "integrity": "sha512-wTzYulosJr/6nFnqGW7FrG3jfUUlEf8UjGA0/pyypJl42ExdVgC6xJgcXQ+V8QFn6niSG2Pb8+MIG1mZr2vczw==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-darwin-x64": {
+      "version": "16.1.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-16.1.6.tgz",
+      "integrity": "sha512-BLFPYPDO+MNJsiDWbeVzqvYd4NyuRrEYVB5k2N3JfWncuHAy2IVwMAOlVQDFjj+krkWzhY2apvmekMkfQR0CUQ==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-arm64-gnu": {
+      "version": "16.1.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-16.1.6.tgz",
+      "integrity": "sha512-OJYkCd5pj/QloBvoEcJ2XiMnlJkRv9idWA/j0ugSuA34gMT6f5b7vOiCQHVRpvStoZUknhl6/UxOXL4OwtdaBw==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-arm64-musl": {
+      "version": "16.1.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-16.1.6.tgz",
+      "integrity": "sha512-S4J2v+8tT3NIO9u2q+S0G5KdvNDjXfAv06OhfOzNDaBn5rw84DGXWndOEB7d5/x852A20sW1M56vhC/tRVbccQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-x64-gnu": {
+      "version": "16.1.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-16.1.6.tgz",
+      "integrity": "sha512-2eEBDkFlMMNQnkTyPBhQOAyn2qMxyG2eE7GPH2WIDGEpEILcBPI/jdSv4t6xupSP+ot/jkfrCShLAa7+ZUPcJQ==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-x64-musl": {
+      "version": "16.1.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-16.1.6.tgz",
+      "integrity": "sha512-oicJwRlyOoZXVlxmIMaTq7f8pN9QNbdes0q2FXfRsPhfCi8n8JmOZJm5oo1pwDaFbnnD421rVU409M3evFbIqg==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-win32-arm64-msvc": {
+      "version": "16.1.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-16.1.6.tgz",
+      "integrity": "sha512-gQmm8izDTPgs+DCWH22kcDmuUp7NyiJgEl18bcr8irXA5N2m2O+JQIr6f3ct42GOs9c0h8QF3L5SzIxcYAAXXw==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-win32-x64-msvc": {
+      "version": "16.1.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-16.1.6.tgz",
+      "integrity": "sha512-NRfO39AIrzBnixKbjuo2YiYhB6o9d8v/ymU9m/Xk8cyVk+k7XylniXkHwjs4s70wedVffc6bQNbufk5v0xEm0A==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
     }
   }
 }

--- a/shift-puzzle-bubly/shift-puzzle-app/index.html
+++ b/shift-puzzle-bubly/shift-puzzle-app/index.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html lang="ja">
+  <head>
+    <meta charset="utf-8" />
+    <title>ShiftPuzzle</title>
+    <base href="/" />
+
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <link rel="icon" type="image/x-icon" href="/favicon.ico" />
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/shift-puzzle-bubly/shift-puzzle-app/package.json
+++ b/shift-puzzle-bubly/shift-puzzle-app/package.json
@@ -1,0 +1,41 @@
+{
+  "name": "@bublys-org/shift-puzzle-app",
+  "version": "0.0.1",
+  "private": true,
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "build:bubly": "vite build -c vite.config.bubly.ts"
+  },
+  "dependencies": {
+    "@bublys-org/bubbles-ui": "*",
+    "@bublys-org/shift-puzzle-libs": "*",
+    "@bublys-org/shift-puzzle-model": "*",
+    "@bublys-org/state-management": "*",
+    "modern-normalize": "^3.0.1",
+    "react": "19.0.0",
+    "react-dom": "19.0.0",
+    "react-redux": "^9.2.0",
+    "redux-persist": "^6.0.0",
+    "styled-components": "5.3.6"
+  },
+  "nx": {
+    "targets": {
+      "build": {
+        "dependsOn": ["^build"]
+      },
+      "build:bubly": {
+        "dependsOn": ["^build"]
+      },
+      "dev": {
+        "dependsOn": [
+          {
+            "projects": ["@bublys-org/shift-puzzle-libs", "@bublys-org/shift-puzzle-model"],
+            "target": "dev"
+          }
+        ],
+        "continuous": true
+      }
+    }
+  }
+}

--- a/shift-puzzle-bubly/shift-puzzle-app/src/app/app.tsx
+++ b/shift-puzzle-bubly/shift-puzzle-app/src/app/app.tsx
@@ -1,4 +1,5 @@
 import { BublyApp, BublyStoreProvider, BubbleRouteRegistry } from "@bublys-org/bubbles-ui";
+import { getCurrentStore } from "@bublys-org/state-management";
 
 // shift-puzzle-libs の slices を import（自動注入される）
 import "@bublys-org/shift-puzzle-libs";
@@ -7,8 +8,25 @@ import { shiftPuzzleBubbleRoutes } from "../registration/index.js";
 
 BubbleRouteRegistry.registerRoutes(shiftPuzzleBubbleRoutes);
 
+/** 現在の Redux 状態から配置理由一覧 URL を動的生成 */
+function getReasonsUrl(): string {
+  const store = getCurrentStore();
+  if (store) {
+    const state = store.getState() as {
+      shiftPuzzleMain?: { currentEventId: string | null; currentShiftPlanId: string | null };
+    };
+    const eventId = state.shiftPuzzleMain?.currentEventId;
+    const planId = state.shiftPuzzleMain?.currentShiftPlanId;
+    if (eventId && planId) {
+      return `shift-puzzle/events/${eventId}/shift-plans/${planId}/reasons`;
+    }
+  }
+  return "shift-puzzle/reasons";
+}
+
 const menuItems = [
   { label: "シフトパズル", url: "shift-puzzle/editor", icon: null },
+  { label: "配置理由一覧", url: getReasonsUrl, icon: null },
 ];
 
 export function App() {

--- a/shift-puzzle-bubly/shift-puzzle-app/src/app/app.tsx
+++ b/shift-puzzle-bubly/shift-puzzle-app/src/app/app.tsx
@@ -1,0 +1,29 @@
+import { BublyApp, BublyStoreProvider, BubbleRouteRegistry } from "@bublys-org/bubbles-ui";
+
+// shift-puzzle-libs の slices を import（自動注入される）
+import "@bublys-org/shift-puzzle-libs";
+
+import { shiftPuzzleBubbleRoutes } from "../registration/index.js";
+
+BubbleRouteRegistry.registerRoutes(shiftPuzzleBubbleRoutes);
+
+const menuItems = [
+  { label: "シフトパズル", url: "shift-puzzle/editor", icon: null },
+];
+
+export function App() {
+  return (
+    <BublyStoreProvider
+      persistKey="shift-puzzle-standalone"
+      initialBubbleUrls={["shift-puzzle/editor"]}
+    >
+      <BublyApp
+        title="シフトパズル"
+        subtitle="Standalone • Port 4003"
+        menuItems={menuItems}
+      />
+    </BublyStoreProvider>
+  );
+}
+
+export default App;

--- a/shift-puzzle-bubly/shift-puzzle-app/src/bubly.ts
+++ b/shift-puzzle-bubly/shift-puzzle-app/src/bubly.ts
@@ -1,0 +1,34 @@
+/**
+ * Bublys Bubly Entry Point for shift-puzzle
+ *
+ * このファイルはスタンドアロンバンドルとしてビルドされ、
+ * 動的にロードされるバブリとして動作する
+ */
+
+import { registerBubly, Bubly } from "@bublys-org/bubbles-ui";
+import { shiftPuzzleBubbleRoutes } from "./registration/index.js";
+
+const ShiftPuzzleBubly: Bubly = {
+  name: "shift-puzzle",
+  version: "0.0.1",
+
+  menuItems: [
+    {
+      label: "シフトパズル",
+      url: "shift-puzzle/editor",
+      icon: null,
+    },
+  ],
+
+  register(context) {
+    context.registerBubbleRoutes(shiftPuzzleBubbleRoutes);
+  },
+
+  unregister() {
+    // cleanup if needed
+  },
+};
+
+registerBubly(ShiftPuzzleBubly);
+
+export default ShiftPuzzleBubly;

--- a/shift-puzzle-bubly/shift-puzzle-app/src/main.tsx
+++ b/shift-puzzle-bubly/shift-puzzle-app/src/main.tsx
@@ -1,0 +1,14 @@
+import "modern-normalize";
+import { StrictMode } from "react";
+import * as ReactDOM from "react-dom/client";
+import App from "./app/app";
+
+const root = ReactDOM.createRoot(
+  document.getElementById("root") as HTMLElement
+);
+
+root.render(
+  <StrictMode>
+    <App />
+  </StrictMode>
+);

--- a/shift-puzzle-bubly/shift-puzzle-app/src/registration/bubbleRoutes.tsx
+++ b/shift-puzzle-bubly/shift-puzzle-app/src/registration/bubbleRoutes.tsx
@@ -5,6 +5,7 @@ import { BubbleRoute } from "@bublys-org/bubbles-ui";
 import { useAppDispatch, useAppSelector } from "@bublys-org/state-management";
 import {
   ShiftPlanGanttEditor,
+  ReasonListFeature,
   selectEvents,
   selectCurrentEventId,
   selectCurrentShiftPlanId,
@@ -194,10 +195,43 @@ const ShiftPuzzleEditorBubble: BubbleRoute["Component"] = () => {
   );
 };
 
+/** F-3-3: 配置理由一覧バブル */
+const ReasonListBubble: BubbleRoute["Component"] = ({ bubble }) => {
+  const currentEventId = useAppSelector(selectCurrentEventId);
+  const currentShiftPlanId = useAppSelector(selectCurrentShiftPlanId);
+
+  // URL パラメータ優先、なければ Redux の現在選択状態を使用
+  const eventId = bubble.params.eventId ?? currentEventId;
+  const planId = bubble.params.planId ?? currentShiftPlanId;
+
+  if (!eventId || !planId) {
+    return (
+      <div style={{ padding: 24, color: "#888", textAlign: "center" }}>
+        イベントまたはシフト案が選択されていません
+      </div>
+    );
+  }
+
+  return <ReasonListFeature shiftPlanId={planId} eventId={eventId} />;
+};
+
 export const shiftPuzzleBubbleRoutes: BubbleRoute[] = [
   {
     pattern: "shift-puzzle/editor",
     type: "shift-puzzle-editor",
     Component: ShiftPuzzleEditorBubble,
+  },
+  {
+    // F-3-3: 配置理由一覧
+    // パターン: shift-puzzle/events/:eventId/shift-plans/:planId/reasons
+    // または    shift-puzzle/reasons（パラメータなし → Redux状態を使用）
+    pattern: "shift-puzzle/events/:eventId/shift-plans/:planId/reasons",
+    type: "shift-puzzle-reasons",
+    Component: ReasonListBubble,
+  },
+  {
+    pattern: "shift-puzzle/reasons",
+    type: "shift-puzzle-reasons",
+    Component: ReasonListBubble,
   },
 ];

--- a/shift-puzzle-bubly/shift-puzzle-app/src/registration/bubbleRoutes.tsx
+++ b/shift-puzzle-bubly/shift-puzzle-app/src/registration/bubbleRoutes.tsx
@@ -1,0 +1,203 @@
+"use client";
+
+import { useEffect } from "react";
+import { BubbleRoute } from "@bublys-org/bubbles-ui";
+import { useAppDispatch, useAppSelector } from "@bublys-org/state-management";
+import {
+  ShiftPlanGanttEditor,
+  selectEvents,
+  selectCurrentEventId,
+  selectCurrentShiftPlanId,
+  addEvent,
+  setMembersForEvent,
+  setRolesForEvent,
+  setTimeSlotsForEvent,
+  addShiftPlan,
+  setCurrentEventId,
+  setCurrentShiftPlanId,
+} from "@bublys-org/shift-puzzle-libs";
+import type {
+  EventJSON,
+  MemberJSON,
+  RoleJSON,
+  TimeSlotJSON,
+  ShiftPlanJSON,
+} from "@bublys-org/shift-puzzle-model";
+
+const DEMO_EVENT_ID = "demo-event-001";
+const DEMO_PLAN_ID = "demo-plan-001";
+const SEED_TIMESTAMP = "2024-11-01T00:00:00.000Z";
+
+function createDemoData(): {
+  event: EventJSON;
+  members: MemberJSON[];
+  roles: RoleJSON[];
+  timeSlots: TimeSlotJSON[];
+  shiftPlan: ShiftPlanJSON;
+} {
+  const event: EventJSON = {
+    id: DEMO_EVENT_ID,
+    name: "デモイベント 2024",
+    description: "シフトパズルのデモ用イベント",
+    startDate: "2024-11-01",
+    endDate: "2024-11-01",
+    timezone: "Asia/Tokyo",
+    skillDefinitions: [],
+    defaultSlotDuration: 60,
+    createdAt: SEED_TIMESTAMP,
+    updatedAt: SEED_TIMESTAMP,
+  };
+
+  const timeSlots: TimeSlotJSON[] = [
+    { id: "ts-001", dayIndex: 0, startMinute: 9 * 60, durationMinutes: 60, eventId: DEMO_EVENT_ID },
+    { id: "ts-002", dayIndex: 0, startMinute: 10 * 60, durationMinutes: 60, eventId: DEMO_EVENT_ID },
+    { id: "ts-003", dayIndex: 0, startMinute: 11 * 60, durationMinutes: 60, eventId: DEMO_EVENT_ID },
+    { id: "ts-004", dayIndex: 0, startMinute: 12 * 60, durationMinutes: 60, eventId: DEMO_EVENT_ID },
+    { id: "ts-005", dayIndex: 0, startMinute: 13 * 60, durationMinutes: 60, eventId: DEMO_EVENT_ID },
+    { id: "ts-006", dayIndex: 0, startMinute: 14 * 60, durationMinutes: 60, eventId: DEMO_EVENT_ID },
+    { id: "ts-007", dayIndex: 0, startMinute: 15 * 60, durationMinutes: 60, eventId: DEMO_EVENT_ID },
+    { id: "ts-008", dayIndex: 0, startMinute: 16 * 60, durationMinutes: 60, eventId: DEMO_EVENT_ID },
+  ];
+
+  const members: MemberJSON[] = [
+    {
+      id: "m-001",
+      name: "田中 太郎",
+      eventId: DEMO_EVENT_ID,
+      tags: ["一般"],
+      skills: [],
+      availableSlotIds: ["ts-001", "ts-002", "ts-003", "ts-004", "ts-005", "ts-006", "ts-007", "ts-008"],
+      memo: "",
+      createdAt: SEED_TIMESTAMP,
+      updatedAt: SEED_TIMESTAMP,
+    },
+    {
+      id: "m-002",
+      name: "佐藤 花子",
+      eventId: DEMO_EVENT_ID,
+      tags: ["一般"],
+      skills: [],
+      availableSlotIds: ["ts-001", "ts-002", "ts-003", "ts-004"],
+      memo: "",
+      createdAt: SEED_TIMESTAMP,
+      updatedAt: SEED_TIMESTAMP,
+    },
+    {
+      id: "m-003",
+      name: "鈴木 次郎",
+      eventId: DEMO_EVENT_ID,
+      tags: ["リーダー"],
+      skills: [],
+      availableSlotIds: ["ts-005", "ts-006", "ts-007", "ts-008"],
+      memo: "",
+      createdAt: SEED_TIMESTAMP,
+      updatedAt: SEED_TIMESTAMP,
+    },
+    {
+      id: "m-004",
+      name: "高橋 美咲",
+      eventId: DEMO_EVENT_ID,
+      tags: ["一般"],
+      skills: [],
+      availableSlotIds: ["ts-002", "ts-003", "ts-006", "ts-007"],
+      memo: "",
+      createdAt: SEED_TIMESTAMP,
+      updatedAt: SEED_TIMESTAMP,
+    },
+    {
+      id: "m-005",
+      name: "中村 健一",
+      eventId: DEMO_EVENT_ID,
+      tags: ["一般"],
+      skills: [],
+      availableSlotIds: ["ts-001", "ts-004", "ts-005", "ts-008"],
+      memo: "",
+      createdAt: SEED_TIMESTAMP,
+      updatedAt: SEED_TIMESTAMP,
+    },
+  ];
+
+  const roles: RoleJSON[] = [
+    {
+      id: "r-001",
+      name: "受付",
+      description: "来場者の受付対応",
+      requiredSkillIds: [],
+      minRequired: 2,
+      maxRequired: 3,
+      color: "#4caf50",
+      eventId: DEMO_EVENT_ID,
+    },
+    {
+      id: "r-002",
+      name: "案内",
+      description: "会場・展示の案内",
+      requiredSkillIds: [],
+      minRequired: 1,
+      maxRequired: 2,
+      color: "#2196f3",
+      eventId: DEMO_EVENT_ID,
+    },
+    {
+      id: "r-003",
+      name: "司会",
+      description: "セッションの進行",
+      requiredSkillIds: [],
+      minRequired: 1,
+      maxRequired: 1,
+      color: "#ff9800",
+      eventId: DEMO_EVENT_ID,
+    },
+  ];
+
+  const shiftPlan: ShiftPlanJSON = {
+    id: DEMO_PLAN_ID,
+    name: "シフト案 A",
+    scenarioLabel: "標準版",
+    assignments: [],
+    eventId: DEMO_EVENT_ID,
+    createdAt: SEED_TIMESTAMP,
+    updatedAt: SEED_TIMESTAMP,
+  };
+
+  return { event, members, roles, timeSlots, shiftPlan };
+}
+
+const ShiftPuzzleEditorBubble: BubbleRoute["Component"] = () => {
+  const dispatch = useAppDispatch();
+  const events = useAppSelector(selectEvents);
+  const currentEventId = useAppSelector(selectCurrentEventId);
+  const currentShiftPlanId = useAppSelector(selectCurrentShiftPlanId);
+
+  useEffect(() => {
+    if (events.length === 0) {
+      const { event, members, roles, timeSlots, shiftPlan } = createDemoData();
+      dispatch(addEvent(event));
+      dispatch(setMembersForEvent({ eventId: event.id, members }));
+      dispatch(setRolesForEvent({ eventId: event.id, roles }));
+      dispatch(setTimeSlotsForEvent({ eventId: event.id, timeSlots }));
+      dispatch(addShiftPlan(shiftPlan));
+      dispatch(setCurrentEventId(event.id));
+      dispatch(setCurrentShiftPlanId(shiftPlan.id));
+    }
+  }, [dispatch, events.length]);
+
+  if (!currentEventId || !currentShiftPlanId) {
+    return <div style={{ padding: 24, color: "#666" }}>データを初期化中...</div>;
+  }
+
+  return (
+    <ShiftPlanGanttEditor
+      shiftPlanId={currentShiftPlanId}
+      eventId={currentEventId}
+    />
+  );
+};
+
+export const shiftPuzzleBubbleRoutes: BubbleRoute[] = [
+  {
+    pattern: "shift-puzzle/editor",
+    type: "shift-puzzle-editor",
+    Component: ShiftPuzzleEditorBubble,
+  },
+];

--- a/shift-puzzle-bubly/shift-puzzle-app/src/registration/index.ts
+++ b/shift-puzzle-bubly/shift-puzzle-app/src/registration/index.ts
@@ -1,0 +1,1 @@
+export * from "./bubbleRoutes.js";

--- a/shift-puzzle-bubly/shift-puzzle-app/src/store/index.ts
+++ b/shift-puzzle-bubly/shift-puzzle-app/src/store/index.ts
@@ -1,0 +1,11 @@
+// shift-puzzle-libs のsliceをimport（rootReducerへの自動注入が実行される）
+// makeStore より前に import する必要がある
+import '@bublys-org/shift-puzzle-libs';
+
+import { makeStore } from '@bublys-org/state-management';
+
+const { store, persistor } = makeStore({ persistKey: 'shift-puzzle-standalone' });
+
+export { store, persistor };
+export type RootState = ReturnType<typeof store.getState>;
+export type AppDispatch = typeof store.dispatch;

--- a/shift-puzzle-bubly/shift-puzzle-app/tsconfig.app.json
+++ b/shift-puzzle-bubly/shift-puzzle-app/tsconfig.app.json
@@ -1,0 +1,19 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "tsBuildInfoFile": "dist/tsconfig.app.tsbuildinfo",
+    "jsx": "react-jsx",
+    "lib": ["dom"],
+    "types": ["node", "vite/client"],
+    "rootDir": "src"
+  },
+  "exclude": ["out-tsc", "dist", "src/**/*.spec.ts", "src/**/*.test.ts", "src/**/*.spec.tsx", "src/**/*.test.tsx"],
+  "include": ["src/**/*.js", "src/**/*.jsx", "src/**/*.ts", "src/**/*.tsx"],
+  "references": [
+    {"path": "../../bublys-libs/state-management"},
+    {"path": "../../bublys-libs/bubbles-ui"},
+    {"path": "../shift-puzzle-libs/tsconfig.lib.json"},
+    {"path": "../shift-puzzle-model/tsconfig.lib.json"}
+  ]
+}

--- a/shift-puzzle-bubly/shift-puzzle-app/tsconfig.json
+++ b/shift-puzzle-bubly/shift-puzzle-app/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.app.json"
+    }
+  ],
+  "extends": "../../tsconfig.base.json"
+}

--- a/shift-puzzle-bubly/shift-puzzle-app/vite.config.bubly.ts
+++ b/shift-puzzle-bubly/shift-puzzle-app/vite.config.bubly.ts
@@ -1,0 +1,113 @@
+import { defineConfig } from "vite";
+import react from "@vitejs/plugin-react";
+import { resolve } from "path";
+
+/**
+ * shift-puzzle-app をスタンドアロンバブリとしてビルドする設定
+ *
+ * ビルドコマンド:
+ *   npx vite build -c vite.config.bubly.ts
+ *
+ * 出力:
+ *   public/bubly.js
+ *
+ * 規約: バブリは {origin}/bubly.js として配信される
+ */
+export default defineConfig({
+  plugins: [react()],
+
+  define: {
+    "process.env.NODE_ENV": JSON.stringify("production"),
+    "process.env": JSON.stringify({}),
+  },
+
+  build: {
+    outDir: "public",
+    emptyOutDir: false,
+    lib: {
+      entry: resolve(__dirname, "src/bubly.ts"),
+      name: "ShiftPuzzleBubly",
+      fileName: () => "bubly.js",
+      formats: ["iife"],
+    },
+    rollupOptions: {
+      external: (id) => {
+        if (
+          id === "@bublys-org/shift-puzzle-libs" ||
+          id.startsWith("@bublys-org/shift-puzzle-libs/") ||
+          id === "@bublys-org/shift-puzzle-model" ||
+          id.startsWith("@bublys-org/shift-puzzle-model/")
+        ) {
+          return false;
+        }
+        if (id === "react/jsx-runtime" || id === "react/jsx-dev-runtime") {
+          return false;
+        }
+        if (
+          id === "react" ||
+          id === "react-dom" ||
+          id.startsWith("react/") ||
+          id.startsWith("react-dom/") ||
+          id === "@reduxjs/toolkit" ||
+          id.startsWith("@reduxjs/toolkit/") ||
+          id === "react-redux" ||
+          id === "styled-components" ||
+          id.startsWith("@bublys-org/") ||
+          id.startsWith("@mui/") ||
+          id.startsWith("@emotion/")
+        ) {
+          return true;
+        }
+        return false;
+      },
+      output: {
+        globals: (id) => {
+          if (id === "react" || id.startsWith("react/")) {
+            return "React";
+          }
+          if (id === "react-dom" || id.startsWith("react-dom/")) {
+            return "ReactDOM";
+          }
+          if (id === "styled-components") {
+            return "styled";
+          }
+          if (id === "@reduxjs/toolkit" || id.startsWith("@reduxjs/toolkit/")) {
+            return "window.__BUBLYS_SHARED__.Redux";
+          }
+          if (id === "react-redux") {
+            return "window.__BUBLYS_SHARED__.ReactRedux";
+          }
+          if (id === "@bublys-org/state-management") {
+            return "window.__BUBLYS_SHARED__.StateManagement";
+          }
+          if (id === "@bublys-org/bubbles-ui" || id.startsWith("@bublys-org/bubbles-ui/")) {
+            return "window.__BUBLYS_SHARED__.BubblesUI";
+          }
+          if (id.startsWith("@mui/material")) {
+            return "window.__BUBLYS_SHARED__.MuiMaterial";
+          }
+          if (id.startsWith("@mui/icons-material/")) {
+            const iconName = id.replace("@mui/icons-material/", "");
+            return `window.__BUBLYS_SHARED__.MuiIcons.${iconName}`;
+          }
+          if (id === "@mui/icons-material") {
+            return "window.__BUBLYS_SHARED__.MuiIcons";
+          }
+          if (id.startsWith("@mui/")) {
+            return "window.__BUBLYS_SHARED__.Mui";
+          }
+          if (id.startsWith("@emotion/")) {
+            return "window.__BUBLYS_SHARED__.Emotion";
+          }
+          if (id.startsWith("@bublys-org/")) {
+            console.warn(`[vite] Unknown @bublys-org package: ${id}`);
+            return `window.__BUBLYS_SHARED__["${id}"]`;
+          }
+          return id;
+        },
+      },
+    },
+    sourcemap: true,
+    minify: false,
+  },
+});

--- a/shift-puzzle-bubly/shift-puzzle-app/vite.config.mts
+++ b/shift-puzzle-bubly/shift-puzzle-app/vite.config.mts
@@ -1,0 +1,25 @@
+/// <reference types='vitest' />
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig(() => ({
+  root: import.meta.dirname,
+  cacheDir: '../../node_modules/.vite/shift-puzzle-bubly/shift-puzzle-app',
+  server: {
+    port: 4003,
+    host: 'localhost',
+  },
+  preview: {
+    port: 4003,
+    host: 'localhost',
+  },
+  plugins: [react()],
+  build: {
+    outDir: './dist',
+    emptyOutDir: true,
+    reportCompressedSize: true,
+    commonjsOptions: {
+      transformMixedEsModules: true,
+    },
+  },
+}));

--- a/shift-puzzle-bubly/shift-puzzle-libs/package.json
+++ b/shift-puzzle-bubly/shift-puzzle-libs/package.json
@@ -1,0 +1,33 @@
+{
+  "name": "@bublys-org/shift-puzzle-libs",
+  "version": "0.0.1",
+  "private": true,
+  "type": "module",
+  "main": "./dist/index.js",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "scripts": {
+    "build": "tsc -p tsconfig.lib.json",
+    "dev": "tsc -p tsconfig.lib.json --watch"
+  },
+  "exports": {
+    "./package.json": "./package.json",
+    ".": {
+      "@bublys-org/source": "./src/index.ts",
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "default": "./dist/index.js"
+    }
+  },
+  "dependencies": {
+    "tslib": "^2.3.0",
+    "@bublys-org/shift-puzzle-model": "*",
+    "@bublys-org/bubbles-ui": "*",
+    "@bublys-org/state-management": "*"
+  },
+  "nx": {
+    "targets": {
+      "dev": { "continuous": true }
+    }
+  }
+}

--- a/shift-puzzle-bubly/shift-puzzle-libs/src/domain/index.ts
+++ b/shift-puzzle-bubly/shift-puzzle-libs/src/domain/index.ts
@@ -1,0 +1,5 @@
+/**
+ * ドメインモデル再エクスポート
+ * @bublys-org/shift-puzzle-model から全てを再エクスポート
+ */
+export * from '@bublys-org/shift-puzzle-model';

--- a/shift-puzzle-bubly/shift-puzzle-libs/src/feature/ReasonListFeature.tsx
+++ b/shift-puzzle-bubly/shift-puzzle-libs/src/feature/ReasonListFeature.tsx
@@ -1,0 +1,116 @@
+'use client';
+import React, { useMemo } from 'react';
+import styled from 'styled-components';
+import { useAppSelector } from '@bublys-org/state-management';
+import {
+  selectShiftPlanById,
+  selectMembersForEvent,
+  selectRolesForEvent,
+  selectTimeSlotsForEvent,
+} from '../slice/index.js';
+import { ReasonList } from '../ui/index.js';
+
+interface ReasonListFeatureProps {
+  shiftPlanId: string;
+  eventId: string;
+}
+
+/** F-3-3: 配置理由一覧フィーチャー（Redux連携） */
+export const ReasonListFeature: React.FC<ReasonListFeatureProps> = ({
+  shiftPlanId,
+  eventId,
+}) => {
+  const shiftPlan = useAppSelector(selectShiftPlanById(shiftPlanId));
+  const members = useAppSelector(selectMembersForEvent(eventId));
+  const roles = useAppSelector(selectRolesForEvent(eventId));
+  const timeSlots = useAppSelector(selectTimeSlotsForEvent(eventId));
+
+  const memberMap = useMemo(
+    () => new Map(members.map((m) => [m.state.id, m.state])),
+    [members]
+  );
+
+  const roleMap = useMemo(
+    () => new Map(roles.map((r) => [r.state.id, r.state])),
+    [roles]
+  );
+
+  const timeSlotMap = useMemo(
+    () => new Map(timeSlots.map((s) => [s.id, s])),
+    [timeSlots]
+  );
+
+  if (!shiftPlan) {
+    return (
+      <div style={{ padding: 24, color: '#666', textAlign: 'center' }}>
+        シフト案を読み込み中...
+      </div>
+    );
+  }
+
+  const assignments = shiftPlan.state.assignments;
+
+  return (
+    <StyledWrapper>
+      <div className="e-header">
+        <span className="e-plan-name">{shiftPlan.name}</span>
+        {shiftPlan.scenarioLabel && (
+          <span className="e-scenario-label">{shiftPlan.scenarioLabel}</span>
+        )}
+        <span className="e-count">{assignments.length}件の配置</span>
+      </div>
+
+      <div className="e-body">
+        <ReasonList
+          assignments={[...assignments]}
+          memberMap={memberMap}
+          roleMap={roleMap}
+          timeSlotMap={timeSlotMap}
+        />
+      </div>
+    </StyledWrapper>
+  );
+};
+
+const StyledWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  overflow: hidden;
+
+  .e-header {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 10px 16px;
+    border-bottom: 1px solid #eee;
+    background: #fafafa;
+    flex-shrink: 0;
+    flex-wrap: wrap;
+  }
+
+  .e-plan-name {
+    font-weight: 600;
+    font-size: 0.95em;
+    color: #222;
+  }
+
+  .e-scenario-label {
+    background: #e8eaf6;
+    color: #3949ab;
+    padding: 2px 8px;
+    border-radius: 12px;
+    font-size: 0.8em;
+  }
+
+  .e-count {
+    margin-left: auto;
+    font-size: 0.82em;
+    color: #888;
+  }
+
+  .e-body {
+    flex: 1;
+    overflow: hidden;
+  }
+`;

--- a/shift-puzzle-bubly/shift-puzzle-libs/src/feature/ShiftPlanGanttEditor.tsx
+++ b/shift-puzzle-bubly/shift-puzzle-libs/src/feature/ShiftPlanGanttEditor.tsx
@@ -1,0 +1,318 @@
+'use client';
+import React, { useMemo } from 'react';
+import styled from 'styled-components';
+import { useAppDispatch, useAppSelector } from '@bublys-org/state-management';
+import {
+  Assignment,
+  type AssignmentReasonState,
+  type AssignmentState,
+} from '@bublys-org/shift-puzzle-model';
+import {
+  selectShiftPlanById,
+  selectMembersForEvent,
+  selectRolesForEvent,
+  selectTimeSlotsForEvent,
+  selectViolationsForPlan,
+  selectGanttHourPx,
+  selectGanttAxisMode,
+  selectGanttDayIndex,
+  addAssignment,
+  moveAssignment,
+  setGanttAxisMode,
+  setGanttDayIndex,
+  setGanttHourPx,
+} from '../slice/index.js';
+import { GanttChartView } from '../ui/index.js';
+
+interface ShiftPlanGanttEditorProps {
+  shiftPlanId: string;
+  eventId: string;
+  /** 配置クリック時のコールバック（理由詳細表示等） */
+  onAssignmentClick?: (assignmentId: string) => void;
+}
+
+/** ガントチャート編集画面（Redux連携） */
+export const ShiftPlanGanttEditor: React.FC<ShiftPlanGanttEditorProps> = ({
+  shiftPlanId,
+  eventId,
+  onAssignmentClick,
+}) => {
+  const dispatch = useAppDispatch();
+
+  const shiftPlan = useAppSelector(selectShiftPlanById(shiftPlanId));
+  const members = useAppSelector(selectMembersForEvent(eventId));
+  const roles = useAppSelector(selectRolesForEvent(eventId));
+  const timeSlots = useAppSelector(selectTimeSlotsForEvent(eventId));
+  const violations = useAppSelector(selectViolationsForPlan(shiftPlanId, eventId));
+  const hourPx = useAppSelector(selectGanttHourPx);
+  const axisMode = useAppSelector(selectGanttAxisMode);
+  const dayIndex = useAppSelector(selectGanttDayIndex);
+
+  // 利用可能なdayIndex一覧
+  const availableDays = useMemo(() => {
+    const indices = [...new Set(timeSlots.map((s) => s.dayIndex))].sort((a, b) => a - b);
+    return indices;
+  }, [timeSlots]);
+
+  const assignments = shiftPlan?.state.assignments ?? [];
+
+  // ========== ハンドラ ==========
+
+  const handleCreateAssignment = (
+    memberId: string,
+    timeSlotId: string,
+    roleId: string,
+    reason: AssignmentReasonState
+  ) => {
+    if (!shiftPlan) return;
+
+    // 重複チェック（同じメンバー × 時間帯 × 役割）
+    const exists = assignments.some(
+      (a: AssignmentState) => a.memberId === memberId && a.timeSlotId === timeSlotId && a.roleId === roleId
+    );
+    if (exists) return;
+
+    const assignment = Assignment.create({
+      memberId,
+      roleId,
+      timeSlotId,
+      shiftPlanId,
+      reason,
+    });
+
+    dispatch(addAssignment({ shiftPlanId, assignment: assignment.toJSON() }));
+  };
+
+  const handleMoveAssignment = (assignmentId: string, newTimeSlotId: string) => {
+    if (!shiftPlan) return;
+
+    // ロック確認
+    const target = assignments.find((a: AssignmentState) => a.id === assignmentId);
+    if (target?.locked) return;
+
+    dispatch(moveAssignment({ shiftPlanId, assignmentId, newTimeSlotId }));
+  };
+
+  if (!shiftPlan) {
+    return <div style={{ padding: 16, color: '#666' }}>シフト案を読み込み中...</div>;
+  }
+
+  return (
+    <StyledContainer>
+      {/* ツールバー */}
+      <div className="e-toolbar">
+        <span className="e-plan-name">{shiftPlan.name}</span>
+        {shiftPlan.scenarioLabel && (
+          <span className="e-scenario-label">{shiftPlan.scenarioLabel}</span>
+        )}
+
+        {/* 表示モード切替 */}
+        <div className="e-mode-switcher">
+          <button
+            className={`e-mode-btn ${axisMode === 'role' ? 'is-active' : ''}`}
+            onClick={() => dispatch(setGanttAxisMode('role'))}
+          >
+            役割ビュー
+          </button>
+          <button
+            className={`e-mode-btn ${axisMode === 'member' ? 'is-active' : ''}`}
+            onClick={() => dispatch(setGanttAxisMode('member'))}
+          >
+            メンバービュー
+          </button>
+        </div>
+
+        {/* 日付タブ（複数日の場合） */}
+        {availableDays.length > 1 && (
+          <div className="e-day-tabs">
+            {availableDays.map((d) => (
+              <button
+                key={d}
+                className={`e-day-tab ${dayIndex === d ? 'is-active' : ''}`}
+                onClick={() => dispatch(setGanttDayIndex(d))}
+              >
+                Day {d + 1}
+              </button>
+            ))}
+          </div>
+        )}
+
+        {/* ズーム */}
+        <div className="e-zoom">
+          <button
+            className="e-zoom-btn"
+            onClick={() => dispatch(setGanttHourPx(hourPx - 10))}
+            disabled={hourPx <= 40}
+          >
+            −
+          </button>
+          <span className="e-zoom-label">{hourPx}px/h</span>
+          <button
+            className="e-zoom-btn"
+            onClick={() => dispatch(setGanttHourPx(hourPx + 10))}
+            disabled={hourPx >= 120}
+          >
+            ＋
+          </button>
+        </div>
+
+        {/* 統計 */}
+        <div className="e-stats">
+          <span>配置数: {assignments.length}</span>
+          {violations.length > 0 && (
+            <span className="e-violation-badge">⚠ {violations.length}件の違反</span>
+          )}
+        </div>
+      </div>
+
+      {/* ガントチャート本体 */}
+      <div className="e-gantt-wrapper">
+        <GanttChartView
+          members={members.map((m) => m.state)}
+          roles={roles.map((r) => r.state)}
+          timeSlots={timeSlots}
+          assignments={[...assignments]}
+          violations={violations}
+          dayIndex={dayIndex}
+          hourPx={hourPx}
+          axisMode={axisMode}
+          onCreateAssignment={handleCreateAssignment}
+          onMoveAssignment={handleMoveAssignment}
+          onAssignmentClick={(id) => {
+            onAssignmentClick?.(id);
+          }}
+        />
+      </div>
+    </StyledContainer>
+  );
+};
+
+const StyledContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  overflow: hidden;
+
+  .e-toolbar {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    padding: 8px 12px;
+    border-bottom: 1px solid #eee;
+    background: #fafafa;
+    flex-shrink: 0;
+    flex-wrap: wrap;
+  }
+
+  .e-plan-name {
+    font-weight: 600;
+    font-size: 0.95em;
+  }
+
+  .e-scenario-label {
+    background: #e8eaf6;
+    color: #3949ab;
+    padding: 2px 8px;
+    border-radius: 12px;
+    font-size: 0.8em;
+  }
+
+  .e-mode-switcher {
+    display: flex;
+    border: 1px solid #ddd;
+    border-radius: 4px;
+    overflow: hidden;
+  }
+
+  .e-mode-btn {
+    padding: 4px 10px;
+    border: none;
+    background: white;
+    cursor: pointer;
+    font-size: 0.8em;
+    color: #555;
+
+    &.is-active {
+      background: #1976d2;
+      color: white;
+    }
+
+    &:not(:last-child) {
+      border-right: 1px solid #ddd;
+    }
+  }
+
+  .e-day-tabs {
+    display: flex;
+    gap: 4px;
+  }
+
+  .e-day-tab {
+    padding: 3px 10px;
+    border: 1px solid #ddd;
+    border-radius: 4px;
+    background: white;
+    cursor: pointer;
+    font-size: 0.8em;
+
+    &.is-active {
+      background: #1976d2;
+      color: white;
+      border-color: #1976d2;
+    }
+  }
+
+  .e-zoom {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+    margin-left: auto;
+  }
+
+  .e-zoom-btn {
+    width: 24px;
+    height: 24px;
+    border: 1px solid #ddd;
+    border-radius: 4px;
+    background: white;
+    cursor: pointer;
+    font-size: 0.9em;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+
+    &:disabled {
+      opacity: 0.4;
+      cursor: not-allowed;
+    }
+  }
+
+  .e-zoom-label {
+    font-size: 0.8em;
+    color: #777;
+    min-width: 50px;
+    text-align: center;
+  }
+
+  .e-stats {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    font-size: 0.85em;
+    color: #666;
+  }
+
+  .e-violation-badge {
+    background: #fff3e0;
+    color: #e65100;
+    padding: 2px 8px;
+    border-radius: 3px;
+    border: 1px solid #ff8f00;
+    font-weight: 500;
+  }
+
+  .e-gantt-wrapper {
+    flex: 1;
+    overflow: hidden;
+  }
+`;

--- a/shift-puzzle-bubly/shift-puzzle-libs/src/feature/index.ts
+++ b/shift-puzzle-bubly/shift-puzzle-libs/src/feature/index.ts
@@ -1,1 +1,2 @@
 export { ShiftPlanGanttEditor } from './ShiftPlanGanttEditor.js';
+export { ReasonListFeature } from './ReasonListFeature.js';

--- a/shift-puzzle-bubly/shift-puzzle-libs/src/feature/index.ts
+++ b/shift-puzzle-bubly/shift-puzzle-libs/src/feature/index.ts
@@ -1,0 +1,1 @@
+export { ShiftPlanGanttEditor } from './ShiftPlanGanttEditor.js';

--- a/shift-puzzle-bubly/shift-puzzle-libs/src/index.ts
+++ b/shift-puzzle-bubly/shift-puzzle-libs/src/index.ts
@@ -1,0 +1,14 @@
+// Object type registration (副作用)
+// import './object-type-registration.js';  // Phase 2で追加予定
+
+// Domain models (re-exported from @bublys-org/shift-puzzle-model)
+export * from './domain/index.js';
+
+// UI components
+export * from './ui/index.js';
+
+// Feature components
+export * from './feature/index.js';
+
+// Redux slice
+export * from './slice/index.js';

--- a/shift-puzzle-bubly/shift-puzzle-libs/src/slice/index.ts
+++ b/shift-puzzle-bubly/shift-puzzle-libs/src/slice/index.ts
@@ -1,0 +1,1 @@
+export * from './shift-puzzle-main-slice.js';

--- a/shift-puzzle-bubly/shift-puzzle-libs/src/slice/shift-puzzle-main-slice.ts
+++ b/shift-puzzle-bubly/shift-puzzle-libs/src/slice/shift-puzzle-main-slice.ts
@@ -1,0 +1,309 @@
+import { createSlice, createSelector, type WithSlice } from '@reduxjs/toolkit';
+import type { PayloadAction } from '@reduxjs/toolkit';
+import { rootReducer, type RootState } from '@bublys-org/state-management';
+import {
+  Member,
+  Role,
+  ShiftPlan,
+  Assignment,
+  ConstraintChecker,
+  type EventJSON,
+  type MemberJSON,
+  type RoleJSON,
+  type TimeSlotJSON,
+  type ShiftPlanJSON,
+  type AssignmentJSON,
+  type AssignmentReasonState,
+  type ConstraintViolation,
+} from '@bublys-org/shift-puzzle-model';
+
+// ========== State ==========
+
+type ShiftPuzzleMainState = {
+  events: EventJSON[];
+  members: MemberJSON[];
+  roles: RoleJSON[];
+  timeSlots: TimeSlotJSON[];
+  shiftPlans: ShiftPlanJSON[];
+  currentEventId: string | null;
+  currentShiftPlanId: string | null;
+  /** ガントチャートUI設定 */
+  ganttHourPx: number;
+  ganttAxisMode: 'role' | 'member';
+  /** ガントチャートで表示するdayIndex */
+  ganttDayIndex: number;
+};
+
+const initialState: ShiftPuzzleMainState = {
+  events: [],
+  members: [],
+  roles: [],
+  timeSlots: [],
+  shiftPlans: [],
+  currentEventId: null,
+  currentShiftPlanId: null,
+  ganttHourPx: 80,
+  ganttAxisMode: 'role',
+  ganttDayIndex: 0,
+};
+
+// ========== Helper ==========
+
+function toMutableShiftPlan(plan: ShiftPlanJSON) {
+  return {
+    ...plan,
+    assignments: [...plan.assignments],
+  };
+}
+
+// ========== Slice ==========
+
+export const shiftPuzzleMainSlice = createSlice({
+  name: 'shiftPuzzleMain',
+  initialState,
+  reducers: {
+    // --- Events ---
+    addEvent: (state, action: PayloadAction<EventJSON>) => {
+      state.events.push(action.payload);
+    },
+    updateEvent: (state, action: PayloadAction<EventJSON>) => {
+      const idx = state.events.findIndex((e) => e.id === action.payload.id);
+      if (idx !== -1) state.events[idx] = action.payload;
+    },
+    deleteEvent: (state, action: PayloadAction<string>) => {
+      state.events = state.events.filter((e) => e.id !== action.payload);
+      if (state.currentEventId === action.payload) state.currentEventId = null;
+    },
+    setCurrentEventId: (state, action: PayloadAction<string | null>) => {
+      state.currentEventId = action.payload;
+    },
+
+    // --- Members ---
+    addMember: (state, action: PayloadAction<MemberJSON>) => {
+      state.members.push(action.payload);
+    },
+    updateMember: (state, action: PayloadAction<MemberJSON>) => {
+      const idx = state.members.findIndex((m) => m.id === action.payload.id);
+      if (idx !== -1) state.members[idx] = action.payload;
+    },
+    deleteMember: (state, action: PayloadAction<string>) => {
+      state.members = state.members.filter((m) => m.id !== action.payload);
+    },
+    setMembersForEvent: (state, action: PayloadAction<{ eventId: string; members: MemberJSON[] }>) => {
+      state.members = [
+        ...state.members.filter((m) => m.eventId !== action.payload.eventId),
+        ...action.payload.members,
+      ];
+    },
+
+    // --- Roles ---
+    addRole: (state, action: PayloadAction<RoleJSON>) => {
+      state.roles.push(action.payload);
+    },
+    updateRole: (state, action: PayloadAction<RoleJSON>) => {
+      const idx = state.roles.findIndex((r) => r.id === action.payload.id);
+      if (idx !== -1) state.roles[idx] = action.payload;
+    },
+    deleteRole: (state, action: PayloadAction<string>) => {
+      state.roles = state.roles.filter((r) => r.id !== action.payload);
+    },
+    setRolesForEvent: (state, action: PayloadAction<{ eventId: string; roles: RoleJSON[] }>) => {
+      state.roles = [
+        ...state.roles.filter((r) => r.eventId !== action.payload.eventId),
+        ...action.payload.roles,
+      ];
+    },
+
+    // --- TimeSlots ---
+    setTimeSlotsForEvent: (state, action: PayloadAction<{ eventId: string; timeSlots: TimeSlotJSON[] }>) => {
+      state.timeSlots = [
+        ...state.timeSlots.filter((s) => s.eventId !== action.payload.eventId),
+        ...action.payload.timeSlots,
+      ];
+    },
+    addTimeSlots: (state, action: PayloadAction<TimeSlotJSON[]>) => {
+      state.timeSlots.push(...action.payload);
+    },
+
+    // --- ShiftPlans ---
+    addShiftPlan: (state, action: PayloadAction<ShiftPlanJSON>) => {
+      state.shiftPlans.push(toMutableShiftPlan(action.payload));
+    },
+    updateShiftPlan: (state, action: PayloadAction<ShiftPlanJSON>) => {
+      const idx = state.shiftPlans.findIndex((p) => p.id === action.payload.id);
+      if (idx !== -1) state.shiftPlans[idx] = toMutableShiftPlan(action.payload);
+    },
+    deleteShiftPlan: (state, action: PayloadAction<string>) => {
+      state.shiftPlans = state.shiftPlans.filter((p) => p.id !== action.payload);
+      if (state.currentShiftPlanId === action.payload) {
+        state.currentShiftPlanId = state.shiftPlans[0]?.id ?? null;
+      }
+    },
+    setCurrentShiftPlanId: (state, action: PayloadAction<string | null>) => {
+      state.currentShiftPlanId = action.payload;
+    },
+
+    // --- Assignments（ShiftPlan内の配置を直接操作） ---
+    addAssignment: (
+      state,
+      action: PayloadAction<{ shiftPlanId: string; assignment: AssignmentJSON }>
+    ) => {
+      const plan = state.shiftPlans.find((p) => p.id === action.payload.shiftPlanId);
+      if (plan) plan.assignments.push(action.payload.assignment);
+    },
+    removeAssignment: (
+      state,
+      action: PayloadAction<{ shiftPlanId: string; assignmentId: string }>
+    ) => {
+      const plan = state.shiftPlans.find((p) => p.id === action.payload.shiftPlanId);
+      if (plan) {
+        plan.assignments = plan.assignments.filter(
+          (a) => a.id !== action.payload.assignmentId
+        );
+      }
+    },
+    moveAssignment: (
+      state,
+      action: PayloadAction<{ shiftPlanId: string; assignmentId: string; newTimeSlotId: string }>
+    ) => {
+      const plan = state.shiftPlans.find((p) => p.id === action.payload.shiftPlanId);
+      if (!plan) return;
+      const assignment = plan.assignments.find((a) => a.id === action.payload.assignmentId);
+      if (assignment) {
+        (assignment as AssignmentJSON).timeSlotId = action.payload.newTimeSlotId;
+        (assignment as AssignmentJSON).updatedAt = new Date().toISOString();
+      }
+    },
+    updateAssignmentReason: (
+      state,
+      action: PayloadAction<{
+        shiftPlanId: string;
+        assignmentId: string;
+        reason: AssignmentReasonState;
+      }>
+    ) => {
+      const plan = state.shiftPlans.find((p) => p.id === action.payload.shiftPlanId);
+      if (!plan) return;
+      const assignment = plan.assignments.find((a) => a.id === action.payload.assignmentId);
+      if (assignment) {
+        (assignment as AssignmentJSON).reason = action.payload.reason;
+        (assignment as AssignmentJSON).updatedAt = new Date().toISOString();
+      }
+    },
+
+    // --- UI設定 ---
+    setGanttHourPx: (state, action: PayloadAction<number>) => {
+      state.ganttHourPx = Math.max(40, Math.min(120, action.payload));
+    },
+    setGanttAxisMode: (state, action: PayloadAction<'role' | 'member'>) => {
+      state.ganttAxisMode = action.payload;
+    },
+    setGanttDayIndex: (state, action: PayloadAction<number>) => {
+      state.ganttDayIndex = action.payload;
+    },
+  },
+});
+
+export const {
+  addEvent, updateEvent, deleteEvent, setCurrentEventId,
+  addMember, updateMember, deleteMember, setMembersForEvent,
+  addRole, updateRole, deleteRole, setRolesForEvent,
+  setTimeSlotsForEvent, addTimeSlots,
+  addShiftPlan, updateShiftPlan, deleteShiftPlan, setCurrentShiftPlanId,
+  addAssignment, removeAssignment, moveAssignment, updateAssignmentReason,
+  setGanttHourPx, setGanttAxisMode, setGanttDayIndex,
+} = shiftPuzzleMainSlice.actions;
+
+// LazyLoadedSlicesを拡張
+declare module '@bublys-org/state-management' {
+  export interface LazyLoadedSlices extends WithSlice<typeof shiftPuzzleMainSlice> {}
+}
+
+// rootReducerに注入
+shiftPuzzleMainSlice.injectInto(rootReducer);
+
+// ========== Selectors ==========
+
+type StateWithShiftPuzzleMain = RootState & { shiftPuzzleMain: ShiftPuzzleMainState };
+
+const selectSlice = (state: StateWithShiftPuzzleMain): ShiftPuzzleMainState =>
+  state.shiftPuzzleMain ?? initialState;
+
+// --- Events ---
+export const selectEvents = createSelector(
+  [selectSlice],
+  (s) => s.events
+);
+export const selectCurrentEventId = (state: StateWithShiftPuzzleMain) =>
+  selectSlice(state).currentEventId;
+export const selectCurrentEvent = createSelector([selectSlice], (s) =>
+  s.events.find((e) => e.id === s.currentEventId) ?? null
+);
+
+// --- Members ---
+export const selectMembersForEvent = (eventId: string) =>
+  createSelector([selectSlice], (s) =>
+    s.members.filter((m) => m.eventId === eventId).map((m) => new Member(m))
+  );
+
+// --- Roles ---
+export const selectRolesForEvent = (eventId: string) =>
+  createSelector([selectSlice], (s) =>
+    s.roles.filter((r) => r.eventId === eventId).map((r) => new Role(r))
+  );
+
+// --- TimeSlots ---
+export const selectTimeSlotsForEvent = (eventId: string) =>
+  createSelector([selectSlice], (s) =>
+    s.timeSlots.filter((ts) => ts.eventId === eventId)
+  );
+
+// --- ShiftPlans ---
+export const selectShiftPlans = createSelector([selectSlice], (s) =>
+  s.shiftPlans.map((p) => new ShiftPlan(p))
+);
+export const selectCurrentShiftPlanId = (state: StateWithShiftPuzzleMain) =>
+  selectSlice(state).currentShiftPlanId;
+export const selectShiftPlanById = (id: string) =>
+  createSelector([selectSlice], (s) => {
+    const json = s.shiftPlans.find((p) => p.id === id);
+    return json ? new ShiftPlan(json) : undefined;
+  });
+export const selectCurrentShiftPlan = createSelector([selectSlice], (s) => {
+  const id = s.currentShiftPlanId;
+  if (!id) return undefined;
+  const json = s.shiftPlans.find((p) => p.id === id);
+  return json ? new ShiftPlan(json) : undefined;
+});
+
+// --- Assignments ---
+export const selectAssignmentsForPlan = (planId: string) =>
+  createSelector([selectSlice], (s) => {
+    const plan = s.shiftPlans.find((p) => p.id === planId);
+    return (plan?.assignments ?? []).map((a) => new Assignment(a));
+  });
+
+// --- 制約違反（computed） ---
+export const selectViolationsForPlan = (planId: string, eventId: string) =>
+  createSelector([selectSlice], (s): ConstraintViolation[] => {
+    const plan = s.shiftPlans.find((p) => p.id === planId);
+    if (!plan) return [];
+    const members = s.members.filter((m) => m.eventId === eventId);
+    const roles = s.roles.filter((r) => r.eventId === eventId);
+    const timeSlots = s.timeSlots.filter((ts) => ts.eventId === eventId);
+    const checker = ConstraintChecker.create(
+      plan.assignments,
+      members,
+      roles,
+      timeSlots
+    );
+    return checker.computeViolations();
+  });
+
+// --- UI設定 ---
+export const selectGanttHourPx = (state: StateWithShiftPuzzleMain) =>
+  selectSlice(state).ganttHourPx;
+export const selectGanttAxisMode = (state: StateWithShiftPuzzleMain) =>
+  selectSlice(state).ganttAxisMode;
+export const selectGanttDayIndex = (state: StateWithShiftPuzzleMain) =>
+  selectSlice(state).ganttDayIndex;

--- a/shift-puzzle-bubly/shift-puzzle-libs/src/ui/GanttChart/AssignmentBlock.tsx
+++ b/shift-puzzle-bubly/shift-puzzle-libs/src/ui/GanttChart/AssignmentBlock.tsx
@@ -1,0 +1,138 @@
+'use client';
+import React from 'react';
+import styled from 'styled-components';
+import type {
+  AssignmentState,
+  RoleState,
+  MemberState,
+  ConstraintViolation,
+} from '@bublys-org/shift-puzzle-model';
+
+interface AssignmentBlockProps {
+  assignment: AssignmentState;
+  /** バーに表示するラベル元（役割名 or メンバー名） */
+  role: RoleState | undefined;
+  member: MemberState | undefined;
+  left: number;
+  width: number;
+  rowHeight: number;
+  violation?: ConstraintViolation;
+  onClick?: (assignmentId: string) => void;
+}
+
+/** ガントチャート上の配置ブロック（ドラッグ可能） */
+export const AssignmentBlock: React.FC<AssignmentBlockProps> = ({
+  assignment,
+  role,
+  member,
+  left,
+  width,
+  rowHeight,
+  violation,
+  onClick,
+}) => {
+  const bgColor = role?.color ?? '#1976d2';
+
+  const handleDragStart = (e: React.DragEvent<HTMLDivElement>) => {
+    e.dataTransfer.setData('text/assignment-id', assignment.id);
+    e.dataTransfer.setData('text/member-id', assignment.memberId);
+    e.dataTransfer.setData('text/role-id', assignment.roleId);
+    e.dataTransfer.effectAllowed = 'move';
+    e.stopPropagation();
+  };
+
+  const hasReason = assignment.reason.text.length > 0;
+  const outlineColor = violation ? violationOutlineColor(violation.type) : 'transparent';
+
+  return (
+    <StyledBlock
+      style={{
+        left,
+        width: Math.max(width - 2, 4),
+        height: rowHeight - 8,
+        top: 4,
+        backgroundColor: bgColor,
+        outlineColor,
+        outlineWidth: violation ? 2 : 0,
+        outlineStyle: violation ? 'solid' : 'none',
+        outlineOffset: -2,
+      }}
+      draggable
+      onDragStart={handleDragStart}
+      onClick={(e: React.MouseEvent<HTMLDivElement>) => {
+        e.stopPropagation();
+        onClick?.(assignment.id);
+      }}
+      title={buildTooltip(assignment, role, member, violation)}
+    >
+      <span className="e-label">{role?.name ?? member?.name ?? '?'}</span>
+      {hasReason && (
+        <span className="e-reason-dot" title={`理由: ${assignment.reason.text}`}>
+          ●
+        </span>
+      )}
+    </StyledBlock>
+  );
+};
+
+function violationOutlineColor(type: ConstraintViolation['type']): string {
+  switch (type) {
+    case 'duplicate_member_in_timeslot': return '#f44336';
+    case 'outside_availability':         return '#ff9800';
+    case 'skill_mismatch':               return '#ffc107';
+    default:                             return '#9e9e9e';
+  }
+}
+
+function buildTooltip(
+  assignment: AssignmentState,
+  role: RoleState | undefined,
+  member: MemberState | undefined,
+  violation: ConstraintViolation | undefined
+): string {
+  const lines = [
+    `役割: ${role?.name ?? '-'}`,
+    `担当: ${member?.name ?? '-'}`,
+  ];
+  if (assignment.reason.text) lines.push(`理由: ${assignment.reason.text}`);
+  if (violation) lines.push(`⚠ ${violation.message}`);
+  if (assignment.locked) lines.push('🔒 ロック済み');
+  return lines.join('\n');
+}
+
+const StyledBlock = styled.div`
+  position: absolute;
+  border-radius: 3px;
+  display: flex;
+  align-items: center;
+  gap: 3px;
+  padding: 0 6px;
+  color: white;
+  font-size: 0.8em;
+  cursor: grab;
+  overflow: hidden;
+  white-space: nowrap;
+  transition: box-shadow 0.15s;
+  z-index: 2;
+
+  &:active {
+    cursor: grabbing;
+  }
+
+  &:hover {
+    box-shadow: 0 2px 6px rgba(0, 0, 0, 0.3);
+    z-index: 3;
+  }
+
+  .e-label {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    flex: 1;
+  }
+
+  .e-reason-dot {
+    font-size: 0.5em;
+    opacity: 0.7;
+    flex-shrink: 0;
+  }
+` as React.FC<React.HTMLAttributes<HTMLDivElement> & { draggable?: boolean }>;

--- a/shift-puzzle-bubly/shift-puzzle-libs/src/ui/GanttChart/ConflictHighlight.tsx
+++ b/shift-puzzle-bubly/shift-puzzle-libs/src/ui/GanttChart/ConflictHighlight.tsx
@@ -1,0 +1,44 @@
+'use client';
+import React from 'react';
+import styled from 'styled-components';
+import type { ConstraintViolation } from '@bublys-org/shift-puzzle-model';
+
+interface ConflictHighlightProps {
+  violation: ConstraintViolation;
+  left: number;
+  width: number;
+  rowHeight: number;
+}
+
+/** 制約違反を視覚的にハイライト表示するオーバーレイ */
+export const ConflictHighlight: React.FC<ConflictHighlightProps> = ({
+  violation,
+  left,
+  width,
+  rowHeight,
+}) => {
+  const color = violationColor(violation.type);
+  return (
+    <StyledHighlight
+      style={{ left, width, height: rowHeight - 8, top: 4, borderColor: color, backgroundColor: `${color}22` }}
+      title={violation.message}
+    />
+  );
+};
+
+function violationColor(type: ConstraintViolation['type']): string {
+  switch (type) {
+    case 'duplicate_member_in_timeslot': return '#f44336';
+    case 'outside_availability':         return '#ff9800';
+    case 'skill_mismatch':               return '#ffc107';
+    default:                             return '#9e9e9e';
+  }
+}
+
+const StyledHighlight = styled.div`
+  position: absolute;
+  border-radius: 3px;
+  border: 2px solid;
+  pointer-events: none;
+  z-index: 4;
+` as React.FC<React.HTMLAttributes<HTMLDivElement>>;

--- a/shift-puzzle-bubly/shift-puzzle-libs/src/ui/GanttChart/GanttChartView.tsx
+++ b/shift-puzzle-bubly/shift-puzzle-libs/src/ui/GanttChart/GanttChartView.tsx
@@ -1,0 +1,388 @@
+'use client';
+import React, { useMemo, useRef, useState } from 'react';
+import styled from 'styled-components';
+import {
+  getDragType,
+  DRAG_KEYS,
+} from '@bublys-org/bubbles-ui';
+import type {
+  MemberState,
+  RoleState,
+  TimeSlotState,
+  AssignmentState,
+  AssignmentReasonState,
+  ConstraintViolation,
+} from '@bublys-org/shift-puzzle-model';
+import { TimeAxis } from './TimeAxis.js';
+import { MemberRow } from './MemberRow.js';
+import { ReasonInputDialog } from './ReasonInputDialog.js';
+
+// ========== Props ==========
+
+export interface GanttChartViewProps {
+  /** メンバー一覧 */
+  members: MemberState[];
+  /** 役割一覧 */
+  roles: RoleState[];
+  /** このシフト案のTimeSlot一覧 */
+  timeSlots: TimeSlotState[];
+  /** 配置一覧 */
+  assignments: AssignmentState[];
+  /** 制約違反一覧（F-2-6） */
+  violations?: ConstraintViolation[];
+  /** 表示するdayIndex（デフォルト: 0） */
+  dayIndex?: number;
+  /** 1時間あたりのピクセル幅 */
+  hourPx?: number;
+  /** 行の高さ */
+  rowHeight?: number;
+  /** 行モード: role = 役割行（メンバーをD&D配置）/ member = メンバー行（配置を確認） */
+  axisMode?: 'role' | 'member';
+  /** 新規配置コールバック */
+  onCreateAssignment?: (
+    memberId: string,
+    timeSlotId: string,
+    roleId: string,
+    reason: AssignmentReasonState
+  ) => void;
+  /** 配置移動コールバック（timeSlotId変更） */
+  onMoveAssignment?: (assignmentId: string, newTimeSlotId: string) => void;
+  /** 配置クリックコールバック */
+  onAssignmentClick?: (assignmentId: string) => void;
+}
+
+// ========== 内部型 ==========
+
+interface PendingDrop {
+  memberId: string;
+  timeSlotId: string;
+  /** roleモード時のrowId（roleId）*/
+  rowId: string;
+}
+
+// ========== コンポーネント ==========
+
+const LABEL_WIDTH = 140;
+const AXIS_HEIGHT = 36;
+
+export const GanttChartView: React.FC<GanttChartViewProps> = ({
+  members,
+  roles,
+  timeSlots,
+  assignments,
+  violations = [],
+  dayIndex = 0,
+  hourPx = 80,
+  rowHeight = 48,
+  axisMode = 'role',
+  onCreateAssignment,
+  onMoveAssignment,
+  onAssignmentClick,
+}) => {
+  const scrollRef = useRef<HTMLDivElement>(null);
+  const [pendingDrop, setPendingDrop] = useState<PendingDrop | null>(null);
+  const [pendingRoleId, setPendingRoleId] = useState<string>('');
+
+  // このdayのTimeSlot一覧
+  const daySlots = useMemo(
+    () => timeSlots.filter((s) => s.dayIndex === dayIndex),
+    [timeSlots, dayIndex]
+  );
+
+  // 時刻範囲の計算
+  const { dayStartMinute, dayEndMinute, dayWidth } = useMemo(() => {
+    if (daySlots.length === 0) {
+      return { dayStartMinute: 540, dayEndMinute: 1200, dayWidth: 0 };
+    }
+    const starts = daySlots.map((s) => s.startMinute);
+    const ends = daySlots.map((s) => s.startMinute + s.durationMinutes);
+    const start = Math.min(...starts);
+    const end = Math.max(...ends);
+    const width = (end - start) * (hourPx / 60);
+    return { dayStartMinute: start, dayEndMinute: end, dayWidth: width };
+  }, [daySlots, hourPx]);
+
+  const minutePx = hourPx / 60;
+
+  // ルックアップマップ
+  const roleMap = useMemo(() => new Map(roles.map((r) => [r.id, r])), [roles]);
+  const memberMap = useMemo(() => new Map(members.map((m) => [m.id, m])), [members]);
+
+  // ========== 行データ ==========
+
+  type RowData = {
+    id: string;
+    label: string;
+    assignments: AssignmentState[];
+    availableSlotIds?: ReadonlyArray<string>;
+  };
+
+  const rows: RowData[] = useMemo(() => {
+    if (axisMode === 'role') {
+      return roles.map((role) => ({
+        id: role.id,
+        label: role.name,
+        assignments: assignments.filter(
+          (a) => a.roleId === role.id && daySlots.some((s) => s.id === a.timeSlotId)
+        ),
+      }));
+    } else {
+      return members.map((member) => ({
+        id: member.id,
+        label: member.name,
+        assignments: assignments.filter(
+          (a) => a.memberId === member.id && daySlots.some((s) => s.id === a.timeSlotId)
+        ),
+        availableSlotIds: member.availableSlotIds,
+      }));
+    }
+  }, [axisMode, roles, members, assignments, daySlots]);
+
+  // ========== D&D ハンドラ ==========
+
+  const handleDragOver = (e: React.DragEvent<HTMLDivElement>) => {
+    const types = Array.from(e.dataTransfer.types);
+    const memberDragType = getDragType('Member');
+    const isInternal = types.includes('text/assignment-id');
+    const isMemberDrag = types.includes(memberDragType);
+    if (isInternal || isMemberDrag || types.includes('text/member-id')) {
+      e.preventDefault();
+    }
+  };
+
+  const handleDrop = (e: React.DragEvent<HTMLDivElement>, rowId: string) => {
+    e.preventDefault();
+
+    const scrollEl = scrollRef.current;
+    if (!scrollEl) return;
+
+    // ドロップ位置 → TimeSlot特定
+    const rect = scrollEl.getBoundingClientRect();
+    const px = e.clientX - rect.left + scrollEl.scrollLeft - LABEL_WIDTH;
+    const targetSlot = findSlotAtPx(px);
+    if (!targetSlot) return;
+
+    // 内部移動（既存配置のドラッグ）
+    const assignmentId = e.dataTransfer.getData('text/assignment-id');
+    if (assignmentId) {
+      onMoveAssignment?.(assignmentId, targetSlot.id);
+      return;
+    }
+
+    // ObjectViewからのメンバードラッグ（新規配置）
+    const memberDragType = getDragType('Member');
+    const types = Array.from(e.dataTransfer.types);
+    let memberId: string | null = null;
+
+    if (types.includes('text/member-id')) {
+      memberId = e.dataTransfer.getData('text/member-id');
+    } else if (types.includes(memberDragType)) {
+      const url =
+        e.dataTransfer.getData(memberDragType) || e.dataTransfer.getData(DRAG_KEYS.url);
+      const match = url.match(/members?\/([^/]+)/);
+      if (match) memberId = match[1];
+    }
+
+    if (!memberId) return;
+
+    // roleモード: rowId = roleId として直接使用
+    // memberモード: ダイアログで役割を選択
+    const roleId = axisMode === 'role' ? rowId : '';
+
+    setPendingDrop({ memberId, timeSlotId: targetSlot.id, rowId });
+    setPendingRoleId(roleId);
+  };
+
+  const findSlotAtPx = (px: number): TimeSlotState | undefined => {
+    const minute = px / minutePx + dayStartMinute;
+    return daySlots.find(
+      (s) => s.startMinute <= minute && minute < s.startMinute + s.durationMinutes
+    );
+  };
+
+  // 配置確定
+  const handleConfirmReason = (reason: AssignmentReasonState) => {
+    if (!pendingDrop) return;
+    const roleId = pendingRoleId || pendingDrop.rowId;
+    if (!roleId) return;
+    onCreateAssignment?.(pendingDrop.memberId, pendingDrop.timeSlotId, roleId, reason);
+    setPendingDrop(null);
+    setPendingRoleId('');
+  };
+
+  // ダイアログ用情報
+  const pendingMember = pendingDrop ? memberMap.get(pendingDrop.memberId) : undefined;
+  const pendingRole =
+    pendingDrop && axisMode === 'role' ? roleMap.get(pendingDrop.rowId) : undefined;
+
+  // ========== 役割充足状況バッジ（F-2-6補足） ==========
+
+  const roleFulfillment = useMemo(() => {
+    if (axisMode !== 'role') return new Map<string, boolean>();
+    const map = new Map<string, boolean>();
+    for (const role of roles) {
+      for (const slot of daySlots) {
+        const count = assignments.filter(
+          (a) => a.roleId === role.id && a.timeSlotId === slot.id
+        ).length;
+        if (count < role.minRequired) {
+          map.set(role.id, false);
+          break;
+        }
+        map.set(role.id, true);
+      }
+    }
+    return map;
+  }, [axisMode, roles, assignments, daySlots]);
+
+  // ========== レンダリング ==========
+
+  return (
+    <StyledGantt>
+      {/* ヘッダー行 */}
+      <div className="e-header-row" style={{ height: AXIS_HEIGHT }}>
+        <div className="e-label-header" style={{ width: LABEL_WIDTH }} />
+        <div className="e-timeline-header-scroll">
+          <div className="e-timeline-header-inner" style={{ width: dayWidth }}>
+            <TimeAxis
+              dayStartMinute={dayStartMinute}
+              dayEndMinute={dayEndMinute}
+              hourPx={hourPx}
+            />
+          </div>
+        </div>
+      </div>
+
+      {/* ボディ */}
+      <div className="e-body" ref={scrollRef}>
+        {/* ラベル列（固定） */}
+        <div className="e-label-column" style={{ width: LABEL_WIDTH }}>
+          {rows.map((row) => (
+            <div key={row.id} className="e-row-label" style={{ height: rowHeight }}>
+              <span className="e-label-text">{row.label}</span>
+              {axisMode === 'role' && roleFulfillment.get(row.id) === false && (
+                <span className="e-badge-shortage">不足</span>
+              )}
+            </div>
+          ))}
+        </div>
+
+        {/* タイムライン列 */}
+        <div className="e-timeline-column" style={{ width: dayWidth }}>
+          {rows.map((row) => (
+            <MemberRow
+              key={row.id}
+              label={row.label}
+              availableSlotIds={row.availableSlotIds}
+              assignments={row.assignments}
+              roleMap={roleMap}
+              memberMap={memberMap}
+              dayTimeSlots={daySlots}
+              violations={violations}
+              rowHeight={rowHeight}
+              dayStartMinute={dayStartMinute}
+              hourPx={hourPx}
+              dayWidth={dayWidth}
+              barLabelMode={axisMode === 'role' ? 'member' : 'role'}
+              onAssignmentClick={onAssignmentClick}
+              onDragOver={handleDragOver}
+              onDrop={(e) => handleDrop(e, row.id)}
+            />
+          ))}
+        </div>
+      </div>
+
+      {/* F-2-5: 配置理由入力ダイアログ */}
+      <ReasonInputDialog
+        open={pendingDrop !== null}
+        memberName={pendingMember?.name}
+        roleName={pendingRole?.name}
+        roles={axisMode === 'member' ? roles.map((r) => ({ id: r.id, name: r.name, color: r.color })) : undefined}
+        selectedRoleId={pendingRoleId}
+        onRoleChange={setPendingRoleId}
+        onConfirm={handleConfirmReason}
+        onCancel={() => { setPendingDrop(null); setPendingRoleId(''); }}
+      />
+    </StyledGantt>
+  );
+};
+
+// ========== スタイル ==========
+
+const StyledGantt = styled.div`
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  overflow: hidden;
+  font-size: 0.85em;
+  background: white;
+
+  .e-header-row {
+    display: flex;
+    flex-shrink: 0;
+    border-bottom: 2px solid #c5cae9;
+    background: #f5f5f5;
+  }
+
+  .e-label-header {
+    flex-shrink: 0;
+    border-right: 1px solid #ddd;
+    background: #f5f5f5;
+  }
+
+  .e-timeline-header-scroll {
+    flex: 1;
+    overflow: hidden;
+  }
+
+  .e-timeline-header-inner {
+    height: 100%;
+  }
+
+  .e-body {
+    flex: 1;
+    overflow: auto;
+    display: flex;
+  }
+
+  .e-label-column {
+    flex-shrink: 0;
+    position: sticky;
+    left: 0;
+    z-index: 5;
+    background: #fafafa;
+    border-right: 1px solid #ddd;
+  }
+
+  .e-row-label {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    padding: 0 10px;
+    border-bottom: 1px solid #eee;
+    font-weight: 500;
+    font-size: 0.9em;
+
+    .e-label-text {
+      flex: 1;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+
+    .e-badge-shortage {
+      background: #ffecb3;
+      color: #e65100;
+      font-size: 0.7em;
+      font-weight: bold;
+      padding: 1px 5px;
+      border-radius: 3px;
+      border: 1px solid #ff8f00;
+      white-space: nowrap;
+    }
+  }
+
+  .e-timeline-column {
+    flex-shrink: 0;
+  }
+` as React.FC<React.HTMLAttributes<HTMLDivElement>>;

--- a/shift-puzzle-bubly/shift-puzzle-libs/src/ui/GanttChart/MemberRow.tsx
+++ b/shift-puzzle-bubly/shift-puzzle-libs/src/ui/GanttChart/MemberRow.tsx
@@ -93,6 +93,8 @@ export const MemberRow: React.FC<MemberRowProps> = ({
               assignment={assignment}
               role={barLabelMode === 'role' ? undefined : role}
               member={barLabelMode === 'member' ? undefined : member}
+              memberName={member?.name}
+              roleName={role?.name}
               left={left}
               width={width}
               rowHeight={rowHeight}

--- a/shift-puzzle-bubly/shift-puzzle-libs/src/ui/GanttChart/MemberRow.tsx
+++ b/shift-puzzle-bubly/shift-puzzle-libs/src/ui/GanttChart/MemberRow.tsx
@@ -1,0 +1,137 @@
+'use client';
+import React from 'react';
+import styled from 'styled-components';
+import type {
+  AssignmentState,
+  RoleState,
+  MemberState,
+  TimeSlotState,
+  ConstraintViolation,
+} from '@bublys-org/shift-puzzle-model';
+import { AssignmentBlock } from './AssignmentBlock.js';
+import { ConflictHighlight } from './ConflictHighlight.js';
+
+interface MemberRowProps {
+  label: string;
+  /** F-2-7: このメンバーが参加可能なTimeSlot.id群 */
+  availableSlotIds?: ReadonlyArray<string>;
+  assignments: AssignmentState[];
+  roleMap: Map<string, RoleState>;
+  memberMap: Map<string, MemberState>;
+  /** 同日のTimeSlot一覧 */
+  dayTimeSlots: TimeSlotState[];
+  violations: ConstraintViolation[];
+  rowHeight: number;
+  dayStartMinute: number;
+  hourPx: number;
+  dayWidth: number;
+  /** バーラベルモード: 役割名 or メンバー名 */
+  barLabelMode: 'role' | 'member';
+  onAssignmentClick?: (assignmentId: string) => void;
+  onDragOver?: (e: React.DragEvent<HTMLDivElement>) => void;
+  onDrop?: (e: React.DragEvent<HTMLDivElement>) => void;
+}
+
+/** ガントチャートの1行（メンバー or 役割） */
+export const MemberRow: React.FC<MemberRowProps> = ({
+  availableSlotIds,
+  assignments,
+  roleMap,
+  memberMap,
+  dayTimeSlots,
+  violations,
+  rowHeight,
+  dayStartMinute,
+  hourPx,
+  dayWidth,
+  barLabelMode,
+  onAssignmentClick,
+  onDragOver,
+  onDrop,
+}) => {
+  const minutePx = hourPx / 60;
+
+  const slotToRect = (slot: TimeSlotState) => ({
+    left: (slot.startMinute - dayStartMinute) * minutePx,
+    width: slot.durationMinutes * minutePx,
+  });
+
+  const findViolation = (assignmentId: string) =>
+    violations.find((v) => v.assignmentId === assignmentId);
+
+  const availableRects = availableSlotIds
+    ? dayTimeSlots.filter((s) => availableSlotIds.includes(s.id)).map(slotToRect)
+    : [];
+
+  return (
+    <StyledRow
+      style={{ height: rowHeight, width: dayWidth }}
+      onDragOver={onDragOver}
+      onDrop={onDrop}
+    >
+      {/* F-2-7: 参加可能時間帯のオーバーレイ */}
+      {availableRects.map((rect, i) => (
+        <div
+          key={i}
+          className="e-available-overlay"
+          style={{ left: rect.left, width: rect.width }}
+        />
+      ))}
+
+      {/* 配置ブロック */}
+      {assignments.map((assignment) => {
+        const slot = dayTimeSlots.find((s) => s.id === assignment.timeSlotId);
+        if (!slot) return null;
+        const { left, width } = slotToRect(slot);
+        const violation = findViolation(assignment.id);
+        const role = roleMap.get(assignment.roleId);
+        const member = memberMap.get(assignment.memberId);
+
+        return (
+          <React.Fragment key={assignment.id}>
+            <AssignmentBlock
+              assignment={assignment}
+              role={barLabelMode === 'role' ? undefined : role}
+              member={barLabelMode === 'member' ? undefined : member}
+              left={left}
+              width={width}
+              rowHeight={rowHeight}
+              violation={violation}
+              onClick={onAssignmentClick}
+            />
+            {/* F-2-6: 制約違反ハイライト */}
+            {violation && (
+              <ConflictHighlight
+                violation={violation}
+                left={left}
+                width={width}
+                rowHeight={rowHeight}
+              />
+            )}
+          </React.Fragment>
+        );
+      })}
+    </StyledRow>
+  );
+};
+
+const StyledRow = styled.div`
+  position: relative;
+  border-bottom: 1px solid #eee;
+  cursor: crosshair;
+
+  &:hover {
+    background-color: rgba(25, 118, 210, 0.04);
+  }
+
+  .e-available-overlay {
+    position: absolute;
+    top: 2px;
+    height: calc(100% - 4px);
+    background-color: rgba(76, 175, 80, 0.12);
+    border: 1px solid rgba(76, 175, 80, 0.3);
+    border-radius: 2px;
+    pointer-events: none;
+    z-index: 1;
+  }
+` as React.FC<React.HTMLAttributes<HTMLDivElement>>;

--- a/shift-puzzle-bubly/shift-puzzle-libs/src/ui/GanttChart/ReasonInputDialog.tsx
+++ b/shift-puzzle-bubly/shift-puzzle-libs/src/ui/GanttChart/ReasonInputDialog.tsx
@@ -1,0 +1,284 @@
+'use client';
+import React, { useState } from 'react';
+import styled from 'styled-components';
+import type { AssignmentReasonState, ReasonCategory } from '@bublys-org/shift-puzzle-model';
+
+export interface ReasonInputDialogProps {
+  open: boolean;
+  memberName?: string;
+  roleName?: string;
+  /** 役割選択が必要な場合（memberモード時） */
+  roles?: Array<{ id: string; name: string; color: string }>;
+  selectedRoleId?: string;
+  onRoleChange?: (roleId: string) => void;
+  onConfirm: (reason: AssignmentReasonState) => void;
+  onCancel: () => void;
+}
+
+const CATEGORY_LABELS: Record<ReasonCategory, string> = {
+  skill_match:     'スキル適合',
+  training:        '育成目的',
+  compatibility:   '相性考慮',
+  availability:    '参加可能なため',
+  other:           'その他',
+};
+
+/** F-2-5: 配置理由入力ダイアログ */
+export const ReasonInputDialog: React.FC<ReasonInputDialogProps> = ({
+  open,
+  memberName,
+  roleName,
+  roles,
+  selectedRoleId,
+  onRoleChange,
+  onConfirm,
+  onCancel,
+}) => {
+  const [category, setCategory] = useState<ReasonCategory>('skill_match');
+  const [text, setText] = useState('');
+
+  if (!open) return null;
+
+  const handleConfirm = () => {
+    onConfirm({
+      category,
+      text,
+      createdBy: '',
+      createdAt: new Date().toISOString(),
+    });
+    setText('');
+    setCategory('skill_match');
+  };
+
+  const handleCancel = () => {
+    setText('');
+    setCategory('skill_match');
+    onCancel();
+  };
+
+  return (
+    <StyledOverlay onClick={(e: React.MouseEvent<HTMLDivElement>) => e.stopPropagation()}>
+      <StyledPanel>
+        <div className="e-header">
+          <span className="e-title">配置理由を入力</span>
+        </div>
+
+        <div className="e-info">
+          {memberName && <span className="e-chip">{memberName}</span>}
+          {roleName && <><span className="e-arrow">→</span><span className="e-chip e-role">{roleName}</span></>}
+        </div>
+
+        {/* 役割選択（memberモード時） */}
+        {roles && roles.length > 0 && (
+          <div className="e-field">
+            <label className="e-field-label">役割</label>
+            <select
+              className="e-select"
+              value={selectedRoleId ?? ''}
+              onChange={(e: React.ChangeEvent<HTMLSelectElement>) => onRoleChange?.(e.target.value)}
+            >
+              <option value="">選択してください</option>
+              {roles.map((r) => (
+                <option key={r.id} value={r.id}>{r.name}</option>
+              ))}
+            </select>
+          </div>
+        )}
+
+        <div className="e-field">
+          <label className="e-field-label">理由カテゴリ</label>
+          <div className="e-category-list">
+            {(Object.entries(CATEGORY_LABELS) as [ReasonCategory, string][]).map(([key, label]) => (
+              <label key={key} className={`e-category-btn ${category === key ? 'is-selected' : ''}`}>
+                <input
+                  type="radio"
+                  name="category"
+                  value={key}
+                  checked={category === key}
+                  onChange={() => setCategory(key)}
+                />
+                {label}
+              </label>
+            ))}
+          </div>
+        </div>
+
+        <div className="e-field">
+          <label className="e-field-label">詳細メモ（任意）</label>
+          <textarea
+            className="e-textarea"
+            rows={2}
+            placeholder="配置の背景・理由を記入..."
+            value={text}
+            onChange={(e: React.ChangeEvent<HTMLTextAreaElement>) => setText(e.target.value)}
+          />
+        </div>
+
+        <div className="e-actions">
+          <button className="e-btn e-btn-cancel" onClick={handleCancel}>
+            キャンセル
+          </button>
+          <button className="e-btn e-btn-confirm" onClick={handleConfirm}>
+            配置を確定
+          </button>
+        </div>
+      </StyledPanel>
+    </StyledOverlay>
+  );
+};
+
+const StyledOverlay = styled.div`
+  position: fixed;
+  inset: 0;
+  background-color: rgba(0, 0, 0, 0.3);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 100;
+` as React.FC<React.HTMLAttributes<HTMLDivElement>>;
+
+const StyledPanel = styled.div`
+  background: white;
+  border-radius: 8px;
+  padding: 16px;
+  width: 360px;
+  box-shadow: 0 4px 24px rgba(0, 0, 0, 0.2);
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+
+  .e-header {
+    .e-title {
+      font-size: 1em;
+      font-weight: 600;
+      color: #333;
+    }
+  }
+
+  .e-info {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    flex-wrap: wrap;
+
+    .e-chip {
+      background: #e3f2fd;
+      color: #1565c0;
+      padding: 2px 8px;
+      border-radius: 12px;
+      font-size: 0.85em;
+      font-weight: 500;
+    }
+
+    .e-chip.e-role {
+      background: #f3e5f5;
+      color: #6a1b9a;
+    }
+
+    .e-arrow {
+      color: #888;
+      font-size: 0.9em;
+    }
+  }
+
+  .e-field {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+  }
+
+  .e-field-label {
+    font-size: 0.8em;
+    color: #666;
+    font-weight: 500;
+  }
+
+  .e-select {
+    padding: 6px 8px;
+    border: 1px solid #ddd;
+    border-radius: 4px;
+    font-size: 0.9em;
+    background: white;
+  }
+
+  .e-category-list {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 6px;
+  }
+
+  .e-category-btn {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+    padding: 4px 10px;
+    border: 1px solid #ddd;
+    border-radius: 16px;
+    font-size: 0.82em;
+    cursor: pointer;
+    background: white;
+
+    input[type="radio"] {
+      display: none;
+    }
+
+    &.is-selected {
+      background: #1976d2;
+      border-color: #1976d2;
+      color: white;
+    }
+
+    &:hover:not(.is-selected) {
+      background: #f0f4ff;
+      border-color: #90caf9;
+    }
+  }
+
+  .e-textarea {
+    padding: 6px 8px;
+    border: 1px solid #ddd;
+    border-radius: 4px;
+    font-size: 0.9em;
+    resize: vertical;
+    font-family: inherit;
+
+    &:focus {
+      outline: none;
+      border-color: #1976d2;
+    }
+  }
+
+  .e-actions {
+    display: flex;
+    justify-content: flex-end;
+    gap: 8px;
+    margin-top: 4px;
+  }
+
+  .e-btn {
+    padding: 7px 16px;
+    border: none;
+    border-radius: 4px;
+    font-size: 0.9em;
+    cursor: pointer;
+    font-weight: 500;
+  }
+
+  .e-btn-cancel {
+    background: #f5f5f5;
+    color: #555;
+
+    &:hover {
+      background: #e0e0e0;
+    }
+  }
+
+  .e-btn-confirm {
+    background: #1976d2;
+    color: white;
+
+    &:hover {
+      background: #1565c0;
+    }
+  }
+` as React.FC<React.HTMLAttributes<HTMLDivElement>>;

--- a/shift-puzzle-bubly/shift-puzzle-libs/src/ui/GanttChart/TimeAxis.tsx
+++ b/shift-puzzle-bubly/shift-puzzle-libs/src/ui/GanttChart/TimeAxis.tsx
@@ -1,0 +1,79 @@
+'use client';
+import React from 'react';
+import styled from 'styled-components';
+
+interface TimeAxisProps {
+  /** 表示開始時刻（0:00からの経過分数。例: 540 = 9:00） */
+  dayStartMinute: number;
+  /** 表示終了時刻（0:00からの経過分数。例: 1200 = 20:00） */
+  dayEndMinute: number;
+  /** 1時間あたりのピクセル幅 */
+  hourPx: number;
+}
+
+/** 横スクロール領域内の時刻ラベル・グリッド線 */
+export const TimeAxis: React.FC<TimeAxisProps> = ({ dayStartMinute, dayEndMinute, hourPx }) => {
+  const minutePx = hourPx / 60;
+  const totalWidth = (dayEndMinute - dayStartMinute) * minutePx;
+
+  const startHour = Math.floor(dayStartMinute / 60);
+  const endHour = Math.ceil(dayEndMinute / 60);
+
+  const hourMarkers: { left: number; label: string }[] = [];
+  const halfHourMarkers: { left: number }[] = [];
+
+  for (let h = startHour; h <= endHour; h++) {
+    const minute = h * 60;
+    if (minute >= dayStartMinute && minute <= dayEndMinute) {
+      const left = (minute - dayStartMinute) * minutePx;
+      hourMarkers.push({ left, label: `${String(h).padStart(2, '0')}:00` });
+    }
+    const halfMinute = h * 60 + 30;
+    if (halfMinute > dayStartMinute && halfMinute < dayEndMinute) {
+      const left = (halfMinute - dayStartMinute) * minutePx;
+      halfHourMarkers.push({ left });
+    }
+  }
+
+  return (
+    <StyledTimeAxis style={{ width: totalWidth }}>
+      {hourMarkers.map((m) => (
+        <div key={m.left} className="e-hour-mark" style={{ left: m.left }}>
+          <span className="e-label">{m.label}</span>
+        </div>
+      ))}
+      {halfHourMarkers.map((m, i) => (
+        <div key={i} className="e-half-mark" style={{ left: m.left }} />
+      ))}
+    </StyledTimeAxis>
+  );
+};
+
+const StyledTimeAxis = styled.div`
+  position: relative;
+  height: 100%;
+
+  .e-hour-mark {
+    position: absolute;
+    top: 0;
+    height: 100%;
+    border-left: 1px solid #c5cae9;
+
+    .e-label {
+      display: block;
+      padding-left: 3px;
+      font-size: 0.75em;
+      color: #555;
+      white-space: nowrap;
+      line-height: 1;
+      padding-top: 4px;
+    }
+  }
+
+  .e-half-mark {
+    position: absolute;
+    top: 0;
+    height: 100%;
+    border-left: 1px dashed #e0e0e0;
+  }
+` as React.FC<React.HTMLAttributes<HTMLDivElement>>;

--- a/shift-puzzle-bubly/shift-puzzle-libs/src/ui/ReasonPanel/ReasonInputPanel.tsx
+++ b/shift-puzzle-bubly/shift-puzzle-libs/src/ui/ReasonPanel/ReasonInputPanel.tsx
@@ -1,0 +1,282 @@
+'use client';
+import React, { useState } from 'react';
+import styled from 'styled-components';
+import type { AssignmentReasonState, ReasonCategory } from '@bublys-org/shift-puzzle-model';
+
+export interface ReasonInputPanelProps {
+  memberName?: string;
+  roleName?: string;
+  initialCategory?: ReasonCategory;
+  initialText?: string;
+  initialCreatedBy?: string;
+  onSave: (reason: AssignmentReasonState) => void;
+  onCancel?: () => void;
+}
+
+const CATEGORY_LABELS: Record<ReasonCategory, string> = {
+  skill_match:   'スキル適合',
+  training:      '育成目的',
+  compatibility: '相性考慮',
+  availability:  '空き時間調整',
+  other:         'その他',
+};
+
+/** F-3-1: 配置理由入力パネル（記録者フィールド付き、モーダルなし） */
+export const ReasonInputPanel: React.FC<ReasonInputPanelProps> = ({
+  memberName,
+  roleName,
+  initialCategory = 'skill_match',
+  initialText = '',
+  initialCreatedBy = '',
+  onSave,
+  onCancel,
+}) => {
+  const [category, setCategory] = useState<ReasonCategory>(initialCategory);
+  const [text, setText] = useState(initialText);
+  const [createdBy, setCreatedBy] = useState(initialCreatedBy);
+
+  const handleSave = () => {
+    onSave({
+      category,
+      text,
+      createdBy,
+      createdAt: new Date().toISOString(),
+    });
+  };
+
+  return (
+    <StyledPanel>
+      <div className="e-title">配置理由を記録</div>
+
+      {(memberName || roleName) && (
+        <div className="e-info">
+          {memberName && <span className="e-chip">{memberName}</span>}
+          {roleName && (
+            <>
+              <span className="e-arrow">→</span>
+              <span className="e-chip e-role">{roleName}</span>
+            </>
+          )}
+        </div>
+      )}
+
+      <div className="e-field">
+        <label className="e-field-label">カテゴリ</label>
+        <div className="e-category-list">
+          {(Object.entries(CATEGORY_LABELS) as [ReasonCategory, string][]).map(([key, label]) => (
+            <label
+              key={key}
+              className={`e-category-btn ${category === key ? 'is-selected' : ''}`}
+            >
+              <input
+                type="radio"
+                name="reason-panel-category"
+                value={key}
+                checked={category === key}
+                onChange={() => setCategory(key)}
+              />
+              {label}
+            </label>
+          ))}
+        </div>
+      </div>
+
+      <div className="e-field">
+        <label className="e-field-label">詳細メモ（任意）</label>
+        <textarea
+          className="e-textarea"
+          rows={3}
+          placeholder="配置の背景・理由を記入..."
+          value={text}
+          onChange={(e: React.ChangeEvent<HTMLTextAreaElement>) => setText(e.target.value)}
+        />
+      </div>
+
+      <div className="e-footer">
+        <div className="e-recorder">
+          <label className="e-field-label">記録者</label>
+          <input
+            className="e-recorder-input"
+            type="text"
+            placeholder="名前を入力"
+            value={createdBy}
+            onChange={(e: React.ChangeEvent<HTMLInputElement>) => setCreatedBy(e.target.value)}
+          />
+        </div>
+        <div className="e-actions">
+          {onCancel && (
+            <button className="e-btn e-btn-cancel" onClick={onCancel}>
+              キャンセル
+            </button>
+          )}
+          <button className="e-btn e-btn-save" onClick={handleSave}>
+            保存
+          </button>
+        </div>
+      </div>
+    </StyledPanel>
+  );
+};
+
+const StyledPanel = styled.div`
+  background: white;
+  border-radius: 8px;
+  padding: 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+
+  .e-title {
+    font-size: 0.95em;
+    font-weight: 600;
+    color: #333;
+  }
+
+  .e-info {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    flex-wrap: wrap;
+
+    .e-chip {
+      background: #e3f2fd;
+      color: #1565c0;
+      padding: 2px 8px;
+      border-radius: 12px;
+      font-size: 0.85em;
+      font-weight: 500;
+    }
+
+    .e-chip.e-role {
+      background: #f3e5f5;
+      color: #6a1b9a;
+    }
+
+    .e-arrow {
+      color: #888;
+      font-size: 0.9em;
+    }
+  }
+
+  .e-field {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+  }
+
+  .e-field-label {
+    font-size: 0.8em;
+    color: #666;
+    font-weight: 500;
+  }
+
+  .e-category-list {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 6px;
+  }
+
+  .e-category-btn {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+    padding: 4px 10px;
+    border: 1px solid #ddd;
+    border-radius: 16px;
+    font-size: 0.82em;
+    cursor: pointer;
+    background: white;
+
+    input[type="radio"] {
+      display: none;
+    }
+
+    &.is-selected {
+      background: #1976d2;
+      border-color: #1976d2;
+      color: white;
+    }
+
+    &:hover:not(.is-selected) {
+      background: #f0f4ff;
+      border-color: #90caf9;
+    }
+  }
+
+  .e-textarea {
+    padding: 8px;
+    border: 1px solid #ddd;
+    border-radius: 4px;
+    font-size: 0.9em;
+    resize: vertical;
+    font-family: inherit;
+    min-height: 72px;
+
+    &:focus {
+      outline: none;
+      border-color: #1976d2;
+    }
+  }
+
+  .e-footer {
+    display: flex;
+    align-items: flex-end;
+    justify-content: space-between;
+    gap: 8px;
+    margin-top: 4px;
+  }
+
+  .e-recorder {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    flex: 1;
+  }
+
+  .e-recorder-input {
+    padding: 6px 8px;
+    border: 1px solid #ddd;
+    border-radius: 4px;
+    font-size: 0.9em;
+    font-family: inherit;
+    max-width: 140px;
+
+    &:focus {
+      outline: none;
+      border-color: #1976d2;
+    }
+  }
+
+  .e-actions {
+    display: flex;
+    gap: 8px;
+  }
+
+  .e-btn {
+    padding: 7px 16px;
+    border: none;
+    border-radius: 4px;
+    font-size: 0.9em;
+    cursor: pointer;
+    font-weight: 500;
+    white-space: nowrap;
+  }
+
+  .e-btn-cancel {
+    background: #f5f5f5;
+    color: #555;
+
+    &:hover {
+      background: #e0e0e0;
+    }
+  }
+
+  .e-btn-save {
+    background: #1976d2;
+    color: white;
+
+    &:hover {
+      background: #1565c0;
+    }
+  }
+` as React.FC<React.HTMLAttributes<HTMLDivElement>>;

--- a/shift-puzzle-bubly/shift-puzzle-libs/src/ui/ReasonPanel/ReasonList.tsx
+++ b/shift-puzzle-bubly/shift-puzzle-libs/src/ui/ReasonPanel/ReasonList.tsx
@@ -1,0 +1,336 @@
+'use client';
+import React, { useMemo, useState } from 'react';
+import styled from 'styled-components';
+import type {
+  AssignmentState,
+  MemberState,
+  RoleState,
+  TimeSlotState,
+  ReasonCategory,
+} from '@bublys-org/shift-puzzle-model';
+import { AssignmentReason } from '@bublys-org/shift-puzzle-model';
+
+export interface ReasonListProps {
+  assignments: AssignmentState[];
+  memberMap: Map<string, MemberState>;
+  roleMap: Map<string, RoleState>;
+  timeSlotMap: Map<string, TimeSlotState>;
+}
+
+const CATEGORY_LABELS: Record<ReasonCategory, string> = {
+  skill_match:   'スキル適合',
+  training:      '育成目的',
+  compatibility: '相性考慮',
+  availability:  '空き時間調整',
+  other:         'その他',
+};
+
+const CATEGORY_COLORS: Record<ReasonCategory, { bg: string; text: string }> = {
+  skill_match:   { bg: '#e8f5e9', text: '#2e7d32' },
+  training:      { bg: '#fff3e0', text: '#e65100' },
+  compatibility: { bg: '#fce4ec', text: '#880e4f' },
+  availability:  { bg: '#e3f2fd', text: '#1565c0' },
+  other:         { bg: '#f5f5f5', text: '#616161' },
+};
+
+function formatMinutes(minutes: number): string {
+  const h = Math.floor(minutes / 60);
+  const m = minutes % 60;
+  return `${String(h).padStart(2, '0')}:${String(m).padStart(2, '0')}`;
+}
+
+/** F-3-3: 配置理由一覧ビュー（引き継ぎドキュメント代替） */
+export const ReasonList: React.FC<ReasonListProps> = ({
+  assignments,
+  memberMap,
+  roleMap,
+  timeSlotMap,
+}) => {
+  const [filterCategory, setFilterCategory] = useState<ReasonCategory | 'all'>('all');
+  const [searchText, setSearchText] = useState('');
+
+  const filtered = useMemo(() => {
+    return assignments.filter((a) => {
+      if (filterCategory !== 'all' && a.reason.category !== filterCategory) return false;
+      if (searchText) {
+        const q = searchText.toLowerCase();
+        const memberName = memberMap.get(a.memberId)?.name ?? '';
+        const roleName = roleMap.get(a.roleId)?.name ?? '';
+        if (
+          !memberName.toLowerCase().includes(q) &&
+          !roleName.toLowerCase().includes(q) &&
+          !a.reason.text.toLowerCase().includes(q) &&
+          !(a.reason.createdBy ?? '').toLowerCase().includes(q)
+        ) return false;
+      }
+      return true;
+    });
+  }, [assignments, filterCategory, searchText, memberMap, roleMap]);
+
+  const categoryCounts = useMemo(() => {
+    const counts: Partial<Record<ReasonCategory, number>> = {};
+    for (const a of assignments) {
+      counts[a.reason.category] = (counts[a.reason.category] ?? 0) + 1;
+    }
+    return counts;
+  }, [assignments]);
+
+  return (
+    <StyledContainer>
+      <div className="e-toolbar">
+        <input
+          className="e-search"
+          type="text"
+          placeholder="スタッフ名・役割・メモで検索..."
+          value={searchText}
+          onChange={(e: React.ChangeEvent<HTMLInputElement>) => setSearchText(e.target.value)}
+        />
+        <div className="e-category-filters">
+          <button
+            className={`e-filter-btn ${filterCategory === 'all' ? 'is-active' : ''}`}
+            onClick={() => setFilterCategory('all')}
+          >
+            すべて ({assignments.length})
+          </button>
+          {(Object.entries(CATEGORY_LABELS) as [ReasonCategory, string][]).map(([key, label]) => {
+            const count = categoryCounts[key] ?? 0;
+            return (
+              <button
+                key={key}
+                className={`e-filter-btn ${filterCategory === key ? 'is-active' : ''}`}
+                onClick={() => setFilterCategory(key)}
+                style={
+                  filterCategory === key
+                    ? {}
+                    : { backgroundColor: CATEGORY_COLORS[key].bg, color: CATEGORY_COLORS[key].text, borderColor: 'transparent' }
+                }
+              >
+                {label} ({count})
+              </button>
+            );
+          })}
+        </div>
+      </div>
+
+      {filtered.length === 0 ? (
+        <div className="e-empty">
+          {searchText || filterCategory !== 'all'
+            ? '条件に合う配置理由が見つかりません'
+            : '配置がまだありません'}
+        </div>
+      ) : (
+        <div className="e-list">
+          {filtered.map((assignment) => {
+            const member = memberMap.get(assignment.memberId);
+            const role = roleMap.get(assignment.roleId);
+            const slot = timeSlotMap.get(assignment.timeSlotId);
+            const reason = new AssignmentReason(assignment.reason);
+            const colors = CATEGORY_COLORS[reason.category];
+
+            const timeStr = slot
+              ? `${formatMinutes(slot.startMinute)}〜${formatMinutes(slot.startMinute + slot.durationMinutes)}`
+              : '時間帯不明';
+
+            return (
+              <div key={assignment.id} className="e-card">
+                <div className="e-card-header">
+                  <div className="e-names">
+                    <span className="e-member-name">{member?.name ?? '（不明）'}</span>
+                    <span className="e-arrow">→</span>
+                    <span
+                      className="e-role-name"
+                      style={{ color: role?.color ?? '#555' }}
+                    >
+                      {role?.name ?? '（不明）'}
+                    </span>
+                    <span className="e-time-badge">{timeStr}</span>
+                  </div>
+                  <span
+                    className="e-category-badge"
+                    style={{ background: colors.bg, color: colors.text }}
+                  >
+                    {reason.categoryLabel}
+                  </span>
+                </div>
+
+                {reason.text ? (
+                  <div className="e-reason-text">{reason.text}</div>
+                ) : (
+                  <div className="e-reason-text e-no-text">（詳細メモなし）</div>
+                )}
+
+                <div className="e-meta">
+                  {reason.createdBy && <span>記録: {reason.createdBy}</span>}
+                  {assignment.locked && <span className="e-locked">🔒 確定済み</span>}
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      )}
+    </StyledContainer>
+  );
+};
+
+const StyledContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  overflow: hidden;
+  background: #fafafa;
+
+  .e-toolbar {
+    padding: 12px;
+    background: white;
+    border-bottom: 1px solid #eee;
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    flex-shrink: 0;
+  }
+
+  .e-search {
+    padding: 7px 10px;
+    border: 1px solid #ddd;
+    border-radius: 6px;
+    font-size: 0.9em;
+    width: 100%;
+    box-sizing: border-box;
+    font-family: inherit;
+
+    &:focus {
+      outline: none;
+      border-color: #1976d2;
+    }
+  }
+
+  .e-category-filters {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 4px;
+  }
+
+  .e-filter-btn {
+    padding: 3px 10px;
+    border: 1px solid #ddd;
+    border-radius: 12px;
+    background: white;
+    font-size: 0.78em;
+    cursor: pointer;
+    color: #666;
+    transition: background 0.1s;
+
+    &.is-active {
+      background: #1976d2 !important;
+      border-color: #1976d2 !important;
+      color: white !important;
+    }
+
+    &:hover:not(.is-active) {
+      opacity: 0.8;
+    }
+  }
+
+  .e-list {
+    flex: 1;
+    overflow-y: auto;
+    padding: 10px;
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+  }
+
+  .e-empty {
+    flex: 1;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    color: #999;
+    font-size: 0.9em;
+  }
+
+  .e-card {
+    background: white;
+    border: 1px solid #e0e0e0;
+    border-radius: 8px;
+    padding: 12px;
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+
+    &:hover {
+      border-color: #bdbdbd;
+      box-shadow: 0 1px 4px rgba(0, 0, 0, 0.08);
+    }
+  }
+
+  .e-card-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 8px;
+    flex-wrap: wrap;
+  }
+
+  .e-names {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    font-size: 0.9em;
+    flex-wrap: wrap;
+  }
+
+  .e-member-name {
+    font-weight: 600;
+    color: #222;
+  }
+
+  .e-arrow {
+    color: #bbb;
+  }
+
+  .e-role-name {
+    font-weight: 500;
+  }
+
+  .e-time-badge {
+    background: #f5f5f5;
+    padding: 1px 6px;
+    border-radius: 4px;
+    font-size: 0.82em;
+    color: #666;
+  }
+
+  .e-category-badge {
+    padding: 2px 8px;
+    border-radius: 4px;
+    font-size: 0.78em;
+    font-weight: 600;
+    white-space: nowrap;
+    flex-shrink: 0;
+  }
+
+  .e-reason-text {
+    font-size: 0.85em;
+    color: #444;
+    line-height: 1.5;
+    white-space: pre-wrap;
+    word-break: break-word;
+  }
+
+  .e-no-text {
+    color: #bbb;
+    font-style: italic;
+  }
+
+  .e-meta {
+    display: flex;
+    gap: 10px;
+    font-size: 0.76em;
+    color: #aaa;
+  }
+
+  .e-locked {
+    color: #666;
+  }
+` as React.FC<React.HTMLAttributes<HTMLDivElement>>;

--- a/shift-puzzle-bubly/shift-puzzle-libs/src/ui/ReasonPanel/ReasonPopover.tsx
+++ b/shift-puzzle-bubly/shift-puzzle-libs/src/ui/ReasonPanel/ReasonPopover.tsx
@@ -1,0 +1,162 @@
+'use client';
+import React from 'react';
+import styled from 'styled-components';
+import type { AssignmentState } from '@bublys-org/shift-puzzle-model';
+import { AssignmentReason } from '@bublys-org/shift-puzzle-model';
+
+export interface ReasonPopoverProps {
+  assignment: AssignmentState;
+  memberName: string;
+  roleName: string;
+  /** ビューポート基準のX座標（px） */
+  top: number;
+  /** ビューポート基準のY座標（px） */
+  left: number;
+}
+
+const CATEGORY_COLORS: Record<string, { bg: string; text: string }> = {
+  skill_match:   { bg: '#e8f5e9', text: '#2e7d32' },
+  training:      { bg: '#fff3e0', text: '#e65100' },
+  compatibility: { bg: '#fce4ec', text: '#880e4f' },
+  availability:  { bg: '#e3f2fd', text: '#1565c0' },
+  other:         { bg: '#f5f5f5', text: '#616161' },
+};
+
+/** F-3-2: 配置ブロックのホバーポップオーバー（position:fixed で親のoverflow:hiddenを突き抜ける） */
+export const ReasonPopover: React.FC<ReasonPopoverProps> = ({
+  assignment,
+  memberName,
+  roleName,
+  top,
+  left,
+}) => {
+  const reason = new AssignmentReason(assignment.reason);
+  const colors = CATEGORY_COLORS[reason.category] ?? CATEGORY_COLORS.other;
+
+  const formattedDate = (() => {
+    try {
+      return new Date(reason.createdAt).toLocaleString('ja-JP', {
+        month: '2-digit',
+        day: '2-digit',
+        hour: '2-digit',
+        minute: '2-digit',
+      });
+    } catch {
+      return '';
+    }
+  })();
+
+  return (
+    <StyledPopover style={{ top, left }}>
+      <div className="e-header">
+        <span className="e-chip">{memberName || '?'}</span>
+        <span className="e-arrow">→</span>
+        <span className="e-chip e-role">{roleName || '?'}</span>
+      </div>
+
+      <span
+        className="e-category-badge"
+        style={{ background: colors.bg, color: colors.text }}
+      >
+        {reason.categoryLabel}
+      </span>
+
+      {reason.text ? (
+        <div className="e-text">{reason.text}</div>
+      ) : (
+        <div className="e-text e-no-text">（詳細メモなし）</div>
+      )}
+
+      {(reason.createdBy || formattedDate) && (
+        <div className="e-meta">
+          {reason.createdBy && <span>記録: {reason.createdBy}</span>}
+          {formattedDate && <span>{formattedDate}</span>}
+        </div>
+      )}
+
+      {assignment.locked && (
+        <div className="e-locked-badge">🔒 確定済み</div>
+      )}
+    </StyledPopover>
+  );
+};
+
+// position:fixed はビューポート基準で表示されるため、
+// 祖先要素の overflow:hidden の影響を受けない
+const StyledPopover = styled.div`
+  position: fixed;
+  z-index: 9999;
+  background: white;
+  border: 1px solid #e0e0e0;
+  border-radius: 8px;
+  padding: 10px 12px;
+  min-width: 180px;
+  max-width: 280px;
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.18);
+  pointer-events: none;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  font-size: 0.85em;
+
+  .e-header {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    flex-wrap: wrap;
+
+    .e-chip {
+      background: #e3f2fd;
+      color: #1565c0;
+      padding: 1px 8px;
+      border-radius: 12px;
+      font-size: 0.88em;
+      font-weight: 500;
+    }
+
+    .e-chip.e-role {
+      background: #f3e5f5;
+      color: #6a1b9a;
+    }
+
+    .e-arrow {
+      color: #bbb;
+      font-size: 0.85em;
+    }
+  }
+
+  .e-category-badge {
+    display: inline-block;
+    padding: 2px 8px;
+    border-radius: 4px;
+    font-size: 0.8em;
+    font-weight: 600;
+    align-self: flex-start;
+  }
+
+  .e-text {
+    font-size: 0.85em;
+    color: #333;
+    line-height: 1.5;
+    word-break: break-word;
+    white-space: pre-wrap;
+  }
+
+  .e-no-text {
+    color: #bbb;
+    font-style: italic;
+  }
+
+  .e-meta {
+    display: flex;
+    gap: 8px;
+    font-size: 0.76em;
+    color: #aaa;
+    flex-wrap: wrap;
+  }
+
+  .e-locked-badge {
+    font-size: 0.78em;
+    color: #777;
+  }
+` as React.FC<React.HTMLAttributes<HTMLDivElement>>;

--- a/shift-puzzle-bubly/shift-puzzle-libs/src/ui/index.ts
+++ b/shift-puzzle-bubly/shift-puzzle-libs/src/ui/index.ts
@@ -5,5 +5,13 @@ export { MemberRow } from './GanttChart/MemberRow.js';
 export { ConflictHighlight } from './GanttChart/ConflictHighlight.js';
 export { ReasonInputDialog } from './GanttChart/ReasonInputDialog.js';
 
+// F-3-1〜F-3-3: 配置理由パネル
+export { ReasonInputPanel } from './ReasonPanel/ReasonInputPanel.js';
+export { ReasonPopover } from './ReasonPanel/ReasonPopover.js';
+export { ReasonList } from './ReasonPanel/ReasonList.js';
+
 export type { GanttChartViewProps } from './GanttChart/GanttChartView.js';
 export type { ReasonInputDialogProps } from './GanttChart/ReasonInputDialog.js';
+export type { ReasonInputPanelProps } from './ReasonPanel/ReasonInputPanel.js';
+export type { ReasonPopoverProps } from './ReasonPanel/ReasonPopover.js';
+export type { ReasonListProps } from './ReasonPanel/ReasonList.js';

--- a/shift-puzzle-bubly/shift-puzzle-libs/src/ui/index.ts
+++ b/shift-puzzle-bubly/shift-puzzle-libs/src/ui/index.ts
@@ -1,0 +1,9 @@
+export { GanttChartView } from './GanttChart/GanttChartView.js';
+export { AssignmentBlock } from './GanttChart/AssignmentBlock.js';
+export { TimeAxis } from './GanttChart/TimeAxis.js';
+export { MemberRow } from './GanttChart/MemberRow.js';
+export { ConflictHighlight } from './GanttChart/ConflictHighlight.js';
+export { ReasonInputDialog } from './GanttChart/ReasonInputDialog.js';
+
+export type { GanttChartViewProps } from './GanttChart/GanttChartView.js';
+export type { ReasonInputDialogProps } from './GanttChart/ReasonInputDialog.js';

--- a/shift-puzzle-bubly/shift-puzzle-libs/tsconfig.lib.json
+++ b/shift-puzzle-bubly/shift-puzzle-libs/tsconfig.lib.json
@@ -1,0 +1,24 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "baseUrl": ".",
+    "rootDir": "src",
+    "outDir": "dist",
+    "tsBuildInfoFile": "dist/tsconfig.lib.tsbuildinfo",
+    "emitDeclarationOnly": false,
+    "forceConsistentCasingInFileNames": true,
+    "types": ["node"],
+    "jsx": "react-jsx",
+    "lib": ["dom", "dom.iterable", "esnext"]
+  },
+  "include": ["src/**/*.ts", "src/**/*.tsx"],
+  "references": [
+    { "path": "../shift-puzzle-model/tsconfig.lib.json" }
+  ],
+  "exclude": [
+    "jest.config.ts",
+    "jest.config.cts",
+    "src/**/*.spec.ts",
+    "src/**/*.test.ts"
+  ]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -80,6 +80,12 @@
     },
     {
       "path": "./sekaisen-igo-bubly/sekaisen-igo-app"
+    },
+    {
+      "path": "./shift-puzzle-bubly/shift-puzzle-model"
+    },
+    {
+      "path": "./shift-puzzle-bubly/shift-puzzle-libs"
     }
   ]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -85,7 +85,7 @@
       "path": "./shift-puzzle-bubly/shift-puzzle-model"
     },
     {
-      "path": "./shift-puzzle-bubly/shift-puzzle-libs"
+      "path": "./shift-puzzle-bubly/shift-puzzle-app"
     }
   ]
 }


### PR DESCRIPTION
## Summary

- **F-3-1**: `ReasonInputPanel` を新設（記録者フィールド付き）。`ui/ReasonPanel/` ディレクトリに整理
- **F-3-2**: ガントチャート配置ブロックのホバーで `ReasonPopover` を表示（`position: fixed` で親の `overflow: hidden` を突き抜ける）
- **F-3-3**: `ReasonList`（カテゴリフィルター＋テキスト検索）+ `ReasonListFeature`（Redux連携）を実装。バブルルート `shift-puzzle/events/:eventId/shift-plans/:planId/reasons` を追加

Closes #35
Related: #32

## Test plan

- [ ] ガントチャートでスタッフをD&Dしたとき、理由入力ダイアログが表示される
- [ ] 配置ブロックにカーソルを当てると ReasonPopover が表示され、カテゴリ・メモ・記録者が確認できる
- [ ] サイドバー「配置理由一覧」をクリックするとバブルが開き、全配置の理由が一覧表示される
- [ ] カテゴリフィルターとテキスト検索が機能する

🤖 Generated with [Claude Code](https://claude.com/claude-code)