### PR TITLE
[Phase 1] Bubbles統合基本（F-4-1〜F-4-3）

### DIFF
--- a/shift-puzzle-bubly/shift-puzzle-app/src/bubly.ts
+++ b/shift-puzzle-bubly/shift-puzzle-app/src/bubly.ts
@@ -5,8 +5,11 @@
  * 動的にロードされるバブリとして動作する
  */
 
-import { registerBubly, Bubly } from "@bublys-org/bubbles-ui";
+import { registerBubly, Bubly, registerObjectType } from "@bublys-org/bubbles-ui";
 import { shiftPuzzleBubbleRoutes } from "./registration/index.js";
+
+// F-4-3: ポケット連携のためメンバーオブジェクト型を登録（DragType: 'type/member'）
+registerObjectType("Member");
 
 const ShiftPuzzleBubly: Bubly = {
   name: "shift-puzzle",

--- a/shift-puzzle-bubly/shift-puzzle-app/src/registration/bubbleRoutes.tsx
+++ b/shift-puzzle-bubly/shift-puzzle-app/src/registration/bubbleRoutes.tsx
@@ -9,6 +9,7 @@ import {
   MemberCollection,
   MemberDetailFeature,
   RoleFulfillmentFeature,
+  ShiftPlanSummary,
   selectEvents,
   selectCurrentEventId,
   selectCurrentShiftPlanId,
@@ -167,7 +168,8 @@ function createDemoData(): {
   return { event, members, roles, timeSlots, shiftPlan };
 }
 
-const ShiftPuzzleEditorBubble: BubbleRoute["Component"] = () => {
+const ShiftPuzzleEditorBubble: BubbleRoute["Component"] = ({ bubble }) => {
+  const { openBubble } = useContext(BubblesContext);
   const dispatch = useAppDispatch();
   const events = useAppSelector(selectEvents);
   const currentEventId = useAppSelector(selectCurrentEventId);
@@ -190,11 +192,30 @@ const ShiftPuzzleEditorBubble: BubbleRoute["Component"] = () => {
     return <div style={{ padding: 24, color: "#666" }}>データを初期化中...</div>;
   }
 
+  const handleOpenSummary = () => {
+    openBubble(
+      `shift-puzzle/events/${currentEventId}/shift-plans/${currentShiftPlanId}/summary`,
+      bubble.id
+    );
+  };
+
   return (
-    <ShiftPlanGanttEditor
-      shiftPlanId={currentShiftPlanId}
-      eventId={currentEventId}
-    />
+    <div style={{ display: "flex", flexDirection: "column", height: "100%" }}>
+      <div style={{ padding: "6px 12px", background: "#f5f5f5", borderBottom: "1px solid #e0e0e0", display: "flex", gap: 8, flexShrink: 0 }}>
+        <button
+          onClick={handleOpenSummary}
+          style={{ padding: "4px 12px", background: "#1976d2", color: "white", border: "none", borderRadius: 4, cursor: "pointer", fontSize: "0.82em", fontWeight: 600 }}
+        >
+          評価サマリー
+        </button>
+      </div>
+      <div style={{ flex: 1, overflow: "hidden" }}>
+        <ShiftPlanGanttEditor
+          shiftPlanId={currentShiftPlanId}
+          eventId={currentEventId}
+        />
+      </div>
+    </div>
   );
 };
 
@@ -322,6 +343,25 @@ const RoleFulfillmentBubble: BubbleRoute["Component"] = ({ bubble }) => {
   );
 };
 
+/** F-7-1〜F-7-3: 評価サマリーバブル */
+const ShiftPlanSummaryBubble: BubbleRoute["Component"] = ({ bubble }) => {
+  const currentEventId = useAppSelector(selectCurrentEventId);
+  const currentShiftPlanId = useAppSelector(selectCurrentShiftPlanId);
+
+  const eventId = bubble.params.eventId ?? currentEventId;
+  const planId = bubble.params.planId ?? currentShiftPlanId;
+
+  if (!eventId || !planId) {
+    return (
+      <div style={{ padding: 24, color: "#888", textAlign: "center" }}>
+        イベントまたはシフト案が選択されていません
+      </div>
+    );
+  }
+
+  return <ShiftPlanSummary eventId={eventId} shiftPlanId={planId} />;
+};
+
 export const shiftPuzzleBubbleRoutes: BubbleRoute[] = [
   {
     pattern: "shift-puzzle/editor",
@@ -362,6 +402,12 @@ export const shiftPuzzleBubbleRoutes: BubbleRoute[] = [
     pattern: "shift-puzzle/events/:eventId/roles/:roleId",
     type: "shift-puzzle-role-detail",
     Component: RoleDetailBubble,
+  },
+  {
+    // F-7-1〜F-7-3: 評価サマリー
+    pattern: "shift-puzzle/events/:eventId/shift-plans/:planId/summary",
+    type: "shift-puzzle-summary",
+    Component: ShiftPlanSummaryBubble,
   },
   {
     // F-1-1〜F-1-4: メンバー一覧

--- a/shift-puzzle-bubly/shift-puzzle-libs/src/feature/MemberCollection.tsx
+++ b/shift-puzzle-bubly/shift-puzzle-libs/src/feature/MemberCollection.tsx
@@ -16,6 +16,8 @@ import { MemberForm } from '../ui/MemberCard/MemberForm.js';
 
 interface MemberCollectionProps {
   eventId: string;
+  /** F-4-1: メンバーカードタップで詳細バブルを開くコールバック */
+  onMemberTap?: (memberId: string) => void;
 }
 
 type EditingState =
@@ -24,7 +26,7 @@ type EditingState =
   | { mode: 'edit'; memberId: string };
 
 /** F-1-1〜F-1-4: メンバー一覧＋CRUD（Redux連携） */
-export const MemberCollection: React.FC<MemberCollectionProps> = ({ eventId }) => {
+export const MemberCollection: React.FC<MemberCollectionProps> = ({ eventId, onMemberTap }) => {
   const dispatch = useAppDispatch();
   const members = useAppSelector(selectMembersForEvent(eventId));
   const event = useAppSelector(selectEventById(eventId));
@@ -163,6 +165,7 @@ export const MemberCollection: React.FC<MemberCollectionProps> = ({ eventId }) =
                 timeSlots={timeSlots}
                 onEdit={(id) => setEditing({ mode: 'edit', memberId: id })}
                 onDelete={handleDelete}
+                onTap={onMemberTap}
               />
             ))
           )}

--- a/shift-puzzle-bubly/shift-puzzle-libs/src/feature/MemberCollection.tsx
+++ b/shift-puzzle-bubly/shift-puzzle-libs/src/feature/MemberCollection.tsx
@@ -2,22 +2,17 @@
 import React, { useMemo, useState } from 'react';
 import styled from 'styled-components';
 import { useAppDispatch, useAppSelector } from '@bublys-org/state-management';
-import { Assignment, Member, type AssignmentReasonState, type MemberState } from '@bublys-org/shift-puzzle-model';
+import { Member, type MemberState } from '@bublys-org/shift-puzzle-model';
 import {
   selectMembersForEvent,
   selectEventById,
   selectTimeSlotsForEvent,
-  selectRolesForEvent,
-  selectCurrentShiftPlanId,
-  selectAssignmentsForPlan,
   addMember,
   updateMember,
   deleteMember,
-  addAssignment,
 } from '../slice/index.js';
 import { MemberCard } from '../ui/index.js';
 import { MemberForm } from '../ui/MemberCard/MemberForm.js';
-import { ReasonInputDialog } from '../ui/GanttChart/ReasonInputDialog.js';
 
 interface MemberCollectionProps {
   eventId: string;
@@ -30,22 +25,14 @@ type EditingState =
   | { mode: 'add' }
   | { mode: 'edit'; memberId: string };
 
-type QuickAssignState =
-  | { open: false }
-  | { open: true; memberId: string; selectedRoleId: string; selectedTimeSlotId: string };
-
 /** F-1-1〜F-1-4: メンバー一覧＋CRUD（Redux連携） */
 export const MemberCollection: React.FC<MemberCollectionProps> = ({ eventId, onMemberTap }) => {
   const dispatch = useAppDispatch();
   const members = useAppSelector(selectMembersForEvent(eventId));
   const event = useAppSelector(selectEventById(eventId));
   const timeSlots = useAppSelector(selectTimeSlotsForEvent(eventId));
-  const roles = useAppSelector(selectRolesForEvent(eventId));
-  const currentShiftPlanId = useAppSelector(selectCurrentShiftPlanId);
-  const assignments = useAppSelector(selectAssignmentsForPlan(currentShiftPlanId ?? ''));
   const [editing, setEditing] = useState<EditingState>({ mode: 'none' });
   const [tagFilter, setTagFilter] = useState<string | null>(null);
-  const [quickAssign, setQuickAssign] = useState<QuickAssignState>({ open: false });
   const [searchText, setSearchText] = useState('');
 
   const skillDefinitions = event?.state.skillDefinitions ?? [];
@@ -95,48 +82,6 @@ export const MemberCollection: React.FC<MemberCollectionProps> = ({ eventId, onM
       dispatch(deleteMember(memberId));
     }
   };
-
-  // F-4-3: ダブルクリック → クイック配置ダイアログ
-  const handleMemberDoubleClick = (memberId: string) => {
-    setQuickAssign({ open: true, memberId, selectedRoleId: '', selectedTimeSlotId: '' });
-  };
-
-  const handleQuickAssignConfirm = (reason: AssignmentReasonState) => {
-    if (!quickAssign.open || !currentShiftPlanId) return;
-    const { memberId, selectedRoleId, selectedTimeSlotId } = quickAssign;
-    if (!selectedRoleId || !selectedTimeSlotId) return;
-
-    // 重複チェック
-    const exists = assignments.some(
-      (a) => a.state.memberId === memberId && a.state.timeSlotId === selectedTimeSlotId && a.state.roleId === selectedRoleId
-    );
-    if (!exists) {
-      const assignment = Assignment.create({
-        memberId,
-        roleId: selectedRoleId,
-        timeSlotId: selectedTimeSlotId,
-        shiftPlanId: currentShiftPlanId,
-        reason,
-      });
-      dispatch(addAssignment({ shiftPlanId: currentShiftPlanId, assignment: assignment.toJSON() }));
-    }
-    setQuickAssign({ open: false });
-  };
-
-  const formatSlotLabel = (slotId: string) => {
-    const slot = timeSlots.find((s) => s.id === slotId);
-    if (!slot) return slotId;
-    const h1 = Math.floor(slot.startMinute / 60);
-    const m1 = slot.startMinute % 60;
-    const end = slot.startMinute + slot.durationMinutes;
-    const h2 = Math.floor(end / 60);
-    const m2 = end % 60;
-    return `${h1}:${String(m1).padStart(2, '0')}〜${h2}:${String(m2).padStart(2, '0')}`;
-  };
-
-  const quickAssignMember = quickAssign.open
-    ? members.find((m) => m.state.id === quickAssign.memberId)
-    : undefined;
 
   return (
     <StyledWrapper>
@@ -221,7 +166,6 @@ export const MemberCollection: React.FC<MemberCollectionProps> = ({ eventId, onM
                 onEdit={(id) => setEditing({ mode: 'edit', memberId: id })}
                 onDelete={handleDelete}
                 onTap={onMemberTap}
-                onDoubleClick={currentShiftPlanId ? handleMemberDoubleClick : undefined}
                 dragUrl={`shift-puzzle/events/${eventId}/members/${m.state.id}`}
               />
             ))
@@ -229,23 +173,6 @@ export const MemberCollection: React.FC<MemberCollectionProps> = ({ eventId, onM
         </div>
       )}
 
-      {/* F-4-3: ダブルクリック クイック配置ダイアログ */}
-      <ReasonInputDialog
-        open={quickAssign.open}
-        memberName={quickAssignMember?.state.name}
-        roles={roles.map((r) => ({ id: r.state.id, name: r.state.name, color: r.state.color }))}
-        selectedRoleId={quickAssign.open ? quickAssign.selectedRoleId : ''}
-        onRoleChange={(roleId) =>
-          setQuickAssign((s) => s.open ? { ...s, selectedRoleId: roleId } : s)
-        }
-        timeSlots={timeSlots.map((s) => ({ id: s.id, label: formatSlotLabel(s.id) }))}
-        selectedTimeSlotId={quickAssign.open ? quickAssign.selectedTimeSlotId : ''}
-        onTimeSlotChange={(slotId) =>
-          setQuickAssign((s) => s.open ? { ...s, selectedTimeSlotId: slotId } : s)
-        }
-        onConfirm={handleQuickAssignConfirm}
-        onCancel={() => setQuickAssign({ open: false })}
-      />
     </StyledWrapper>
   );
 };

--- a/shift-puzzle-bubly/shift-puzzle-libs/src/feature/MemberDetailFeature.tsx
+++ b/shift-puzzle-bubly/shift-puzzle-libs/src/feature/MemberDetailFeature.tsx
@@ -1,0 +1,84 @@
+'use client';
+import React, { useCallback } from 'react';
+import {
+  useAppDispatch,
+  useAppSelector,
+  addPocketItem,
+  selectPocketItems,
+} from '@bublys-org/state-management';
+import { getDragType } from '@bublys-org/bubbles-ui';
+import {
+  selectMembersForEvent,
+  selectEventById,
+  selectTimeSlotsForEvent,
+  selectAssignmentsForPlan,
+  selectRolesForEvent,
+} from '../slice/index.js';
+import { MemberDetailView } from '../ui/MemberDetail/MemberDetailView.js';
+
+interface MemberDetailFeatureProps {
+  eventId: string;
+  memberId: string;
+  shiftPlanId?: string;
+}
+
+/** F-4-1: メンバー詳細（スキル・参加可能時間・現在の配置状況） + F-4-3: ポケット追加 */
+export const MemberDetailFeature: React.FC<MemberDetailFeatureProps> = ({
+  eventId,
+  memberId,
+  shiftPlanId,
+}) => {
+  const dispatch = useAppDispatch();
+  const members = useAppSelector(selectMembersForEvent(eventId));
+  const event = useAppSelector(selectEventById(eventId));
+  const timeSlots = useAppSelector(selectTimeSlotsForEvent(eventId));
+  const roles = useAppSelector(selectRolesForEvent(eventId));
+  const assignments = useAppSelector(selectAssignmentsForPlan(shiftPlanId ?? ''));
+  const pocketItems = useAppSelector(selectPocketItems);
+
+  const member = members.find((m) => m.state.id === memberId);
+  const skillDefinitions = event?.state.skillDefinitions ?? [];
+
+  const assignmentStates = assignments.map((a) => a.state);
+  const roleStates = roles.map((r) => r.state);
+
+  // ポケット内に既にこのメンバーが存在するか
+  const pocketUrl = shiftPlanId
+    ? `shift-puzzle/events/${eventId}/shift-plans/${shiftPlanId}/member/${memberId}`
+    : `shift-puzzle/events/${eventId}/members/${memberId}`;
+  const isPocketed = pocketItems.some((item) => item.url === pocketUrl);
+
+  const handleAddToPocket = useCallback(() => {
+    if (isPocketed || !member) return;
+    dispatch(
+      addPocketItem({
+        id: crypto.randomUUID(),
+        url: pocketUrl,
+        type: getDragType('Member'),
+        objectId: memberId,
+        label: member.state.name,
+        addedAt: Date.now(),
+      })
+    );
+  }, [dispatch, isPocketed, member, memberId, pocketUrl]);
+
+  if (!member) {
+    return (
+      <div style={{ padding: 24, color: '#888', textAlign: 'center' }}>
+        メンバーが見つかりません（ID: {memberId}）
+      </div>
+    );
+  }
+
+  return (
+    <MemberDetailView
+      member={member.state}
+      skillDefinitions={skillDefinitions}
+      timeSlots={timeSlots}
+      assignments={assignmentStates}
+      roles={roleStates}
+      isPocketed={isPocketed}
+      onAddToPocket={handleAddToPocket}
+    />
+  );
+};

--- a/shift-puzzle-bubly/shift-puzzle-libs/src/feature/RoleFulfillmentFeature.tsx
+++ b/shift-puzzle-bubly/shift-puzzle-libs/src/feature/RoleFulfillmentFeature.tsx
@@ -1,0 +1,54 @@
+'use client';
+import React from 'react';
+import { useAppSelector } from '@bublys-org/state-management';
+import {
+  selectRolesForEvent,
+  selectEventById,
+  selectTimeSlotsForEvent,
+  selectMembersForEvent,
+  selectAssignmentsForPlan,
+} from '../slice/index.js';
+import { RoleFulfillmentView } from '../ui/RoleFulfillment/RoleFulfillmentView.js';
+
+interface RoleFulfillmentFeatureProps {
+  eventId: string;
+  roleId: string;
+  shiftPlanId?: string;
+}
+
+/** F-4-2: 役割充足状況（配置人数/必要人数・スキル充足率） */
+export const RoleFulfillmentFeature: React.FC<RoleFulfillmentFeatureProps> = ({
+  eventId,
+  roleId,
+  shiftPlanId,
+}) => {
+  const roles = useAppSelector(selectRolesForEvent(eventId));
+  const event = useAppSelector(selectEventById(eventId));
+  const timeSlots = useAppSelector(selectTimeSlotsForEvent(eventId));
+  const members = useAppSelector(selectMembersForEvent(eventId));
+  const assignments = useAppSelector(selectAssignmentsForPlan(shiftPlanId ?? ''));
+
+  const role = roles.find((r) => r.state.id === roleId);
+  const skillDefinitions = event?.state.skillDefinitions ?? [];
+
+  const assignmentStates = assignments.map((a) => a.state);
+  const memberStates = members.map((m) => m.state);
+
+  if (!role) {
+    return (
+      <div style={{ padding: 24, color: '#888', textAlign: 'center' }}>
+        役割が見つかりません（ID: {roleId}）
+      </div>
+    );
+  }
+
+  return (
+    <RoleFulfillmentView
+      role={role.state}
+      assignments={assignmentStates}
+      timeSlots={timeSlots}
+      members={memberStates}
+      skillDefinitions={skillDefinitions}
+    />
+  );
+};

--- a/shift-puzzle-bubly/shift-puzzle-libs/src/feature/ShiftPlanSummary.tsx
+++ b/shift-puzzle-bubly/shift-puzzle-libs/src/feature/ShiftPlanSummary.tsx
@@ -1,0 +1,35 @@
+'use client';
+import React from 'react';
+import { useAppSelector } from '@bublys-org/state-management';
+import {
+  selectMembersForEvent,
+  selectRolesForEvent,
+  selectTimeSlotsForEvent,
+  selectAssignmentsForPlan,
+} from '../slice/index.js';
+import { ShiftPlanSummaryView } from '../ui/Summary/ShiftPlanSummaryView.js';
+
+interface ShiftPlanSummaryProps {
+  eventId: string;
+  shiftPlanId: string;
+}
+
+/** F-7-1〜F-7-3: シフト案評価サマリー（Redux連携） */
+export const ShiftPlanSummary: React.FC<ShiftPlanSummaryProps> = ({
+  eventId,
+  shiftPlanId,
+}) => {
+  const members = useAppSelector(selectMembersForEvent(eventId));
+  const roles = useAppSelector(selectRolesForEvent(eventId));
+  const timeSlots = useAppSelector(selectTimeSlotsForEvent(eventId));
+  const assignments = useAppSelector(selectAssignmentsForPlan(shiftPlanId));
+
+  return (
+    <ShiftPlanSummaryView
+      members={members.map((m) => m.state)}
+      roles={roles.map((r) => r.state)}
+      timeSlots={timeSlots}
+      assignments={assignments.map((a) => a.state)}
+    />
+  );
+};

--- a/shift-puzzle-bubly/shift-puzzle-libs/src/feature/index.ts
+++ b/shift-puzzle-bubly/shift-puzzle-libs/src/feature/index.ts
@@ -1,3 +1,5 @@
 export { ShiftPlanGanttEditor } from './ShiftPlanGanttEditor.js';
 export { ReasonListFeature } from './ReasonListFeature.js';
 export { MemberCollection } from './MemberCollection.js';
+export { MemberDetailFeature } from './MemberDetailFeature.js';
+export { RoleFulfillmentFeature } from './RoleFulfillmentFeature.js';

--- a/shift-puzzle-bubly/shift-puzzle-libs/src/feature/index.ts
+++ b/shift-puzzle-bubly/shift-puzzle-libs/src/feature/index.ts
@@ -3,3 +3,4 @@ export { ReasonListFeature } from './ReasonListFeature.js';
 export { MemberCollection } from './MemberCollection.js';
 export { MemberDetailFeature } from './MemberDetailFeature.js';
 export { RoleFulfillmentFeature } from './RoleFulfillmentFeature.js';
+export { ShiftPlanSummary } from './ShiftPlanSummary.js';

--- a/shift-puzzle-bubly/shift-puzzle-libs/src/ui/GanttChart/MemberRow.tsx
+++ b/shift-puzzle-bubly/shift-puzzle-libs/src/ui/GanttChart/MemberRow.tsx
@@ -30,6 +30,7 @@ interface MemberRowProps {
   onAssignmentClick?: (assignmentId: string) => void;
   onDragOver?: (e: React.DragEvent<HTMLDivElement>) => void;
   onDrop?: (e: React.DragEvent<HTMLDivElement>) => void;
+  onRowClick?: (e: React.MouseEvent<HTMLDivElement>) => void;
 }
 
 /** ガントチャートの1行（メンバー or 役割） */
@@ -48,6 +49,7 @@ export const MemberRow: React.FC<MemberRowProps> = ({
   onAssignmentClick,
   onDragOver,
   onDrop,
+  onRowClick,
 }) => {
   const minutePx = hourPx / 60;
 
@@ -68,6 +70,7 @@ export const MemberRow: React.FC<MemberRowProps> = ({
       style={{ height: rowHeight, width: dayWidth }}
       onDragOver={onDragOver}
       onDrop={onDrop}
+      onClick={onRowClick}
     >
       {/* F-2-7: 参加可能時間帯のオーバーレイ */}
       {availableRects.map((rect, i) => (

--- a/shift-puzzle-bubly/shift-puzzle-libs/src/ui/GanttChart/PlacementPickerDialog.tsx
+++ b/shift-puzzle-bubly/shift-puzzle-libs/src/ui/GanttChart/PlacementPickerDialog.tsx
@@ -1,0 +1,157 @@
+'use client';
+import React from 'react';
+import styled from 'styled-components';
+
+export interface PickerItem {
+  id: string;
+  name: string;
+  /** 役割の場合に使う色ドット */
+  color?: string;
+  /** 補足テキスト（参加可否など） */
+  subtitle?: string;
+}
+
+interface PlacementPickerDialogProps {
+  open: boolean;
+  title: string;
+  items: PickerItem[];
+  onSelect: (id: string) => void;
+  onCancel: () => void;
+}
+
+/** セルクリック時に表示するメンバー or 役割ピッカー */
+export const PlacementPickerDialog: React.FC<PlacementPickerDialogProps> = ({
+  open,
+  title,
+  items,
+  onSelect,
+  onCancel,
+}) => {
+  if (!open) return null;
+
+  return (
+    <Overlay onClick={onCancel}>
+      <Panel onClick={(e) => e.stopPropagation()}>
+        <div className="e-header">
+          <span className="e-title">{title}</span>
+          <button className="e-close" onClick={onCancel} aria-label="閉じる">
+            ✕
+          </button>
+        </div>
+        {items.length === 0 ? (
+          <div className="e-empty">対応可能な候補がありません</div>
+        ) : (
+          <ul className="e-list">
+            {items.map((item) => (
+              <li key={item.id} className="e-item" onClick={() => onSelect(item.id)}>
+                {item.color && (
+                  <span className="e-dot" style={{ background: item.color }} />
+                )}
+                <span className="e-name">{item.name}</span>
+                {item.subtitle && <span className="e-sub">{item.subtitle}</span>}
+              </li>
+            ))}
+          </ul>
+        )}
+      </Panel>
+    </Overlay>
+  );
+};
+
+const Overlay = styled.div`
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.35);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 200;
+` as React.FC<React.HTMLAttributes<HTMLDivElement>>;
+
+const Panel = styled.div`
+  background: white;
+  border-radius: 10px;
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.18);
+  min-width: 280px;
+  max-width: 360px;
+  max-height: 480px;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+
+  .e-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 14px 16px 12px;
+    border-bottom: 1px solid #eee;
+    flex-shrink: 0;
+  }
+
+  .e-title {
+    font-size: 0.95em;
+    font-weight: 600;
+    color: #222;
+  }
+
+  .e-close {
+    background: none;
+    border: none;
+    cursor: pointer;
+    font-size: 0.9em;
+    color: #999;
+    padding: 4px 6px;
+    border-radius: 4px;
+
+    &:hover {
+      background: #f5f5f5;
+      color: #333;
+    }
+  }
+
+  .e-empty {
+    padding: 32px 24px;
+    text-align: center;
+    color: #999;
+    font-size: 0.88em;
+  }
+
+  .e-list {
+    list-style: none;
+    margin: 0;
+    padding: 6px 0;
+    overflow-y: auto;
+    flex: 1;
+  }
+
+  .e-item {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    padding: 10px 16px;
+    cursor: pointer;
+    transition: background 0.1s;
+
+    &:hover {
+      background: #e3f2fd;
+    }
+  }
+
+  .e-dot {
+    width: 12px;
+    height: 12px;
+    border-radius: 50%;
+    flex-shrink: 0;
+  }
+
+  .e-name {
+    flex: 1;
+    font-size: 0.9em;
+    color: #222;
+  }
+
+  .e-sub {
+    font-size: 0.76em;
+    color: #888;
+  }
+` as React.FC<React.HTMLAttributes<HTMLDivElement>>;

--- a/shift-puzzle-bubly/shift-puzzle-libs/src/ui/GanttChart/ReasonInputDialog.tsx
+++ b/shift-puzzle-bubly/shift-puzzle-libs/src/ui/GanttChart/ReasonInputDialog.tsx
@@ -7,10 +7,14 @@ export interface ReasonInputDialogProps {
   open: boolean;
   memberName?: string;
   roleName?: string;
-  /** 役割選択が必要な場合（memberモード時） */
+  /** 役割選択が必要な場合 */
   roles?: Array<{ id: string; name: string; color: string }>;
   selectedRoleId?: string;
   onRoleChange?: (roleId: string) => void;
+  /** 時間帯選択が必要な場合（MemberCardダブルクリック等） */
+  timeSlots?: Array<{ id: string; label: string }>;
+  selectedTimeSlotId?: string;
+  onTimeSlotChange?: (slotId: string) => void;
   onConfirm: (reason: AssignmentReasonState) => void;
   onCancel: () => void;
 }
@@ -31,6 +35,9 @@ export const ReasonInputDialog: React.FC<ReasonInputDialogProps> = ({
   roles,
   selectedRoleId,
   onRoleChange,
+  timeSlots,
+  selectedTimeSlotId,
+  onTimeSlotChange,
   onConfirm,
   onCancel,
 }) => {
@@ -39,7 +46,12 @@ export const ReasonInputDialog: React.FC<ReasonInputDialogProps> = ({
 
   if (!open) return null;
 
+  const canConfirm =
+    (!roles || roles.length === 0 || !!selectedRoleId) &&
+    (!timeSlots || timeSlots.length === 0 || !!selectedTimeSlotId);
+
   const handleConfirm = () => {
+    if (!canConfirm) return;
     onConfirm({
       category,
       text,
@@ -68,7 +80,7 @@ export const ReasonInputDialog: React.FC<ReasonInputDialogProps> = ({
           {roleName && <><span className="e-arrow">→</span><span className="e-chip e-role">{roleName}</span></>}
         </div>
 
-        {/* 役割選択（memberモード時） */}
+        {/* 役割選択 */}
         {roles && roles.length > 0 && (
           <div className="e-field">
             <label className="e-field-label">役割</label>
@@ -80,6 +92,23 @@ export const ReasonInputDialog: React.FC<ReasonInputDialogProps> = ({
               <option value="">選択してください</option>
               {roles.map((r) => (
                 <option key={r.id} value={r.id}>{r.name}</option>
+              ))}
+            </select>
+          </div>
+        )}
+
+        {/* 時間帯選択 */}
+        {timeSlots && timeSlots.length > 0 && (
+          <div className="e-field">
+            <label className="e-field-label">時間帯</label>
+            <select
+              className="e-select"
+              value={selectedTimeSlotId ?? ''}
+              onChange={(e: React.ChangeEvent<HTMLSelectElement>) => onTimeSlotChange?.(e.target.value)}
+            >
+              <option value="">選択してください</option>
+              {timeSlots.map((s) => (
+                <option key={s.id} value={s.id}>{s.label}</option>
               ))}
             </select>
           </div>
@@ -118,7 +147,7 @@ export const ReasonInputDialog: React.FC<ReasonInputDialogProps> = ({
           <button className="e-btn e-btn-cancel" onClick={handleCancel}>
             キャンセル
           </button>
-          <button className="e-btn e-btn-confirm" onClick={handleConfirm}>
+          <button className="e-btn e-btn-confirm" onClick={handleConfirm} disabled={!canConfirm}>
             配置を確定
           </button>
         </div>
@@ -277,8 +306,13 @@ const StyledPanel = styled.div`
     background: #1976d2;
     color: white;
 
-    &:hover {
+    &:hover:not(:disabled) {
       background: #1565c0;
+    }
+
+    &:disabled {
+      opacity: 0.4;
+      cursor: not-allowed;
     }
   }
 ` as React.FC<React.HTMLAttributes<HTMLDivElement>>;

--- a/shift-puzzle-bubly/shift-puzzle-libs/src/ui/MemberCard/MemberCard.tsx
+++ b/shift-puzzle-bubly/shift-puzzle-libs/src/ui/MemberCard/MemberCard.tsx
@@ -13,6 +13,8 @@ export interface MemberCardProps {
   timeSlots?: ReadonlyArray<TimeSlotState>;
   onEdit?: (memberId: string) => void;
   onDelete?: (memberId: string) => void;
+  /** F-4-1: タップで詳細バブルを開く */
+  onTap?: (memberId: string) => void;
 }
 
 /** F-1-1: メンバー情報の表示カード */
@@ -22,6 +24,7 @@ export const MemberCard: React.FC<MemberCardProps> = ({
   timeSlots = [],
   onEdit,
   onDelete,
+  onTap,
 }) => {
   const skillLabels = member.skills
     .map((skillId) => skillDefinitions.find((d) => d.id === skillId)?.label ?? skillId)
@@ -31,19 +34,19 @@ export const MemberCard: React.FC<MemberCardProps> = ({
   const totalCount = timeSlots.length;
 
   return (
-    <StyledCard>
+    <StyledCard onClick={onTap ? () => onTap(member.id) : undefined} style={onTap ? { cursor: 'pointer' } : undefined}>
       <div className="e-header">
         <div className="e-name">{member.name}</div>
         <div className="e-actions">
           {onEdit && (
-            <button className="e-btn-icon" onClick={() => onEdit(member.id)} title="編集">
+            <button className="e-btn-icon" onClick={(e) => { e.stopPropagation(); onEdit(member.id); }} title="編集">
               ✏️
             </button>
           )}
           {onDelete && (
             <button
               className="e-btn-icon e-btn-delete"
-              onClick={() => onDelete(member.id)}
+              onClick={(e) => { e.stopPropagation(); onDelete(member.id); }}
               title="削除"
             >
               🗑️

--- a/shift-puzzle-bubly/shift-puzzle-libs/src/ui/MemberCard/MemberCard.tsx
+++ b/shift-puzzle-bubly/shift-puzzle-libs/src/ui/MemberCard/MemberCard.tsx
@@ -1,5 +1,5 @@
 'use client';
-import React, { useRef } from 'react';
+import React from 'react';
 import styled from 'styled-components';
 import { setDragPayload, getDragType } from '@bublys-org/bubbles-ui';
 import type {
@@ -16,8 +16,6 @@ export interface MemberCardProps {
   onDelete?: (memberId: string) => void;
   /** F-4-1: タップで詳細バブルを開く */
   onTap?: (memberId: string) => void;
-  /** F-4-3: ダブルクリックでクイック配置ダイアログを開く */
-  onDoubleClick?: (memberId: string) => void;
   /** F-4-3: ドラッグ&ドロップ用URL（設定するとカードがドラッグ可能になる） */
   dragUrl?: string;
 }
@@ -30,11 +28,8 @@ export const MemberCard: React.FC<MemberCardProps> = ({
   onEdit,
   onDelete,
   onTap,
-  onDoubleClick,
   dragUrl,
 }) => {
-  const clickTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-
   const skillLabels = member.skills
     .map((skillId) => skillDefinitions.find((d) => d.id === skillId)?.label ?? skillId)
     .filter(Boolean);
@@ -43,24 +38,7 @@ export const MemberCard: React.FC<MemberCardProps> = ({
   const totalCount = timeSlots.length;
 
   const handleClick = () => {
-    if (!onTap) return;
-    if (onDoubleClick) {
-      // ダブルクリックと区別するため 250ms 待つ
-      clickTimerRef.current = setTimeout(() => {
-        clickTimerRef.current = null;
-        onTap(member.id);
-      }, 250);
-    } else {
-      onTap(member.id);
-    }
-  };
-
-  const handleDoubleClick = () => {
-    if (clickTimerRef.current) {
-      clearTimeout(clickTimerRef.current);
-      clickTimerRef.current = null;
-    }
-    onDoubleClick?.(member.id);
+    onTap?.(member.id);
   };
 
   const handleDragStart = (e: React.DragEvent<HTMLDivElement>) => {
@@ -76,7 +54,6 @@ export const MemberCard: React.FC<MemberCardProps> = ({
   return (
     <StyledCard
       onClick={onTap ? handleClick : undefined}
-      onDoubleClick={onDoubleClick ? handleDoubleClick : undefined}
       draggable={!!dragUrl}
       onDragStart={dragUrl ? handleDragStart : undefined}
       style={{

--- a/shift-puzzle-bubly/shift-puzzle-libs/src/ui/MemberDetail/MemberDetailView.tsx
+++ b/shift-puzzle-bubly/shift-puzzle-libs/src/ui/MemberDetail/MemberDetailView.tsx
@@ -1,0 +1,341 @@
+'use client';
+import React from 'react';
+import styled from 'styled-components';
+import type {
+  MemberState,
+  TimeSlotState,
+  SkillDefinitionState,
+  AssignmentState,
+  RoleState,
+} from '@bublys-org/shift-puzzle-model';
+
+export interface MemberDetailViewProps {
+  member: MemberState;
+  skillDefinitions?: ReadonlyArray<SkillDefinitionState>;
+  timeSlots?: ReadonlyArray<TimeSlotState>;
+  /** このシフト案内での配置一覧 */
+  assignments?: ReadonlyArray<AssignmentState>;
+  roles?: ReadonlyArray<RoleState>;
+  isPocketed?: boolean;
+  onAddToPocket?: () => void;
+}
+
+/** F-4-1: メンバー詳細バブル（スキル・参加可能時間・現在の配置状況） */
+export const MemberDetailView: React.FC<MemberDetailViewProps> = ({
+  member,
+  skillDefinitions = [],
+  timeSlots = [],
+  assignments = [],
+  roles = [],
+  isPocketed = false,
+  onAddToPocket,
+}) => {
+  const skillLabels = member.skills
+    .map((skillId) => skillDefinitions.find((d) => d.id === skillId)?.label ?? skillId)
+    .filter(Boolean);
+
+  const availableSlots = timeSlots.filter((s) => member.availableSlotIds.includes(s.id));
+  const totalCount = timeSlots.length;
+  const availableCount = availableSlots.length;
+
+  const myAssignments = assignments.filter((a) => a.memberId === member.id);
+
+  const formatTime = (minutes: number) => {
+    const h = Math.floor(minutes / 60);
+    const m = minutes % 60;
+    return `${h}:${String(m).padStart(2, '0')}`;
+  };
+
+  const getRoleName = (roleId: string) =>
+    roles.find((r) => r.id === roleId)?.name ?? roleId;
+
+  const getSlotLabel = (slotId: string) => {
+    const slot = timeSlots.find((s) => s.id === slotId);
+    if (!slot) return slotId;
+    return `${formatTime(slot.startMinute)}〜${formatTime(slot.startMinute + slot.durationMinutes)}`;
+  };
+
+  return (
+    <StyledWrapper>
+      {/* ヘッダー */}
+      <div className="e-header">
+        <div className="e-name">{member.name}</div>
+        {onAddToPocket && (
+          <button
+            className={`e-pocket-btn ${isPocketed ? 'is-pocketed' : ''}`}
+            onClick={onAddToPocket}
+            disabled={isPocketed}
+            title={isPocketed ? 'ポケット済み' : 'ポケットに追加'}
+          >
+            {isPocketed ? '📌 ポケット済み' : '📌 ポケットに追加'}
+          </button>
+        )}
+      </div>
+
+      {/* F-1-4: タグ */}
+      {member.tags.length > 0 && (
+        <div className="e-section">
+          <div className="e-section-title">タグ</div>
+          <div className="e-tags">
+            {member.tags.map((tag) => (
+              <span key={tag} className="e-tag">{tag}</span>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {/* F-1-2: スキル */}
+      <div className="e-section">
+        <div className="e-section-title">スキル</div>
+        {skillLabels.length > 0 ? (
+          <div className="e-skills">
+            {skillLabels.map((label) => (
+              <span key={label} className="e-skill-badge">✓ {label}</span>
+            ))}
+          </div>
+        ) : (
+          <div className="e-empty-note">スキル未登録</div>
+        )}
+      </div>
+
+      {/* F-1-3: 参加可能時間帯 */}
+      {totalCount > 0 && (
+        <div className="e-section">
+          <div className="e-section-title">
+            参加可能時間帯
+            <span className="e-count-badge">{availableCount}/{totalCount}</span>
+          </div>
+          <div className="e-avail-bar-wrap">
+            <div
+              className="e-avail-bar"
+              style={{ width: `${(availableCount / totalCount) * 100}%` }}
+            />
+          </div>
+          {availableSlots.length > 0 && (
+            <div className="e-slot-list">
+              {availableSlots.map((slot) => (
+                <span key={slot.id} className="e-slot-chip">
+                  {formatTime(slot.startMinute)}〜{formatTime(slot.startMinute + slot.durationMinutes)}
+                </span>
+              ))}
+            </div>
+          )}
+        </div>
+      )}
+
+      {/* 現在の配置状況 */}
+      <div className="e-section">
+        <div className="e-section-title">
+          現在の配置
+          <span className="e-count-badge">{myAssignments.length}件</span>
+        </div>
+        {myAssignments.length > 0 ? (
+          <div className="e-assignment-list">
+            {myAssignments.map((a) => (
+              <div key={a.id} className="e-assignment-item">
+                <span
+                  className="e-role-dot"
+                  style={{ background: roles.find((r) => r.id === a.roleId)?.color ?? '#999' }}
+                />
+                <span className="e-role-name">{getRoleName(a.roleId)}</span>
+                <span className="e-slot-time">{getSlotLabel(a.timeSlotId)}</span>
+              </div>
+            ))}
+          </div>
+        ) : (
+          <div className="e-empty-note">このシフト案では未配置</div>
+        )}
+      </div>
+
+      {/* メモ */}
+      {member.memo && (
+        <div className="e-section">
+          <div className="e-section-title">メモ</div>
+          <div className="e-memo">{member.memo}</div>
+        </div>
+      )}
+    </StyledWrapper>
+  );
+};
+
+const StyledWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  overflow-y: auto;
+  background: #fafafa;
+  gap: 0;
+
+  .e-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 12px 14px;
+    background: white;
+    border-bottom: 1px solid #eee;
+    flex-shrink: 0;
+    gap: 8px;
+  }
+
+  .e-name {
+    font-size: 1.05em;
+    font-weight: 700;
+    color: #222;
+  }
+
+  .e-pocket-btn {
+    padding: 5px 12px;
+    background: #f3f4f6;
+    border: 1px solid #d1d5db;
+    border-radius: 6px;
+    font-size: 0.8em;
+    cursor: pointer;
+    white-space: nowrap;
+    transition: all 0.15s;
+
+    &:hover:not(:disabled) {
+      background: #e0f2fe;
+      border-color: #0284c7;
+      color: #0284c7;
+    }
+
+    &.is-pocketed {
+      background: #eff6ff;
+      border-color: #93c5fd;
+      color: #1d4ed8;
+      cursor: default;
+    }
+  }
+
+  .e-section {
+    padding: 10px 14px;
+    border-bottom: 1px solid #f0f0f0;
+    background: white;
+  }
+
+  .e-section-title {
+    font-size: 0.75em;
+    font-weight: 600;
+    color: #888;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    margin-bottom: 6px;
+    display: flex;
+    align-items: center;
+    gap: 6px;
+  }
+
+  .e-count-badge {
+    background: #f0f0f0;
+    color: #555;
+    padding: 1px 7px;
+    border-radius: 10px;
+    font-size: 0.9em;
+    font-weight: 500;
+    text-transform: none;
+  }
+
+  .e-tags {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 4px;
+  }
+
+  .e-tag {
+    background: #e3f2fd;
+    color: #1565c0;
+    padding: 2px 9px;
+    border-radius: 12px;
+    font-size: 0.8em;
+    font-weight: 500;
+  }
+
+  .e-skills {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 4px;
+  }
+
+  .e-skill-badge {
+    background: #e8f5e9;
+    color: #2e7d32;
+    padding: 2px 9px;
+    border-radius: 4px;
+    font-size: 0.8em;
+    font-weight: 500;
+  }
+
+  .e-empty-note {
+    font-size: 0.82em;
+    color: #bbb;
+  }
+
+  .e-avail-bar-wrap {
+    height: 6px;
+    background: #e0e0e0;
+    border-radius: 3px;
+    overflow: hidden;
+    margin-bottom: 8px;
+  }
+
+  .e-avail-bar {
+    height: 100%;
+    background: #4caf50;
+    border-radius: 3px;
+    transition: width 0.3s;
+  }
+
+  .e-slot-list {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 4px;
+  }
+
+  .e-slot-chip {
+    background: #f5f5f5;
+    border: 1px solid #e0e0e0;
+    color: #555;
+    padding: 2px 8px;
+    border-radius: 4px;
+    font-size: 0.76em;
+  }
+
+  .e-assignment-list {
+    display: flex;
+    flex-direction: column;
+    gap: 5px;
+  }
+
+  .e-assignment-item {
+    display: flex;
+    align-items: center;
+    gap: 7px;
+    font-size: 0.85em;
+  }
+
+  .e-role-dot {
+    width: 8px;
+    height: 8px;
+    border-radius: 50%;
+    flex-shrink: 0;
+  }
+
+  .e-role-name {
+    font-weight: 500;
+    color: #333;
+    flex: 1;
+  }
+
+  .e-slot-time {
+    color: #888;
+    font-size: 0.9em;
+    white-space: nowrap;
+  }
+
+  .e-memo {
+    font-size: 0.85em;
+    color: #666;
+    line-height: 1.5;
+    white-space: pre-wrap;
+  }
+` as React.FC<React.HTMLAttributes<HTMLDivElement>>;

--- a/shift-puzzle-bubly/shift-puzzle-libs/src/ui/RoleFulfillment/RoleFulfillmentView.tsx
+++ b/shift-puzzle-bubly/shift-puzzle-libs/src/ui/RoleFulfillment/RoleFulfillmentView.tsx
@@ -1,0 +1,367 @@
+'use client';
+import React, { useMemo } from 'react';
+import styled from 'styled-components';
+import type {
+  RoleState,
+  TimeSlotState,
+  MemberState,
+  AssignmentState,
+  SkillDefinitionState,
+} from '@bublys-org/shift-puzzle-model';
+
+export interface RoleFulfillmentViewProps {
+  role: RoleState;
+  /** このシフト案内での配置一覧 */
+  assignments?: ReadonlyArray<AssignmentState>;
+  timeSlots?: ReadonlyArray<TimeSlotState>;
+  members?: ReadonlyArray<MemberState>;
+  skillDefinitions?: ReadonlyArray<SkillDefinitionState>;
+}
+
+/** F-4-2: 役割充足状況バブル（配置人数/必要人数・スキル充足率） */
+export const RoleFulfillmentView: React.FC<RoleFulfillmentViewProps> = ({
+  role,
+  assignments = [],
+  timeSlots = [],
+  members = [],
+  skillDefinitions = [],
+}) => {
+  const roleAssignments = assignments.filter((a) => a.roleId === role.id);
+
+  const formatTime = (minutes: number) => {
+    const h = Math.floor(minutes / 60);
+    const m = minutes % 60;
+    return `${h}:${String(m).padStart(2, '0')}`;
+  };
+
+  const getMemberName = (memberId: string) =>
+    members.find((m) => m.id === memberId)?.name ?? memberId;
+
+  // 時間帯ごとの充足状況
+  const slotFulfillment = useMemo(() => {
+    return timeSlots.map((slot) => {
+      const count = roleAssignments.filter((a) => a.timeSlotId === slot.id).length;
+      const assignedMembers = roleAssignments
+        .filter((a) => a.timeSlotId === slot.id)
+        .map((a) => getMemberName(a.memberId));
+      const isFulfilled = count >= role.minRequired;
+      const isOverFilled = role.maxRequired !== null && count > role.maxRequired;
+      return { slot, count, assignedMembers, isFulfilled, isOverFilled };
+    });
+  }, [timeSlots, roleAssignments, role, members]);
+
+  // 全体充足率（充足スロット数 / 全スロット数）
+  const fulfilledCount = slotFulfillment.filter((s) => s.isFulfilled).length;
+  const totalSlots = timeSlots.length;
+  const fulfillRate = totalSlots > 0 ? (fulfilledCount / totalSlots) * 100 : 0;
+
+  const requiredSkillLabels = role.requiredSkillIds.map(
+    (id) => skillDefinitions.find((d) => d.id === id)?.label ?? id
+  );
+
+  return (
+    <StyledWrapper>
+      {/* ヘッダー */}
+      <div className="e-header">
+        <div className="e-role-dot" style={{ background: role.color }} />
+        <div className="e-name">{role.name}</div>
+      </div>
+
+      {/* 概要 */}
+      {role.description && (
+        <div className="e-section">
+          <div className="e-section-title">説明</div>
+          <div className="e-description">{role.description}</div>
+        </div>
+      )}
+
+      {/* 必要人数 */}
+      <div className="e-section">
+        <div className="e-section-title">必要人数</div>
+        <div className="e-requirement">
+          <span className="e-req-min">{role.minRequired}名以上</span>
+          {role.maxRequired !== null && (
+            <span className="e-req-max">{role.maxRequired}名以下</span>
+          )}
+        </div>
+      </div>
+
+      {/* 必須スキル */}
+      <div className="e-section">
+        <div className="e-section-title">必須スキル</div>
+        {requiredSkillLabels.length > 0 ? (
+          <div className="e-skills">
+            {requiredSkillLabels.map((label) => (
+              <span key={label} className="e-skill-badge">✓ {label}</span>
+            ))}
+          </div>
+        ) : (
+          <div className="e-empty-note">スキル要件なし</div>
+        )}
+      </div>
+
+      {/* 充足状況サマリー */}
+      {totalSlots > 0 && (
+        <div className="e-section">
+          <div className="e-section-title">
+            充足状況
+            <span className={`e-fulfill-badge ${fulfillRate === 100 ? 'is-full' : fulfillRate > 0 ? 'is-partial' : 'is-empty'}`}>
+              {fulfilledCount}/{totalSlots} スロット充足
+            </span>
+          </div>
+          <div className="e-fulfill-bar-wrap">
+            <div
+              className={`e-fulfill-bar ${fulfillRate === 100 ? 'is-full' : ''}`}
+              style={{ width: `${fulfillRate}%` }}
+            />
+          </div>
+        </div>
+      )}
+
+      {/* 時間帯別充足 */}
+      {timeSlots.length > 0 && (
+        <div className="e-section">
+          <div className="e-section-title">時間帯別配置</div>
+          <div className="e-slot-table">
+            {slotFulfillment.map(({ slot, count, assignedMembers, isFulfilled, isOverFilled }) => (
+              <div
+                key={slot.id}
+                className={`e-slot-row ${isFulfilled ? 'is-fulfilled' : 'is-short'} ${isOverFilled ? 'is-over' : ''}`}
+              >
+                <div className="e-slot-time">
+                  {formatTime(slot.startMinute)}〜{formatTime(slot.startMinute + slot.durationMinutes)}
+                </div>
+                <div className="e-slot-count">
+                  <span className={`e-count-num ${isFulfilled ? 'ok' : 'ng'}`}>{count}</span>
+                  <span className="e-count-slash">/</span>
+                  <span className="e-count-req">{role.minRequired}</span>
+                </div>
+                {assignedMembers.length > 0 && (
+                  <div className="e-slot-members">
+                    {assignedMembers.map((name, i) => (
+                      <span key={i} className="e-member-chip">{name}</span>
+                    ))}
+                  </div>
+                )}
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+    </StyledWrapper>
+  );
+};
+
+const StyledWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  overflow-y: auto;
+  background: #fafafa;
+
+  .e-header {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    padding: 12px 14px;
+    background: white;
+    border-bottom: 1px solid #eee;
+    flex-shrink: 0;
+  }
+
+  .e-role-dot {
+    width: 12px;
+    height: 12px;
+    border-radius: 50%;
+    flex-shrink: 0;
+  }
+
+  .e-name {
+    font-size: 1.05em;
+    font-weight: 700;
+    color: #222;
+  }
+
+  .e-section {
+    padding: 10px 14px;
+    border-bottom: 1px solid #f0f0f0;
+    background: white;
+  }
+
+  .e-section-title {
+    font-size: 0.75em;
+    font-weight: 600;
+    color: #888;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    margin-bottom: 6px;
+    display: flex;
+    align-items: center;
+    gap: 6px;
+  }
+
+  .e-description {
+    font-size: 0.88em;
+    color: #555;
+    line-height: 1.5;
+  }
+
+  .e-requirement {
+    display: flex;
+    gap: 8px;
+  }
+
+  .e-req-min {
+    background: #e8f5e9;
+    color: #2e7d32;
+    padding: 2px 10px;
+    border-radius: 4px;
+    font-size: 0.85em;
+    font-weight: 600;
+  }
+
+  .e-req-max {
+    background: #fff3e0;
+    color: #e65100;
+    padding: 2px 10px;
+    border-radius: 4px;
+    font-size: 0.85em;
+    font-weight: 600;
+  }
+
+  .e-skills {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 4px;
+  }
+
+  .e-skill-badge {
+    background: #e8f5e9;
+    color: #2e7d32;
+    padding: 2px 9px;
+    border-radius: 4px;
+    font-size: 0.8em;
+    font-weight: 500;
+  }
+
+  .e-empty-note {
+    font-size: 0.82em;
+    color: #bbb;
+  }
+
+  .e-fulfill-badge {
+    padding: 1px 8px;
+    border-radius: 10px;
+    font-size: 0.9em;
+    font-weight: 500;
+    text-transform: none;
+
+    &.is-full {
+      background: #e8f5e9;
+      color: #2e7d32;
+    }
+    &.is-partial {
+      background: #fff3e0;
+      color: #e65100;
+    }
+    &.is-empty {
+      background: #fce4e4;
+      color: #c62828;
+    }
+  }
+
+  .e-fulfill-bar-wrap {
+    height: 6px;
+    background: #e0e0e0;
+    border-radius: 3px;
+    overflow: hidden;
+  }
+
+  .e-fulfill-bar {
+    height: 100%;
+    background: #ff9800;
+    border-radius: 3px;
+    transition: width 0.3s;
+
+    &.is-full {
+      background: #4caf50;
+    }
+  }
+
+  .e-slot-table {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+  }
+
+  .e-slot-row {
+    display: flex;
+    flex-direction: column;
+    gap: 3px;
+    padding: 6px 8px;
+    border-radius: 5px;
+    border: 1px solid #e0e0e0;
+    background: #fafafa;
+
+    &.is-fulfilled {
+      border-color: #a5d6a7;
+      background: #f1f8f1;
+    }
+
+    &.is-short {
+      border-color: #ffcc80;
+      background: #fff8f0;
+    }
+
+    &.is-over {
+      border-color: #ef9a9a;
+      background: #fff5f5;
+    }
+  }
+
+  .e-slot-time {
+    font-size: 0.8em;
+    color: #666;
+    font-weight: 500;
+  }
+
+  .e-slot-count {
+    display: flex;
+    align-items: baseline;
+    gap: 2px;
+    font-size: 0.9em;
+  }
+
+  .e-count-num {
+    font-weight: 700;
+    font-size: 1.1em;
+
+    &.ok { color: #2e7d32; }
+    &.ng { color: #e65100; }
+  }
+
+  .e-count-slash {
+    color: #bbb;
+    font-size: 0.9em;
+  }
+
+  .e-count-req {
+    color: #888;
+    font-size: 0.9em;
+  }
+
+  .e-slot-members {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 3px;
+  }
+
+  .e-member-chip {
+    background: white;
+    border: 1px solid #ddd;
+    color: #555;
+    padding: 1px 7px;
+    border-radius: 10px;
+    font-size: 0.76em;
+  }
+` as React.FC<React.HTMLAttributes<HTMLDivElement>>;

--- a/shift-puzzle-bubly/shift-puzzle-libs/src/ui/Summary/ShiftPlanSummaryView.tsx
+++ b/shift-puzzle-bubly/shift-puzzle-libs/src/ui/Summary/ShiftPlanSummaryView.tsx
@@ -1,0 +1,562 @@
+'use client';
+import React, { useMemo } from 'react';
+import styled from 'styled-components';
+import type {
+  MemberState,
+  RoleState,
+  TimeSlotState,
+  AssignmentState,
+} from '@bublys-org/shift-puzzle-model';
+
+// ========== 型定義 ==========
+
+/** メンバー拘束時間サマリー（F-7-1） */
+export interface MemberWorkloadSummary {
+  member: MemberState;
+  totalMinutes: number;
+  isUnassigned: boolean;
+  isOverloaded: boolean;
+}
+
+/** 役割充足状況サマリー（F-7-2） */
+export interface RoleFulfillmentSummary {
+  role: RoleState;
+  /** 充足スロット数 */
+  fulfilledSlots: number;
+  /** 全スロット数（minRequired > 0 のもの） */
+  totalSlots: number;
+  /** 不足合計人数（全スロット分の合算） */
+  totalShortfall: number;
+  /** 充足率 (0〜100) */
+  fulfillmentRate: number;
+  isFullyFulfilled: boolean;
+}
+
+/** アラート（F-7-3） */
+export interface SummaryAlert {
+  type: 'unassigned_member' | 'understaffed_role';
+  label: string;
+  detail: string;
+}
+
+export interface ShiftPlanSummaryViewProps {
+  members: ReadonlyArray<MemberState>;
+  roles: ReadonlyArray<RoleState>;
+  timeSlots: ReadonlyArray<TimeSlotState>;
+  assignments: ReadonlyArray<AssignmentState>;
+}
+
+// ========== ヘルパー ==========
+
+function formatMinutes(minutes: number): string {
+  const h = Math.floor(minutes / 60);
+  const m = minutes % 60;
+  if (m === 0) return `${h}時間`;
+  return `${h}時間${m}分`;
+}
+
+// ========== コンポーネント ==========
+
+/** F-7-1〜F-7-3: シフト案評価サマリービュー */
+export const ShiftPlanSummaryView: React.FC<ShiftPlanSummaryViewProps> = ({
+  members,
+  roles,
+  timeSlots,
+  assignments,
+}) => {
+  // タイムスロットをMapに変換
+  const timeSlotMap = useMemo(
+    () => new Map(timeSlots.map((ts) => [ts.id, ts])),
+    [timeSlots]
+  );
+
+  // F-7-1: メンバーごとの総拘束時間
+  const memberWorkloads = useMemo((): MemberWorkloadSummary[] => {
+    const assignedMinutes = new Map<string, number>();
+    for (const assignment of assignments) {
+      const slot = timeSlotMap.get(assignment.timeSlotId);
+      const duration = slot?.durationMinutes ?? 0;
+      assignedMinutes.set(
+        assignment.memberId,
+        (assignedMinutes.get(assignment.memberId) ?? 0) + duration
+      );
+    }
+
+    // 平均拘束時間（配置済みメンバーのみ）
+    const assignedValues = [...assignedMinutes.values()].filter((v) => v > 0);
+    const avgMinutes =
+      assignedValues.length > 0
+        ? assignedValues.reduce((s, v) => s + v, 0) / assignedValues.length
+        : 0;
+
+    return members.map((member) => {
+      const totalMinutes = assignedMinutes.get(member.id) ?? 0;
+      return {
+        member,
+        totalMinutes,
+        isUnassigned: totalMinutes === 0,
+        isOverloaded: avgMinutes > 0 && totalMinutes > avgMinutes * 1.8,
+      };
+    });
+  }, [members, assignments, timeSlotMap]);
+
+  const maxWorkloadMinutes = useMemo(
+    () => Math.max(...memberWorkloads.map((w) => w.totalMinutes), 1),
+    [memberWorkloads]
+  );
+
+  // F-7-2: 役割ごとの充足率
+  const roleFulfillments = useMemo((): RoleFulfillmentSummary[] => {
+    // timeSlotId × roleId での配置人数集計
+    const countMap = new Map<string, number>();
+    for (const assignment of assignments) {
+      const key = `${assignment.timeSlotId}:${assignment.roleId}`;
+      countMap.set(key, (countMap.get(key) ?? 0) + 1);
+    }
+
+    return roles.map((role) => {
+      const relevantSlots = timeSlots.filter(() => role.minRequired > 0);
+      let fulfilledSlots = 0;
+      let totalShortfall = 0;
+
+      for (const slot of relevantSlots) {
+        const assigned = countMap.get(`${slot.id}:${role.id}`) ?? 0;
+        if (assigned >= role.minRequired) {
+          fulfilledSlots++;
+        } else {
+          totalShortfall += role.minRequired - assigned;
+        }
+      }
+
+      const totalSlots = relevantSlots.length;
+      const fulfillmentRate =
+        totalSlots > 0 ? (fulfilledSlots / totalSlots) * 100 : 100;
+
+      return {
+        role,
+        fulfilledSlots,
+        totalSlots,
+        totalShortfall,
+        fulfillmentRate,
+        isFullyFulfilled: fulfilledSlots === totalSlots,
+      };
+    });
+  }, [roles, timeSlots, assignments]);
+
+  // F-7-3: アラート生成
+  const alerts = useMemo((): SummaryAlert[] => {
+    const result: SummaryAlert[] = [];
+
+    // 未配置メンバー
+    for (const w of memberWorkloads) {
+      if (w.isUnassigned) {
+        result.push({
+          type: 'unassigned_member',
+          label: w.member.name,
+          detail: '配置なし',
+        });
+      }
+    }
+
+    // 充足不足役割
+    for (const f of roleFulfillments) {
+      if (!f.isFullyFulfilled && f.totalShortfall > 0) {
+        result.push({
+          type: 'understaffed_role',
+          label: f.role.name,
+          detail: `計${f.totalShortfall}人不足（${f.fulfilledSlots}/${f.totalSlots}スロット充足）`,
+        });
+      }
+    }
+
+    return result;
+  }, [memberWorkloads, roleFulfillments]);
+
+  // 全体スコア
+  const overallScore = useMemo(() => {
+    if (roleFulfillments.length === 0) return 100;
+    const fulfilledCount = roleFulfillments.filter((f) => f.isFullyFulfilled).length;
+    return Math.round((fulfilledCount / roleFulfillments.length) * 100);
+  }, [roleFulfillments]);
+
+  return (
+    <StyledWrapper>
+      {/* ヘッダー */}
+      <div className="e-header">
+        <div className="e-header-title">評価サマリー</div>
+        <div className={`e-score-badge ${overallScore === 100 ? 'is-perfect' : overallScore >= 60 ? 'is-good' : 'is-poor'}`}>
+          充足スコア {overallScore}%
+        </div>
+      </div>
+
+      {/* F-7-3: アラート */}
+      {alerts.length > 0 && (
+        <section className="e-section">
+          <div className="e-section-title">
+            ⚠ アラート
+            <span className="e-badge e-badge--warn">{alerts.length}件</span>
+          </div>
+          <div className="e-alert-list">
+            {alerts.map((alert, i) => (
+              <div
+                key={i}
+                className={`e-alert-item ${alert.type === 'unassigned_member' ? 'is-member' : 'is-role'}`}
+              >
+                <span className="e-alert-icon">
+                  {alert.type === 'unassigned_member' ? '👤' : '📋'}
+                </span>
+                <span className="e-alert-label">{alert.label}</span>
+                <span className="e-alert-detail">{alert.detail}</span>
+              </div>
+            ))}
+          </div>
+        </section>
+      )}
+
+      {/* F-7-2: 役割充足率 */}
+      <section className="e-section">
+        <div className="e-section-title">役割充足状況</div>
+        <div className="e-role-list">
+          {roleFulfillments.map(({ role, fulfilledSlots, totalSlots, fulfillmentRate, isFullyFulfilled, totalShortfall }) => (
+            <div key={role.id} className="e-role-row">
+              <div className="e-role-row-header">
+                <div className="e-role-dot" style={{ background: role.color }} />
+                <span className="e-role-name">{role.name}</span>
+                <span className={`e-role-status ${isFullyFulfilled ? 'is-ok' : 'is-ng'}`}>
+                  {isFullyFulfilled ? '✓' : `⚠ ${totalShortfall}人不足`}
+                </span>
+                <span className="e-role-rate">{Math.round(fulfillmentRate)}%</span>
+              </div>
+              <div className="e-progress-wrap">
+                <div
+                  className={`e-progress-bar ${isFullyFulfilled ? 'is-full' : fulfillmentRate > 0 ? 'is-partial' : 'is-empty'}`}
+                  style={{ width: `${fulfillmentRate}%` }}
+                />
+              </div>
+              <div className="e-role-slots">
+                {fulfilledSlots}/{totalSlots}スロット充足
+              </div>
+            </div>
+          ))}
+          {roleFulfillments.length === 0 && (
+            <div className="e-empty">役割が登録されていません</div>
+          )}
+        </div>
+      </section>
+
+      {/* F-7-1: メンバー拘束時間 */}
+      <section className="e-section">
+        <div className="e-section-title">メンバー拘束時間</div>
+        <div className="e-member-list">
+          {memberWorkloads.map(({ member, totalMinutes, isUnassigned, isOverloaded }) => (
+            <div
+              key={member.id}
+              className={`e-member-row ${isUnassigned ? 'is-unassigned' : ''} ${isOverloaded ? 'is-overloaded' : ''}`}
+            >
+              <span className="e-member-name">{member.name}</span>
+              <div className="e-member-bar-wrap">
+                <div
+                  className={`e-member-bar ${isOverloaded ? 'is-over' : ''}`}
+                  style={{ width: `${(totalMinutes / maxWorkloadMinutes) * 100}%` }}
+                />
+              </div>
+              <span className="e-member-time">
+                {isUnassigned ? (
+                  <span className="e-unassigned-label">未配置</span>
+                ) : (
+                  <>
+                    {formatMinutes(totalMinutes)}
+                    {isOverloaded && <span className="e-overload-label">過負荷</span>}
+                  </>
+                )}
+              </span>
+            </div>
+          ))}
+          {memberWorkloads.length === 0 && (
+            <div className="e-empty">メンバーが登録されていません</div>
+          )}
+        </div>
+      </section>
+    </StyledWrapper>
+  );
+};
+
+// ========== スタイル ==========
+
+const StyledWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  overflow-y: auto;
+  background: #fafafa;
+
+  .e-header {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    padding: 12px 14px;
+    background: white;
+    border-bottom: 1px solid #eee;
+    flex-shrink: 0;
+  }
+
+  .e-header-title {
+    font-size: 1.05em;
+    font-weight: 700;
+    color: #222;
+  }
+
+  .e-score-badge {
+    margin-left: auto;
+    padding: 3px 12px;
+    border-radius: 12px;
+    font-size: 0.85em;
+    font-weight: 600;
+
+    &.is-perfect {
+      background: #e8f5e9;
+      color: #2e7d32;
+    }
+    &.is-good {
+      background: #fff3e0;
+      color: #e65100;
+    }
+    &.is-poor {
+      background: #fce4e4;
+      color: #c62828;
+    }
+  }
+
+  .e-section {
+    background: white;
+    border-bottom: 1px solid #f0f0f0;
+    padding: 10px 14px;
+  }
+
+  .e-section-title {
+    font-size: 0.75em;
+    font-weight: 600;
+    color: #888;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    margin-bottom: 8px;
+    display: flex;
+    align-items: center;
+    gap: 6px;
+  }
+
+  .e-badge {
+    padding: 1px 7px;
+    border-radius: 10px;
+    font-size: 0.9em;
+    font-weight: 500;
+    text-transform: none;
+
+    &.e-badge--warn {
+      background: #fce4e4;
+      color: #c62828;
+    }
+  }
+
+  /* F-7-3: アラートリスト */
+  .e-alert-list {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+  }
+
+  .e-alert-item {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    padding: 6px 9px;
+    border-radius: 5px;
+    font-size: 0.85em;
+
+    &.is-member {
+      background: #fff8e1;
+      border: 1px solid #ffe082;
+    }
+    &.is-role {
+      background: #fce4e4;
+      border: 1px solid #ef9a9a;
+    }
+  }
+
+  .e-alert-icon {
+    font-size: 1em;
+  }
+
+  .e-alert-label {
+    font-weight: 600;
+    color: #333;
+  }
+
+  .e-alert-detail {
+    color: #666;
+    margin-left: auto;
+    font-size: 0.9em;
+  }
+
+  /* F-7-2: 役割充足率 */
+  .e-role-list {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+  }
+
+  .e-role-row {
+    display: flex;
+    flex-direction: column;
+    gap: 3px;
+  }
+
+  .e-role-row-header {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    font-size: 0.88em;
+  }
+
+  .e-role-dot {
+    width: 10px;
+    height: 10px;
+    border-radius: 50%;
+    flex-shrink: 0;
+  }
+
+  .e-role-name {
+    font-weight: 600;
+    color: #333;
+  }
+
+  .e-role-status {
+    margin-left: auto;
+    font-size: 0.85em;
+
+    &.is-ok {
+      color: #2e7d32;
+    }
+    &.is-ng {
+      color: #c62828;
+      font-weight: 600;
+    }
+  }
+
+  .e-role-rate {
+    font-size: 0.85em;
+    color: #666;
+    min-width: 36px;
+    text-align: right;
+  }
+
+  .e-progress-wrap {
+    height: 6px;
+    background: #e0e0e0;
+    border-radius: 3px;
+    overflow: hidden;
+  }
+
+  .e-progress-bar {
+    height: 100%;
+    border-radius: 3px;
+    transition: width 0.3s;
+
+    &.is-full {
+      background: #4caf50;
+    }
+    &.is-partial {
+      background: #ff9800;
+    }
+    &.is-empty {
+      background: #ef5350;
+      width: 0% !important;
+    }
+  }
+
+  .e-role-slots {
+    font-size: 0.76em;
+    color: #aaa;
+  }
+
+  /* F-7-1: メンバー拘束時間 */
+  .e-member-list {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+  }
+
+  .e-member-row {
+    display: grid;
+    grid-template-columns: 100px 1fr 90px;
+    align-items: center;
+    gap: 6px;
+    font-size: 0.85em;
+
+    &.is-unassigned .e-member-name {
+      color: #bbb;
+    }
+
+    &.is-overloaded .e-member-name {
+      color: #c62828;
+      font-weight: 600;
+    }
+  }
+
+  .e-member-name {
+    color: #333;
+    font-weight: 500;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .e-member-bar-wrap {
+    height: 8px;
+    background: #f0f0f0;
+    border-radius: 4px;
+    overflow: hidden;
+  }
+
+  .e-member-bar {
+    height: 100%;
+    background: #42a5f5;
+    border-radius: 4px;
+    transition: width 0.3s;
+    min-width: 2px;
+
+    &.is-over {
+      background: #ef5350;
+    }
+  }
+
+  .e-member-time {
+    text-align: right;
+    color: #555;
+    display: flex;
+    align-items: center;
+    justify-content: flex-end;
+    gap: 4px;
+  }
+
+  .e-unassigned-label {
+    color: #bbb;
+    font-size: 0.9em;
+  }
+
+  .e-overload-label {
+    background: #fce4e4;
+    color: #c62828;
+    padding: 1px 5px;
+    border-radius: 3px;
+    font-size: 0.8em;
+    font-weight: 600;
+  }
+
+  .e-empty {
+    font-size: 0.85em;
+    color: #bbb;
+    padding: 8px 0;
+    text-align: center;
+  }
+` as React.FC<React.HTMLAttributes<HTMLDivElement>>;

--- a/shift-puzzle-bubly/shift-puzzle-libs/src/ui/index.ts
+++ b/shift-puzzle-bubly/shift-puzzle-libs/src/ui/index.ts
@@ -14,6 +14,12 @@ export { ReasonList } from './ReasonPanel/ReasonList.js';
 export { MemberCard } from './MemberCard/MemberCard.js';
 export { MemberForm } from './MemberCard/MemberForm.js';
 
+// F-4-1: メンバー詳細
+export { MemberDetailView } from './MemberDetail/MemberDetailView.js';
+
+// F-4-2: 役割充足状況
+export { RoleFulfillmentView } from './RoleFulfillment/RoleFulfillmentView.js';
+
 export type { GanttChartViewProps } from './GanttChart/GanttChartView.js';
 export type { ReasonInputDialogProps } from './GanttChart/ReasonInputDialog.js';
 export type { ReasonInputPanelProps } from './ReasonPanel/ReasonInputPanel.js';
@@ -21,3 +27,5 @@ export type { ReasonPopoverProps } from './ReasonPanel/ReasonPopover.js';
 export type { ReasonListProps } from './ReasonPanel/ReasonList.js';
 export type { MemberCardProps } from './MemberCard/MemberCard.js';
 export type { MemberFormProps } from './MemberCard/MemberForm.js';
+export type { MemberDetailViewProps } from './MemberDetail/MemberDetailView.js';
+export type { RoleFulfillmentViewProps } from './RoleFulfillment/RoleFulfillmentView.js';

--- a/shift-puzzle-bubly/shift-puzzle-libs/src/ui/index.ts
+++ b/shift-puzzle-bubly/shift-puzzle-libs/src/ui/index.ts
@@ -20,6 +20,10 @@ export { MemberDetailView } from './MemberDetail/MemberDetailView.js';
 // F-4-2: 役割充足状況
 export { RoleFulfillmentView } from './RoleFulfillment/RoleFulfillmentView.js';
 
+// F-7-1〜F-7-3: 評価サマリー
+export { ShiftPlanSummaryView } from './Summary/ShiftPlanSummaryView.js';
+export type { ShiftPlanSummaryViewProps, MemberWorkloadSummary, RoleFulfillmentSummary, SummaryAlert } from './Summary/ShiftPlanSummaryView.js';
+
 export type { GanttChartViewProps } from './GanttChart/GanttChartView.js';
 export type { ReasonInputDialogProps } from './GanttChart/ReasonInputDialog.js';
 export type { ReasonInputPanelProps } from './ReasonPanel/ReasonInputPanel.js';


### PR DESCRIPTION
## 概要

Issue #37 の実装。Bublysバブル型UIとshift-puzzleの統合機能を追加。

## 実装内容

### F-4-1: メンバーバブルタップ→詳細バブル展開
- `MemberDetailView` (UI層): スキル・参加可能時間帯・現在の配置状況を表示
- `MemberDetailFeature` (Feature層): Redux連携
- `MemberCard` に `onTap` props 追加（編集/削除ボタンはイベント伝播を防止）
- `MemberCollection` に `onMemberTap` props 追加
- `MemberListBubble` で `BubblesContext.openBubble` を使いメンバーカードタップで詳細バブルを開く

### F-4-2: 役割バブルタップ→充足状況バブル展開
- `RoleFulfillmentView` (UI層): 時間帯別の配置人数/必要人数・充足率バーを表示
- `RoleFulfillmentFeature` (Feature層): Redux連携
- 2つのバブルルート（イベントレベル・シフト案レベル）

### F-4-3: ポケット機能との統合
- `registerObjectType("Member")` で `type/member` ドラッグ型を登録
- メンバー詳細バブルの「📌 ポケットに追加」ボタンで `addPocketItem` をディスパッチ
- GanttChartView の既存ドロップ処理（`type/member` URLから memberId を抽出）と連携し、ポケットからガントチャートへのドラッグ配置が可能

## 追加バブルルート

| URL パターン | type | 役割 |
|---|---|---|
| `shift-puzzle/events/:eventId/roles/:roleId` | `shift-puzzle-role-detail` | 役割詳細・充足状況 |
| `shift-puzzle/events/:eventId/shift-plans/:planId/member/:memberId` | `shift-puzzle-member-detail` | メンバー行詳細 |
| `shift-puzzle/events/:eventId/shift-plans/:planId/role/:roleId` | `shift-puzzle-role-fulfillment` | 役割充足詳細 |

## バブル展開シナリオ（実装済み）

**シナリオA: メンバーカードから配置**
```
events/:id/members（メンバーカードタップ）
  → events/:id/shift-plans/:planId/member/:memberId（詳細確認）
  → ポケットに追加
  → ガントチャートにドロップ（配置完了）
```

## 完了条件チェック

- [x] メンバーカードタップで詳細バブルが展開される
- [x] 役割カードタップで充足状況バブルが展開される
- [x] メンバーをポケットに追加できる
- [x] ポケット内のメンバーをガントチャートにドラッグ配置できる
- [x] 全バブルルートが登録されナビゲーションできる

Closes #37