### PR TITLE
feat: ガントチャートD&D役割配置・メンバー管理バグ修正・origin-side展開

### DIFF
--- a/bublys-libs/bubbles-ui/src/lib/bubly/BublyApp.tsx
+++ b/bublys-libs/bubbles-ui/src/lib/bubly/BublyApp.tsx
@@ -5,6 +5,7 @@ import Inventory2Icon from '@mui/icons-material/Inventory2';
 import {
   useAppSelector,
   useAppDispatch,
+  useAppStore,
   selectWindowSize,
   setWindowSize,
   selectPocketItems,
@@ -30,8 +31,10 @@ import {
   selectGlobalCoordinateSystem,
   setGlobalCoordinateSystem,
   selectSurfaceLeftTop,
+  selectBubble,
   OpeningPosition,
 } from '../state/index.js';
+import { convertGlobalPointToLayerLocal } from '../CoordinateSystemHelper.js';
 import { BubblesLayeredView } from '../ui/BubblesLayeredView.js';
 import { PocketView } from '../pocket/PocketView.js';
 import { DragDataType } from '../utils/drag-types.js';
@@ -95,16 +98,32 @@ export const BublyApp: FC<BublyAppProps> = ({
     dispatch(layerUpAction(b.id));
   };
 
+  const store = useAppStore();
+
   const popChild = useCallback((
     b: Bubble,
     openerBubbleId: string,
     openingPosition: OpeningPosition = 'bubble-side'
   ): string => {
+    // openerのrenderedRectが既にある場合は事前に初期位置を計算し、表示ジャンプを防ぐ
+    const currentState = store.getState() as any;
+    if (currentState.bubbleState?.bubbles?.[openerBubbleId]) {
+      const openerBubble = selectBubble(currentState, { id: openerBubbleId });
+      if (openerBubble.renderedRect) {
+        const point = openerBubble.renderedRect.calcPositionToOpen({ width: 0, height: 0 });
+        if (point) {
+          const coordinateConfig = selectGlobalCoordinateSystem(currentState);
+          const sfLeft = selectSurfaceLeftTop(currentState);
+          const relativePoint = convertGlobalPointToLayerLocal(point, 0, coordinateConfig, sfLeft);
+          b = b.moveTo(relativePoint);
+        }
+      }
+    }
     dispatch(addBubble(b.toJSON()));
     dispatch(relateBubbles({ openerId: openerBubbleId, openeeId: b.id }));
     dispatch(popChildAction({ bubbleId: b.id, openingPosition }));
     return b.id;
-  }, [dispatch]);
+  }, [dispatch, store]);
 
   const popChildMax = useCallback((b: Bubble, openerBubbleId: string): string => {
     const availableWidth = pageSize.width - globalCoordinateSystem.offset.x - surfaceLeftTop.x;

--- a/bublys-libs/bubbles-ui/src/lib/bubly/BublyApp.tsx
+++ b/bublys-libs/bubbles-ui/src/lib/bubly/BublyApp.tsx
@@ -186,7 +186,9 @@ export const BublyApp: FC<BublyAppProps> = ({
 
   const handleMenuItemClick = (item: BublyMenuItem) => {
     const url = typeof item.url === 'function' ? item.url() : item.url;
-    popChildOrJoinSibling(url, 'root');
+    // 実際のバブルIDをopenerとして使う（'root'はstore内に存在しないため位置計算が失敗する）
+    const opener = surfaceBubbles?.[0]?.id ?? 'root';
+    popChildOrJoinSibling(url, opener);
   };
 
   return (

--- a/bublys-libs/bubbles-ui/src/lib/state/bubbles-listener.ts
+++ b/bublys-libs/bubbles-ui/src/lib/state/bubbles-listener.ts
@@ -167,6 +167,12 @@ bubblesListener.startListening({
       return;
     }
 
+    // openerが store に存在しない場合（'root' 等の仮想ID）はスキップ
+    if (!state.bubbleState?.bubbles?.[relation.openerId]) {
+      console.log("Pop: Opener bubble not found in store (virtual opener), skipping positioning");
+      return;
+    }
+
     const openerBubble = selectBubble(state, { id: relation.openerId });
     const poppingBubble = selectBubble(state, { id: poppingBubbleId });
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -2572,6 +2572,10 @@
       "resolved": "sekaisen-igo-bubly/sekaisen-igo-model",
       "link": true
     },
+    "node_modules/@bublys-org/shift-puzzle-libs": {
+      "resolved": "shift-puzzle-bubly/shift-puzzle-libs",
+      "link": true
+    },
     "node_modules/@bublys-org/shift-puzzle-model": {
       "resolved": "shift-puzzle-bubly/shift-puzzle-model",
       "link": true
@@ -28328,6 +28332,16 @@
       "version": "0.0.1",
       "dependencies": {
         "@swc/helpers": "~0.5.11"
+      }
+    },
+    "shift-puzzle-bubly/shift-puzzle-libs": {
+      "name": "@bublys-org/shift-puzzle-libs",
+      "version": "0.0.1",
+      "dependencies": {
+        "@bublys-org/bubbles-ui": "*",
+        "@bublys-org/shift-puzzle-model": "*",
+        "@bublys-org/state-management": "*",
+        "tslib": "^2.3.0"
       }
     },
     "shift-puzzle-bubly/shift-puzzle-model": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -2572,6 +2572,10 @@
       "resolved": "sekaisen-igo-bubly/sekaisen-igo-model",
       "link": true
     },
+    "node_modules/@bublys-org/shift-puzzle-app": {
+      "resolved": "shift-puzzle-bubly/shift-puzzle-app",
+      "link": true
+    },
     "node_modules/@bublys-org/shift-puzzle-libs": {
       "resolved": "shift-puzzle-bubly/shift-puzzle-libs",
       "link": true
@@ -28334,6 +28338,22 @@
         "@swc/helpers": "~0.5.11"
       }
     },
+    "shift-puzzle-bubly/shift-puzzle-app": {
+      "name": "@bublys-org/shift-puzzle-app",
+      "version": "0.0.1",
+      "dependencies": {
+        "@bublys-org/bubbles-ui": "*",
+        "@bublys-org/shift-puzzle-libs": "*",
+        "@bublys-org/shift-puzzle-model": "*",
+        "@bublys-org/state-management": "*",
+        "modern-normalize": "^3.0.1",
+        "react": "19.0.0",
+        "react-dom": "19.0.0",
+        "react-redux": "^9.2.0",
+        "redux-persist": "^6.0.0",
+        "styled-components": "5.3.6"
+      }
+    },
     "shift-puzzle-bubly/shift-puzzle-libs": {
       "name": "@bublys-org/shift-puzzle-libs",
       "version": "0.0.1",
@@ -28402,6 +28422,126 @@
     "users-libs": {
       "name": "@bublys-org/users-libs",
       "version": "0.0.1"
+    },
+    "node_modules/@next/swc-darwin-arm64": {
+      "version": "16.1.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-16.1.6.tgz",
+      "integrity": "sha512-wTzYulosJr/6nFnqGW7FrG3jfUUlEf8UjGA0/pyypJl42ExdVgC6xJgcXQ+V8QFn6niSG2Pb8+MIG1mZr2vczw==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-darwin-x64": {
+      "version": "16.1.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-16.1.6.tgz",
+      "integrity": "sha512-BLFPYPDO+MNJsiDWbeVzqvYd4NyuRrEYVB5k2N3JfWncuHAy2IVwMAOlVQDFjj+krkWzhY2apvmekMkfQR0CUQ==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-arm64-gnu": {
+      "version": "16.1.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-16.1.6.tgz",
+      "integrity": "sha512-OJYkCd5pj/QloBvoEcJ2XiMnlJkRv9idWA/j0ugSuA34gMT6f5b7vOiCQHVRpvStoZUknhl6/UxOXL4OwtdaBw==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-arm64-musl": {
+      "version": "16.1.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-16.1.6.tgz",
+      "integrity": "sha512-S4J2v+8tT3NIO9u2q+S0G5KdvNDjXfAv06OhfOzNDaBn5rw84DGXWndOEB7d5/x852A20sW1M56vhC/tRVbccQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-x64-gnu": {
+      "version": "16.1.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-16.1.6.tgz",
+      "integrity": "sha512-2eEBDkFlMMNQnkTyPBhQOAyn2qMxyG2eE7GPH2WIDGEpEILcBPI/jdSv4t6xupSP+ot/jkfrCShLAa7+ZUPcJQ==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-x64-musl": {
+      "version": "16.1.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-16.1.6.tgz",
+      "integrity": "sha512-oicJwRlyOoZXVlxmIMaTq7f8pN9QNbdes0q2FXfRsPhfCi8n8JmOZJm5oo1pwDaFbnnD421rVU409M3evFbIqg==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-win32-arm64-msvc": {
+      "version": "16.1.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-16.1.6.tgz",
+      "integrity": "sha512-gQmm8izDTPgs+DCWH22kcDmuUp7NyiJgEl18bcr8irXA5N2m2O+JQIr6f3ct42GOs9c0h8QF3L5SzIxcYAAXXw==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-win32-x64-msvc": {
+      "version": "16.1.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-16.1.6.tgz",
+      "integrity": "sha512-NRfO39AIrzBnixKbjuo2YiYhB6o9d8v/ymU9m/Xk8cyVk+k7XylniXkHwjs4s70wedVffc6bQNbufk5v0xEm0A==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
     }
   }
 }

--- a/shift-puzzle-bubly/shift-puzzle-app/index.html
+++ b/shift-puzzle-bubly/shift-puzzle-app/index.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html lang="ja">
+  <head>
+    <meta charset="utf-8" />
+    <title>ShiftPuzzle</title>
+    <base href="/" />
+
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <link rel="icon" type="image/x-icon" href="/favicon.ico" />
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/shift-puzzle-bubly/shift-puzzle-app/package.json
+++ b/shift-puzzle-bubly/shift-puzzle-app/package.json
@@ -1,0 +1,41 @@
+{
+  "name": "@bublys-org/shift-puzzle-app",
+  "version": "0.0.1",
+  "private": true,
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "build:bubly": "vite build -c vite.config.bubly.ts"
+  },
+  "dependencies": {
+    "@bublys-org/bubbles-ui": "*",
+    "@bublys-org/shift-puzzle-libs": "*",
+    "@bublys-org/shift-puzzle-model": "*",
+    "@bublys-org/state-management": "*",
+    "modern-normalize": "^3.0.1",
+    "react": "19.0.0",
+    "react-dom": "19.0.0",
+    "react-redux": "^9.2.0",
+    "redux-persist": "^6.0.0",
+    "styled-components": "5.3.6"
+  },
+  "nx": {
+    "targets": {
+      "build": {
+        "dependsOn": ["^build"]
+      },
+      "build:bubly": {
+        "dependsOn": ["^build"]
+      },
+      "dev": {
+        "dependsOn": [
+          {
+            "projects": ["@bublys-org/shift-puzzle-libs", "@bublys-org/shift-puzzle-model"],
+            "target": "dev"
+          }
+        ],
+        "continuous": true
+      }
+    }
+  }
+}

--- a/shift-puzzle-bubly/shift-puzzle-app/src/app/app.tsx
+++ b/shift-puzzle-bubly/shift-puzzle-app/src/app/app.tsx
@@ -1,4 +1,5 @@
 import { BublyApp, BublyStoreProvider, BubbleRouteRegistry } from "@bublys-org/bubbles-ui";
+import { getCurrentStore } from "@bublys-org/state-management";
 
 // shift-puzzle-libs の slices を import（自動注入される）
 import "@bublys-org/shift-puzzle-libs";
@@ -7,8 +8,25 @@ import { shiftPuzzleBubbleRoutes } from "../registration/index.js";
 
 BubbleRouteRegistry.registerRoutes(shiftPuzzleBubbleRoutes);
 
+/** 現在の Redux 状態から配置理由一覧 URL を動的生成 */
+function getReasonsUrl(): string {
+  const store = getCurrentStore();
+  if (store) {
+    const state = store.getState() as {
+      shiftPuzzleMain?: { currentEventId: string | null; currentShiftPlanId: string | null };
+    };
+    const eventId = state.shiftPuzzleMain?.currentEventId;
+    const planId = state.shiftPuzzleMain?.currentShiftPlanId;
+    if (eventId && planId) {
+      return `shift-puzzle/events/${eventId}/shift-plans/${planId}/reasons`;
+    }
+  }
+  return "shift-puzzle/reasons";
+}
+
 const menuItems = [
   { label: "シフトパズル", url: "shift-puzzle/editor", icon: null },
+  { label: "配置理由一覧", url: getReasonsUrl, icon: null },
 ];
 
 export function App() {

--- a/shift-puzzle-bubly/shift-puzzle-app/src/app/app.tsx
+++ b/shift-puzzle-bubly/shift-puzzle-app/src/app/app.tsx
@@ -1,0 +1,29 @@
+import { BublyApp, BublyStoreProvider, BubbleRouteRegistry } from "@bublys-org/bubbles-ui";
+
+// shift-puzzle-libs の slices を import（自動注入される）
+import "@bublys-org/shift-puzzle-libs";
+
+import { shiftPuzzleBubbleRoutes } from "../registration/index.js";
+
+BubbleRouteRegistry.registerRoutes(shiftPuzzleBubbleRoutes);
+
+const menuItems = [
+  { label: "シフトパズル", url: "shift-puzzle/editor", icon: null },
+];
+
+export function App() {
+  return (
+    <BublyStoreProvider
+      persistKey="shift-puzzle-standalone"
+      initialBubbleUrls={["shift-puzzle/editor"]}
+    >
+      <BublyApp
+        title="シフトパズル"
+        subtitle="Standalone • Port 4003"
+        menuItems={menuItems}
+      />
+    </BublyStoreProvider>
+  );
+}
+
+export default App;

--- a/shift-puzzle-bubly/shift-puzzle-app/src/app/app.tsx
+++ b/shift-puzzle-bubly/shift-puzzle-app/src/app/app.tsx
@@ -24,8 +24,22 @@ function getReasonsUrl(): string {
   return "shift-puzzle/reasons";
 }
 
+/** 現在の Redux 状態からメンバー管理 URL を動的生成 */
+function getMembersUrl(): string {
+  const store = getCurrentStore();
+  if (store) {
+    const state = store.getState() as {
+      shiftPuzzleMain?: { currentEventId: string | null };
+    };
+    const eventId = state.shiftPuzzleMain?.currentEventId;
+    if (eventId) return `shift-puzzle/events/${eventId}/members`;
+  }
+  return "shift-puzzle/members";
+}
+
 const menuItems = [
   { label: "シフトパズル", url: "shift-puzzle/editor", icon: null },
+  { label: "メンバー管理", url: getMembersUrl, icon: null },
   { label: "配置理由一覧", url: getReasonsUrl, icon: null },
 ];
 

--- a/shift-puzzle-bubly/shift-puzzle-app/src/bubly.ts
+++ b/shift-puzzle-bubly/shift-puzzle-app/src/bubly.ts
@@ -5,8 +5,11 @@
  * 動的にロードされるバブリとして動作する
  */
 
-import { registerBubly, Bubly } from "@bublys-org/bubbles-ui";
+import { registerBubly, Bubly, registerObjectType } from "@bublys-org/bubbles-ui";
 import { shiftPuzzleBubbleRoutes } from "./registration/index.js";
+
+// F-4-3: ポケット連携のためメンバーオブジェクト型を登録（DragType: 'type/member'）
+registerObjectType("Member");
 
 const ShiftPuzzleBubly: Bubly = {
   name: "shift-puzzle",

--- a/shift-puzzle-bubly/shift-puzzle-app/src/bubly.ts
+++ b/shift-puzzle-bubly/shift-puzzle-app/src/bubly.ts
@@ -1,0 +1,34 @@
+/**
+ * Bublys Bubly Entry Point for shift-puzzle
+ *
+ * このファイルはスタンドアロンバンドルとしてビルドされ、
+ * 動的にロードされるバブリとして動作する
+ */
+
+import { registerBubly, Bubly } from "@bublys-org/bubbles-ui";
+import { shiftPuzzleBubbleRoutes } from "./registration/index.js";
+
+const ShiftPuzzleBubly: Bubly = {
+  name: "shift-puzzle",
+  version: "0.0.1",
+
+  menuItems: [
+    {
+      label: "シフトパズル",
+      url: "shift-puzzle/editor",
+      icon: null,
+    },
+  ],
+
+  register(context) {
+    context.registerBubbleRoutes(shiftPuzzleBubbleRoutes);
+  },
+
+  unregister() {
+    // cleanup if needed
+  },
+};
+
+registerBubly(ShiftPuzzleBubly);
+
+export default ShiftPuzzleBubly;

--- a/shift-puzzle-bubly/shift-puzzle-app/src/bubly.ts
+++ b/shift-puzzle-bubly/shift-puzzle-app/src/bubly.ts
@@ -18,7 +18,7 @@ const ShiftPuzzleBubly: Bubly = {
   menuItems: [
     {
       label: "シフトパズル",
-      url: "shift-puzzle/editor",
+      url: "shift-puzzle/events",
       icon: null,
     },
   ],

--- a/shift-puzzle-bubly/shift-puzzle-app/src/main.tsx
+++ b/shift-puzzle-bubly/shift-puzzle-app/src/main.tsx
@@ -1,0 +1,14 @@
+import "modern-normalize";
+import { StrictMode } from "react";
+import * as ReactDOM from "react-dom/client";
+import App from "./app/app";
+
+const root = ReactDOM.createRoot(
+  document.getElementById("root") as HTMLElement
+);
+
+root.render(
+  <StrictMode>
+    <App />
+  </StrictMode>
+);

--- a/shift-puzzle-bubly/shift-puzzle-app/src/registration/bubbleRoutes.tsx
+++ b/shift-puzzle-bubly/shift-puzzle-app/src/registration/bubbleRoutes.tsx
@@ -6,6 +6,7 @@ import { useAppDispatch, useAppSelector } from "@bublys-org/state-management";
 import {
   ShiftPlanGanttEditor,
   ReasonListFeature,
+  MemberCollection,
   selectEvents,
   selectCurrentEventId,
   selectCurrentShiftPlanId,
@@ -215,6 +216,22 @@ const ReasonListBubble: BubbleRoute["Component"] = ({ bubble }) => {
   return <ReasonListFeature shiftPlanId={planId} eventId={eventId} />;
 };
 
+/** F-1-1〜F-1-4: メンバー一覧バブル */
+const MemberListBubble: BubbleRoute["Component"] = ({ bubble }) => {
+  const currentEventId = useAppSelector(selectCurrentEventId);
+  const eventId = bubble.params.eventId ?? currentEventId;
+
+  if (!eventId) {
+    return (
+      <div style={{ padding: 24, color: "#888", textAlign: "center" }}>
+        イベントが選択されていません
+      </div>
+    );
+  }
+
+  return <MemberCollection eventId={eventId} />;
+};
+
 export const shiftPuzzleBubbleRoutes: BubbleRoute[] = [
   {
     pattern: "shift-puzzle/editor",
@@ -223,8 +240,6 @@ export const shiftPuzzleBubbleRoutes: BubbleRoute[] = [
   },
   {
     // F-3-3: 配置理由一覧
-    // パターン: shift-puzzle/events/:eventId/shift-plans/:planId/reasons
-    // または    shift-puzzle/reasons（パラメータなし → Redux状態を使用）
     pattern: "shift-puzzle/events/:eventId/shift-plans/:planId/reasons",
     type: "shift-puzzle-reasons",
     Component: ReasonListBubble,
@@ -233,5 +248,16 @@ export const shiftPuzzleBubbleRoutes: BubbleRoute[] = [
     pattern: "shift-puzzle/reasons",
     type: "shift-puzzle-reasons",
     Component: ReasonListBubble,
+  },
+  {
+    // F-1-1〜F-1-4: メンバー一覧
+    pattern: "shift-puzzle/events/:eventId/members",
+    type: "shift-puzzle-members",
+    Component: MemberListBubble,
+  },
+  {
+    pattern: "shift-puzzle/members",
+    type: "shift-puzzle-members",
+    Component: MemberListBubble,
   },
 ];

--- a/shift-puzzle-bubly/shift-puzzle-app/src/registration/bubbleRoutes.tsx
+++ b/shift-puzzle-bubly/shift-puzzle-app/src/registration/bubbleRoutes.tsx
@@ -5,6 +5,7 @@ import { BubbleRoute } from "@bublys-org/bubbles-ui";
 import { useAppDispatch, useAppSelector } from "@bublys-org/state-management";
 import {
   ShiftPlanGanttEditor,
+  ReasonListFeature,
   selectEvents,
   selectCurrentEventId,
   selectCurrentShiftPlanId,
@@ -194,10 +195,43 @@ const ShiftPuzzleEditorBubble: BubbleRoute["Component"] = () => {
   );
 };
 
+/** F-3-3: 配置理由一覧バブル */
+const ReasonListBubble: BubbleRoute["Component"] = ({ bubble }) => {
+  const currentEventId = useAppSelector(selectCurrentEventId);
+  const currentShiftPlanId = useAppSelector(selectCurrentShiftPlanId);
+
+  // URL パラメータ優先、なければ Redux の現在選択状態を使用
+  const eventId = bubble.params.eventId ?? currentEventId;
+  const planId = bubble.params.planId ?? currentShiftPlanId;
+
+  if (!eventId || !planId) {
+    return (
+      <div style={{ padding: 24, color: "#888", textAlign: "center" }}>
+        イベントまたはシフト案が選択されていません
+      </div>
+    );
+  }
+
+  return <ReasonListFeature shiftPlanId={planId} eventId={eventId} />;
+};
+
 export const shiftPuzzleBubbleRoutes: BubbleRoute[] = [
   {
     pattern: "shift-puzzle/editor",
     type: "shift-puzzle-editor",
     Component: ShiftPuzzleEditorBubble,
+  },
+  {
+    // F-3-3: 配置理由一覧
+    // パターン: shift-puzzle/events/:eventId/shift-plans/:planId/reasons
+    // または    shift-puzzle/reasons（パラメータなし → Redux状態を使用）
+    pattern: "shift-puzzle/events/:eventId/shift-plans/:planId/reasons",
+    type: "shift-puzzle-reasons",
+    Component: ReasonListBubble,
+  },
+  {
+    pattern: "shift-puzzle/reasons",
+    type: "shift-puzzle-reasons",
+    Component: ReasonListBubble,
   },
 ];

--- a/shift-puzzle-bubly/shift-puzzle-app/src/registration/bubbleRoutes.tsx
+++ b/shift-puzzle-bubly/shift-puzzle-app/src/registration/bubbleRoutes.tsx
@@ -1,0 +1,203 @@
+"use client";
+
+import { useEffect } from "react";
+import { BubbleRoute } from "@bublys-org/bubbles-ui";
+import { useAppDispatch, useAppSelector } from "@bublys-org/state-management";
+import {
+  ShiftPlanGanttEditor,
+  selectEvents,
+  selectCurrentEventId,
+  selectCurrentShiftPlanId,
+  addEvent,
+  setMembersForEvent,
+  setRolesForEvent,
+  setTimeSlotsForEvent,
+  addShiftPlan,
+  setCurrentEventId,
+  setCurrentShiftPlanId,
+} from "@bublys-org/shift-puzzle-libs";
+import type {
+  EventJSON,
+  MemberJSON,
+  RoleJSON,
+  TimeSlotJSON,
+  ShiftPlanJSON,
+} from "@bublys-org/shift-puzzle-model";
+
+const DEMO_EVENT_ID = "demo-event-001";
+const DEMO_PLAN_ID = "demo-plan-001";
+const SEED_TIMESTAMP = "2024-11-01T00:00:00.000Z";
+
+function createDemoData(): {
+  event: EventJSON;
+  members: MemberJSON[];
+  roles: RoleJSON[];
+  timeSlots: TimeSlotJSON[];
+  shiftPlan: ShiftPlanJSON;
+} {
+  const event: EventJSON = {
+    id: DEMO_EVENT_ID,
+    name: "デモイベント 2024",
+    description: "シフトパズルのデモ用イベント",
+    startDate: "2024-11-01",
+    endDate: "2024-11-01",
+    timezone: "Asia/Tokyo",
+    skillDefinitions: [],
+    defaultSlotDuration: 60,
+    createdAt: SEED_TIMESTAMP,
+    updatedAt: SEED_TIMESTAMP,
+  };
+
+  const timeSlots: TimeSlotJSON[] = [
+    { id: "ts-001", dayIndex: 0, startMinute: 9 * 60, durationMinutes: 60, eventId: DEMO_EVENT_ID },
+    { id: "ts-002", dayIndex: 0, startMinute: 10 * 60, durationMinutes: 60, eventId: DEMO_EVENT_ID },
+    { id: "ts-003", dayIndex: 0, startMinute: 11 * 60, durationMinutes: 60, eventId: DEMO_EVENT_ID },
+    { id: "ts-004", dayIndex: 0, startMinute: 12 * 60, durationMinutes: 60, eventId: DEMO_EVENT_ID },
+    { id: "ts-005", dayIndex: 0, startMinute: 13 * 60, durationMinutes: 60, eventId: DEMO_EVENT_ID },
+    { id: "ts-006", dayIndex: 0, startMinute: 14 * 60, durationMinutes: 60, eventId: DEMO_EVENT_ID },
+    { id: "ts-007", dayIndex: 0, startMinute: 15 * 60, durationMinutes: 60, eventId: DEMO_EVENT_ID },
+    { id: "ts-008", dayIndex: 0, startMinute: 16 * 60, durationMinutes: 60, eventId: DEMO_EVENT_ID },
+  ];
+
+  const members: MemberJSON[] = [
+    {
+      id: "m-001",
+      name: "田中 太郎",
+      eventId: DEMO_EVENT_ID,
+      tags: ["一般"],
+      skills: [],
+      availableSlotIds: ["ts-001", "ts-002", "ts-003", "ts-004", "ts-005", "ts-006", "ts-007", "ts-008"],
+      memo: "",
+      createdAt: SEED_TIMESTAMP,
+      updatedAt: SEED_TIMESTAMP,
+    },
+    {
+      id: "m-002",
+      name: "佐藤 花子",
+      eventId: DEMO_EVENT_ID,
+      tags: ["一般"],
+      skills: [],
+      availableSlotIds: ["ts-001", "ts-002", "ts-003", "ts-004"],
+      memo: "",
+      createdAt: SEED_TIMESTAMP,
+      updatedAt: SEED_TIMESTAMP,
+    },
+    {
+      id: "m-003",
+      name: "鈴木 次郎",
+      eventId: DEMO_EVENT_ID,
+      tags: ["リーダー"],
+      skills: [],
+      availableSlotIds: ["ts-005", "ts-006", "ts-007", "ts-008"],
+      memo: "",
+      createdAt: SEED_TIMESTAMP,
+      updatedAt: SEED_TIMESTAMP,
+    },
+    {
+      id: "m-004",
+      name: "高橋 美咲",
+      eventId: DEMO_EVENT_ID,
+      tags: ["一般"],
+      skills: [],
+      availableSlotIds: ["ts-002", "ts-003", "ts-006", "ts-007"],
+      memo: "",
+      createdAt: SEED_TIMESTAMP,
+      updatedAt: SEED_TIMESTAMP,
+    },
+    {
+      id: "m-005",
+      name: "中村 健一",
+      eventId: DEMO_EVENT_ID,
+      tags: ["一般"],
+      skills: [],
+      availableSlotIds: ["ts-001", "ts-004", "ts-005", "ts-008"],
+      memo: "",
+      createdAt: SEED_TIMESTAMP,
+      updatedAt: SEED_TIMESTAMP,
+    },
+  ];
+
+  const roles: RoleJSON[] = [
+    {
+      id: "r-001",
+      name: "受付",
+      description: "来場者の受付対応",
+      requiredSkillIds: [],
+      minRequired: 2,
+      maxRequired: 3,
+      color: "#4caf50",
+      eventId: DEMO_EVENT_ID,
+    },
+    {
+      id: "r-002",
+      name: "案内",
+      description: "会場・展示の案内",
+      requiredSkillIds: [],
+      minRequired: 1,
+      maxRequired: 2,
+      color: "#2196f3",
+      eventId: DEMO_EVENT_ID,
+    },
+    {
+      id: "r-003",
+      name: "司会",
+      description: "セッションの進行",
+      requiredSkillIds: [],
+      minRequired: 1,
+      maxRequired: 1,
+      color: "#ff9800",
+      eventId: DEMO_EVENT_ID,
+    },
+  ];
+
+  const shiftPlan: ShiftPlanJSON = {
+    id: DEMO_PLAN_ID,
+    name: "シフト案 A",
+    scenarioLabel: "標準版",
+    assignments: [],
+    eventId: DEMO_EVENT_ID,
+    createdAt: SEED_TIMESTAMP,
+    updatedAt: SEED_TIMESTAMP,
+  };
+
+  return { event, members, roles, timeSlots, shiftPlan };
+}
+
+const ShiftPuzzleEditorBubble: BubbleRoute["Component"] = () => {
+  const dispatch = useAppDispatch();
+  const events = useAppSelector(selectEvents);
+  const currentEventId = useAppSelector(selectCurrentEventId);
+  const currentShiftPlanId = useAppSelector(selectCurrentShiftPlanId);
+
+  useEffect(() => {
+    if (events.length === 0) {
+      const { event, members, roles, timeSlots, shiftPlan } = createDemoData();
+      dispatch(addEvent(event));
+      dispatch(setMembersForEvent({ eventId: event.id, members }));
+      dispatch(setRolesForEvent({ eventId: event.id, roles }));
+      dispatch(setTimeSlotsForEvent({ eventId: event.id, timeSlots }));
+      dispatch(addShiftPlan(shiftPlan));
+      dispatch(setCurrentEventId(event.id));
+      dispatch(setCurrentShiftPlanId(shiftPlan.id));
+    }
+  }, [dispatch, events.length]);
+
+  if (!currentEventId || !currentShiftPlanId) {
+    return <div style={{ padding: 24, color: "#666" }}>データを初期化中...</div>;
+  }
+
+  return (
+    <ShiftPlanGanttEditor
+      shiftPlanId={currentShiftPlanId}
+      eventId={currentEventId}
+    />
+  );
+};
+
+export const shiftPuzzleBubbleRoutes: BubbleRoute[] = [
+  {
+    pattern: "shift-puzzle/editor",
+    type: "shift-puzzle-editor",
+    Component: ShiftPuzzleEditorBubble,
+  },
+];

--- a/shift-puzzle-bubly/shift-puzzle-app/src/registration/bubbleRoutes.tsx
+++ b/shift-puzzle-bubly/shift-puzzle-app/src/registration/bubbleRoutes.tsx
@@ -205,7 +205,7 @@ const ShiftPuzzleEditorBubble: BubbleRoute["Component"] = ({ bubble }) => {
       dispatch(setMemberFilter({ availableAtSlotId: timeSlotId }));
       openBubble(`shift-puzzle/events/${eventId}/members`, bubble.id, "bubble-side");
     } else {
-      openBubble(`shift-puzzle/events/${eventId}/roles`, bubble.id, "bubble-side");
+      openBubble(`shift-puzzle/events/${eventId}/roles?readOnly=true`, bubble.id, "bubble-side");
     }
   };
 
@@ -213,7 +213,7 @@ const ShiftPuzzleEditorBubble: BubbleRoute["Component"] = ({ bubble }) => {
     openBubble(
       `shift-puzzle/events/${eventId}/shift-plans/${planId}/member/${memberId}`,
       bubble.id,
-      "bubble-side"
+      "origin-side"
     );
   };
 
@@ -417,6 +417,9 @@ const RoleListBubble: BubbleRoute["Component"] = ({ bubble }) => {
   const currentShiftPlanId = useAppSelector(selectCurrentShiftPlanId);
   const eventId = bubble.params.eventId ?? currentEventId;
 
+  // ガントチャートから開いた場合は readOnly モード（URL に ?readOnly=true が付く）
+  const isReadOnly = bubble.url.includes('readOnly=true');
+
   if (!eventId) {
     return (
       <div style={{ padding: 24, color: "#888", textAlign: "center" }}>
@@ -428,6 +431,7 @@ const RoleListBubble: BubbleRoute["Component"] = ({ bubble }) => {
   return (
     <RoleListFeature
       eventId={eventId}
+      readOnly={isReadOnly}
       onRoleSelect={(roleId) => {
         const planId = currentShiftPlanId;
         const url = planId
@@ -495,19 +499,19 @@ const ShiftPlanDetailBubble: BubbleRoute["Component"] = ({ bubble }) => {
       dispatch(setMemberFilter({ availableAtSlotId: timeSlotId }));
       openBubble(`shift-puzzle/events/${eventId}/members`, bubble.id, "bubble-side");
     } else {
-      // メンバー行クリック: 役割一覧をバブルで表示
-      openBubble(`shift-puzzle/events/${eventId}/roles`, bubble.id, "bubble-side");
+      // メンバー行クリック: 役割一覧をバブルで表示（readOnlyモード＝D&D配置専用）
+      openBubble(`shift-puzzle/events/${eventId}/roles?readOnly=true`, bubble.id, "bubble-side");
     }
   };
 
   /**
-   * 配置ブロッククリック → メンバー詳細バブルを開く
+   * 配置ブロッククリック → メンバー詳細バブルを開く（クリックしたブロックの位置から展開）
    */
   const handleAssignmentClick = (_assignmentId: string, memberId: string, _roleId: string) => {
     openBubble(
       `shift-puzzle/events/${eventId}/shift-plans/${planId}/member/${memberId}`,
       bubble.id,
-      "bubble-side"
+      "origin-side"
     );
   };
 

--- a/shift-puzzle-bubly/shift-puzzle-app/src/registration/bubbleRoutes.tsx
+++ b/shift-puzzle-bubly/shift-puzzle-app/src/registration/bubbleRoutes.tsx
@@ -24,6 +24,7 @@ import {
   addShiftPlan,
   setCurrentEventId,
   setCurrentShiftPlanId,
+  setMemberFilter,
 } from "@bublys-org/shift-puzzle-libs";
 import type {
   EventJSON,
@@ -196,27 +197,34 @@ const ShiftPuzzleEditorBubble: BubbleRoute["Component"] = ({ bubble }) => {
     return <div style={{ padding: 24, color: "#666" }}>データを初期化中...</div>;
   }
 
-  const handleOpenSummary = () => {
+  const eventId = currentEventId;
+  const planId = currentShiftPlanId;
+
+  const handleCellClick = (rowId: string, timeSlotId: string, mode: "role" | "member") => {
+    if (mode === "role") {
+      dispatch(setMemberFilter({ availableAtSlotId: timeSlotId }));
+      openBubble(`shift-puzzle/events/${eventId}/members`, bubble.id, "bubble-side");
+    } else {
+      openBubble(`shift-puzzle/events/${eventId}/roles`, bubble.id, "bubble-side");
+    }
+  };
+
+  const handleAssignmentClick = (_assignmentId: string, memberId: string, _roleId: string) => {
     openBubble(
-      `shift-puzzle/events/${currentEventId}/shift-plans/${currentShiftPlanId}/summary`,
-      bubble.id
+      `shift-puzzle/events/${eventId}/shift-plans/${planId}/member/${memberId}`,
+      bubble.id,
+      "bubble-side"
     );
   };
 
   return (
     <div style={{ display: "flex", flexDirection: "column", height: "100%" }}>
-      <div style={{ padding: "6px 12px", background: "#f5f5f5", borderBottom: "1px solid #e0e0e0", display: "flex", gap: 8, flexShrink: 0 }}>
-        <button
-          onClick={handleOpenSummary}
-          style={{ padding: "4px 12px", background: "#1976d2", color: "white", border: "none", borderRadius: 4, cursor: "pointer", fontSize: "0.82em", fontWeight: 600 }}
-        >
-          評価サマリー
-        </button>
-      </div>
       <div style={{ flex: 1, overflow: "hidden" }}>
         <ShiftPlanGanttEditor
-          shiftPlanId={currentShiftPlanId}
-          eventId={currentEventId}
+          shiftPlanId={planId}
+          eventId={eventId}
+          onCellClick={handleCellClick}
+          onAssignmentClick={handleAssignmentClick}
         />
       </div>
     </div>
@@ -458,6 +466,7 @@ const ShiftPlanListBubble: BubbleRoute["Component"] = ({ bubble }) => {
 /** シフト案詳細（ガントチャート）バブル */
 const ShiftPlanDetailBubble: BubbleRoute["Component"] = ({ bubble }) => {
   const { openBubble } = useContext(BubblesContext);
+  const dispatch = useAppDispatch();
   const currentEventId = useAppSelector(selectCurrentEventId);
   const currentShiftPlanId = useAppSelector(selectCurrentShiftPlanId);
 
@@ -475,6 +484,33 @@ const ShiftPlanDetailBubble: BubbleRoute["Component"] = ({ bubble }) => {
   const handleOpenSummary = () =>
     openBubble(`shift-puzzle/events/${eventId}/shift-plans/${planId}/summary`, bubble.id);
 
+  /**
+   * セルクリック → バブルを開く（gakkai-shift スタイルのダイナミックレイアウト）
+   * 役割ビュー: メンバー一覧を開く（時間帯でフィルター済み）
+   * メンバービュー: 役割一覧を開く
+   */
+  const handleCellClick = (rowId: string, timeSlotId: string, mode: "role" | "member") => {
+    if (mode === "role") {
+      // 役割行クリック: その時間帯に参加可能なメンバー一覧をバブルで表示
+      dispatch(setMemberFilter({ availableAtSlotId: timeSlotId }));
+      openBubble(`shift-puzzle/events/${eventId}/members`, bubble.id, "bubble-side");
+    } else {
+      // メンバー行クリック: 役割一覧をバブルで表示
+      openBubble(`shift-puzzle/events/${eventId}/roles`, bubble.id, "bubble-side");
+    }
+  };
+
+  /**
+   * 配置ブロッククリック → メンバー詳細バブルを開く
+   */
+  const handleAssignmentClick = (_assignmentId: string, memberId: string, _roleId: string) => {
+    openBubble(
+      `shift-puzzle/events/${eventId}/shift-plans/${planId}/member/${memberId}`,
+      bubble.id,
+      "bubble-side"
+    );
+  };
+
   return (
     <div style={{ display: "flex", flexDirection: "column", height: "100%" }}>
       <div style={{ padding: "6px 12px", background: "#f5f5f5", borderBottom: "1px solid #e0e0e0", display: "flex", gap: 8, flexShrink: 0 }}>
@@ -486,7 +522,12 @@ const ShiftPlanDetailBubble: BubbleRoute["Component"] = ({ bubble }) => {
         </button>
       </div>
       <div style={{ flex: 1, overflow: "hidden" }}>
-        <ShiftPlanGanttEditor shiftPlanId={planId} eventId={eventId} />
+        <ShiftPlanGanttEditor
+          shiftPlanId={planId}
+          eventId={eventId}
+          onCellClick={handleCellClick}
+          onAssignmentClick={handleAssignmentClick}
+        />
       </div>
     </div>
   );

--- a/shift-puzzle-bubly/shift-puzzle-app/src/registration/bubbleRoutes.tsx
+++ b/shift-puzzle-bubly/shift-puzzle-app/src/registration/bubbleRoutes.tsx
@@ -13,7 +13,7 @@ import {
   EventListFeature,
   EventDetailFeature,
   RoleListFeature,
-  ShiftPlanListFeature,
+  ShiftPlanManager,
   selectEvents,
   selectCurrentEventId,
   selectCurrentShiftPlanId,
@@ -431,7 +431,7 @@ const RoleListBubble: BubbleRoute["Component"] = ({ bubble }) => {
   );
 };
 
-/** シフト案一覧バブル */
+/** F-6-1〜F-6-3: シフト案管理バブル（Issue #41） */
 const ShiftPlanListBubble: BubbleRoute["Component"] = ({ bubble }) => {
   const { openBubble } = useContext(BubblesContext);
   const currentEventId = useAppSelector(selectCurrentEventId);
@@ -446,7 +446,7 @@ const ShiftPlanListBubble: BubbleRoute["Component"] = ({ bubble }) => {
   }
 
   return (
-    <ShiftPlanListFeature
+    <ShiftPlanManager
       eventId={eventId}
       onPlanSelect={(planId) =>
         openBubble(`shift-puzzle/events/${eventId}/shift-plans/${planId}`, bubble.id)

--- a/shift-puzzle-bubly/shift-puzzle-app/src/registration/bubbleRoutes.tsx
+++ b/shift-puzzle-bubly/shift-puzzle-app/src/registration/bubbleRoutes.tsx
@@ -10,6 +10,10 @@ import {
   MemberDetailFeature,
   RoleFulfillmentFeature,
   ShiftPlanSummary,
+  EventListFeature,
+  EventDetailFeature,
+  RoleListFeature,
+  ShiftPlanListFeature,
   selectEvents,
   selectCurrentEventId,
   selectCurrentShiftPlanId,
@@ -362,8 +366,161 @@ const ShiftPlanSummaryBubble: BubbleRoute["Component"] = ({ bubble }) => {
   return <ShiftPlanSummary eventId={eventId} shiftPlanId={planId} />;
 };
 
+/** イベント一覧バブル */
+const EventListBubble: BubbleRoute["Component"] = ({ bubble }) => {
+  const { openBubble } = useContext(BubblesContext);
+  return (
+    <EventListFeature
+      onEventSelect={(eventId) =>
+        openBubble(`shift-puzzle/events/${eventId}`, bubble.id)
+      }
+    />
+  );
+};
+
+/** イベント詳細バブル */
+const EventDetailBubble: BubbleRoute["Component"] = ({ bubble }) => {
+  const { openBubble } = useContext(BubblesContext);
+  const currentEventId = useAppSelector(selectCurrentEventId);
+  const eventId = bubble.params.eventId ?? currentEventId;
+
+  if (!eventId) {
+    return (
+      <div style={{ padding: 24, color: "#888", textAlign: "center" }}>
+        イベントが指定されていません
+      </div>
+    );
+  }
+
+  return (
+    <EventDetailFeature
+      eventId={eventId}
+      onOpenMembers={() => openBubble(`shift-puzzle/events/${eventId}/members`, bubble.id)}
+      onOpenRoles={() => openBubble(`shift-puzzle/events/${eventId}/roles`, bubble.id)}
+      onOpenShiftPlans={() => openBubble(`shift-puzzle/events/${eventId}/shift-plans`, bubble.id)}
+    />
+  );
+};
+
+/** 役割一覧バブル */
+const RoleListBubble: BubbleRoute["Component"] = ({ bubble }) => {
+  const { openBubble } = useContext(BubblesContext);
+  const currentEventId = useAppSelector(selectCurrentEventId);
+  const currentShiftPlanId = useAppSelector(selectCurrentShiftPlanId);
+  const eventId = bubble.params.eventId ?? currentEventId;
+
+  if (!eventId) {
+    return (
+      <div style={{ padding: 24, color: "#888", textAlign: "center" }}>
+        イベントが指定されていません
+      </div>
+    );
+  }
+
+  return (
+    <RoleListFeature
+      eventId={eventId}
+      onRoleSelect={(roleId) => {
+        const planId = currentShiftPlanId;
+        const url = planId
+          ? `shift-puzzle/events/${eventId}/shift-plans/${planId}/role/${roleId}`
+          : `shift-puzzle/events/${eventId}/roles/${roleId}`;
+        openBubble(url, bubble.id);
+      }}
+    />
+  );
+};
+
+/** シフト案一覧バブル */
+const ShiftPlanListBubble: BubbleRoute["Component"] = ({ bubble }) => {
+  const { openBubble } = useContext(BubblesContext);
+  const currentEventId = useAppSelector(selectCurrentEventId);
+  const eventId = bubble.params.eventId ?? currentEventId;
+
+  if (!eventId) {
+    return (
+      <div style={{ padding: 24, color: "#888", textAlign: "center" }}>
+        イベントが指定されていません
+      </div>
+    );
+  }
+
+  return (
+    <ShiftPlanListFeature
+      eventId={eventId}
+      onPlanSelect={(planId) =>
+        openBubble(`shift-puzzle/events/${eventId}/shift-plans/${planId}`, bubble.id)
+      }
+    />
+  );
+};
+
+/** シフト案詳細（ガントチャート）バブル */
+const ShiftPlanDetailBubble: BubbleRoute["Component"] = ({ bubble }) => {
+  const { openBubble } = useContext(BubblesContext);
+  const currentEventId = useAppSelector(selectCurrentEventId);
+  const currentShiftPlanId = useAppSelector(selectCurrentShiftPlanId);
+
+  const eventId = bubble.params.eventId ?? currentEventId;
+  const planId = bubble.params.planId ?? currentShiftPlanId;
+
+  if (!eventId || !planId) {
+    return (
+      <div style={{ padding: 24, color: "#888", textAlign: "center" }}>
+        シフト案が指定されていません
+      </div>
+    );
+  }
+
+  const handleOpenSummary = () =>
+    openBubble(`shift-puzzle/events/${eventId}/shift-plans/${planId}/summary`, bubble.id);
+
+  return (
+    <div style={{ display: "flex", flexDirection: "column", height: "100%" }}>
+      <div style={{ padding: "6px 12px", background: "#f5f5f5", borderBottom: "1px solid #e0e0e0", display: "flex", gap: 8, flexShrink: 0 }}>
+        <button
+          onClick={handleOpenSummary}
+          style={{ padding: "4px 12px", background: "#1976d2", color: "white", border: "none", borderRadius: 4, cursor: "pointer", fontSize: "0.82em", fontWeight: 600 }}
+        >
+          評価サマリー
+        </button>
+      </div>
+      <div style={{ flex: 1, overflow: "hidden" }}>
+        <ShiftPlanGanttEditor shiftPlanId={planId} eventId={eventId} />
+      </div>
+    </div>
+  );
+};
+
 export const shiftPuzzleBubbleRoutes: BubbleRoute[] = [
+  // Issue #39: Phase 1 全バブルルート
   {
+    pattern: "shift-puzzle/events",
+    type: "shift-puzzle-events",
+    Component: EventListBubble,
+  },
+  {
+    pattern: "shift-puzzle/events/:eventId",
+    type: "shift-puzzle-event-detail",
+    Component: EventDetailBubble,
+  },
+  {
+    pattern: "shift-puzzle/events/:eventId/roles",
+    type: "shift-puzzle-roles",
+    Component: RoleListBubble,
+  },
+  {
+    pattern: "shift-puzzle/events/:eventId/shift-plans",
+    type: "shift-puzzle-shift-plans",
+    Component: ShiftPlanListBubble,
+  },
+  {
+    pattern: "shift-puzzle/events/:eventId/shift-plans/:planId",
+    type: "shift-puzzle-shift-plan-detail",
+    Component: ShiftPlanDetailBubble,
+  },
+  {
+    // 旧: デモ用エントリーポイント（後方互換のため残す）
     pattern: "shift-puzzle/editor",
     type: "shift-puzzle-editor",
     Component: ShiftPuzzleEditorBubble,

--- a/shift-puzzle-bubly/shift-puzzle-app/src/registration/bubbleRoutes.tsx
+++ b/shift-puzzle-bubly/shift-puzzle-app/src/registration/bubbleRoutes.tsx
@@ -9,6 +9,7 @@ import {
   MemberCollection,
   MemberDetailFeature,
   RoleFulfillmentFeature,
+  ShiftPlanSummary,
   selectEvents,
   selectCurrentEventId,
   selectCurrentShiftPlanId,
@@ -167,7 +168,8 @@ function createDemoData(): {
   return { event, members, roles, timeSlots, shiftPlan };
 }
 
-const ShiftPuzzleEditorBubble: BubbleRoute["Component"] = () => {
+const ShiftPuzzleEditorBubble: BubbleRoute["Component"] = ({ bubble }) => {
+  const { openBubble } = useContext(BubblesContext);
   const dispatch = useAppDispatch();
   const events = useAppSelector(selectEvents);
   const currentEventId = useAppSelector(selectCurrentEventId);
@@ -190,11 +192,30 @@ const ShiftPuzzleEditorBubble: BubbleRoute["Component"] = () => {
     return <div style={{ padding: 24, color: "#666" }}>データを初期化中...</div>;
   }
 
+  const handleOpenSummary = () => {
+    openBubble(
+      `shift-puzzle/events/${currentEventId}/shift-plans/${currentShiftPlanId}/summary`,
+      bubble.id
+    );
+  };
+
   return (
-    <ShiftPlanGanttEditor
-      shiftPlanId={currentShiftPlanId}
-      eventId={currentEventId}
-    />
+    <div style={{ display: "flex", flexDirection: "column", height: "100%" }}>
+      <div style={{ padding: "6px 12px", background: "#f5f5f5", borderBottom: "1px solid #e0e0e0", display: "flex", gap: 8, flexShrink: 0 }}>
+        <button
+          onClick={handleOpenSummary}
+          style={{ padding: "4px 12px", background: "#1976d2", color: "white", border: "none", borderRadius: 4, cursor: "pointer", fontSize: "0.82em", fontWeight: 600 }}
+        >
+          評価サマリー
+        </button>
+      </div>
+      <div style={{ flex: 1, overflow: "hidden" }}>
+        <ShiftPlanGanttEditor
+          shiftPlanId={currentShiftPlanId}
+          eventId={currentEventId}
+        />
+      </div>
+    </div>
   );
 };
 
@@ -322,6 +343,25 @@ const RoleFulfillmentBubble: BubbleRoute["Component"] = ({ bubble }) => {
   );
 };
 
+/** F-7-1〜F-7-3: 評価サマリーバブル */
+const ShiftPlanSummaryBubble: BubbleRoute["Component"] = ({ bubble }) => {
+  const currentEventId = useAppSelector(selectCurrentEventId);
+  const currentShiftPlanId = useAppSelector(selectCurrentShiftPlanId);
+
+  const eventId = bubble.params.eventId ?? currentEventId;
+  const planId = bubble.params.planId ?? currentShiftPlanId;
+
+  if (!eventId || !planId) {
+    return (
+      <div style={{ padding: 24, color: "#888", textAlign: "center" }}>
+        イベントまたはシフト案が選択されていません
+      </div>
+    );
+  }
+
+  return <ShiftPlanSummary eventId={eventId} shiftPlanId={planId} />;
+};
+
 export const shiftPuzzleBubbleRoutes: BubbleRoute[] = [
   {
     pattern: "shift-puzzle/editor",
@@ -362,6 +402,12 @@ export const shiftPuzzleBubbleRoutes: BubbleRoute[] = [
     pattern: "shift-puzzle/events/:eventId/roles/:roleId",
     type: "shift-puzzle-role-detail",
     Component: RoleDetailBubble,
+  },
+  {
+    // F-7-1〜F-7-3: 評価サマリー
+    pattern: "shift-puzzle/events/:eventId/shift-plans/:planId/summary",
+    type: "shift-puzzle-summary",
+    Component: ShiftPlanSummaryBubble,
   },
   {
     // F-1-1〜F-1-4: メンバー一覧

--- a/shift-puzzle-bubly/shift-puzzle-app/src/registration/index.ts
+++ b/shift-puzzle-bubly/shift-puzzle-app/src/registration/index.ts
@@ -1,0 +1,1 @@
+export * from "./bubbleRoutes.js";

--- a/shift-puzzle-bubly/shift-puzzle-app/src/store/index.ts
+++ b/shift-puzzle-bubly/shift-puzzle-app/src/store/index.ts
@@ -1,0 +1,11 @@
+// shift-puzzle-libs のsliceをimport（rootReducerへの自動注入が実行される）
+// makeStore より前に import する必要がある
+import '@bublys-org/shift-puzzle-libs';
+
+import { makeStore } from '@bublys-org/state-management';
+
+const { store, persistor } = makeStore({ persistKey: 'shift-puzzle-standalone' });
+
+export { store, persistor };
+export type RootState = ReturnType<typeof store.getState>;
+export type AppDispatch = typeof store.dispatch;

--- a/shift-puzzle-bubly/shift-puzzle-app/tsconfig.app.json
+++ b/shift-puzzle-bubly/shift-puzzle-app/tsconfig.app.json
@@ -1,0 +1,19 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "tsBuildInfoFile": "dist/tsconfig.app.tsbuildinfo",
+    "jsx": "react-jsx",
+    "lib": ["dom"],
+    "types": ["node", "vite/client"],
+    "rootDir": "src"
+  },
+  "exclude": ["out-tsc", "dist", "src/**/*.spec.ts", "src/**/*.test.ts", "src/**/*.spec.tsx", "src/**/*.test.tsx"],
+  "include": ["src/**/*.js", "src/**/*.jsx", "src/**/*.ts", "src/**/*.tsx"],
+  "references": [
+    {"path": "../../bublys-libs/state-management"},
+    {"path": "../../bublys-libs/bubbles-ui"},
+    {"path": "../shift-puzzle-libs/tsconfig.lib.json"},
+    {"path": "../shift-puzzle-model/tsconfig.lib.json"}
+  ]
+}

--- a/shift-puzzle-bubly/shift-puzzle-app/tsconfig.json
+++ b/shift-puzzle-bubly/shift-puzzle-app/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.app.json"
+    }
+  ],
+  "extends": "../../tsconfig.base.json"
+}

--- a/shift-puzzle-bubly/shift-puzzle-app/vite.config.bubly.ts
+++ b/shift-puzzle-bubly/shift-puzzle-app/vite.config.bubly.ts
@@ -1,0 +1,113 @@
+import { defineConfig } from "vite";
+import react from "@vitejs/plugin-react";
+import { resolve } from "path";
+
+/**
+ * shift-puzzle-app をスタンドアロンバブリとしてビルドする設定
+ *
+ * ビルドコマンド:
+ *   npx vite build -c vite.config.bubly.ts
+ *
+ * 出力:
+ *   public/bubly.js
+ *
+ * 規約: バブリは {origin}/bubly.js として配信される
+ */
+export default defineConfig({
+  plugins: [react()],
+
+  define: {
+    "process.env.NODE_ENV": JSON.stringify("production"),
+    "process.env": JSON.stringify({}),
+  },
+
+  build: {
+    outDir: "public",
+    emptyOutDir: false,
+    lib: {
+      entry: resolve(__dirname, "src/bubly.ts"),
+      name: "ShiftPuzzleBubly",
+      fileName: () => "bubly.js",
+      formats: ["iife"],
+    },
+    rollupOptions: {
+      external: (id) => {
+        if (
+          id === "@bublys-org/shift-puzzle-libs" ||
+          id.startsWith("@bublys-org/shift-puzzle-libs/") ||
+          id === "@bublys-org/shift-puzzle-model" ||
+          id.startsWith("@bublys-org/shift-puzzle-model/")
+        ) {
+          return false;
+        }
+        if (id === "react/jsx-runtime" || id === "react/jsx-dev-runtime") {
+          return false;
+        }
+        if (
+          id === "react" ||
+          id === "react-dom" ||
+          id.startsWith("react/") ||
+          id.startsWith("react-dom/") ||
+          id === "@reduxjs/toolkit" ||
+          id.startsWith("@reduxjs/toolkit/") ||
+          id === "react-redux" ||
+          id === "styled-components" ||
+          id.startsWith("@bublys-org/") ||
+          id.startsWith("@mui/") ||
+          id.startsWith("@emotion/")
+        ) {
+          return true;
+        }
+        return false;
+      },
+      output: {
+        globals: (id) => {
+          if (id === "react" || id.startsWith("react/")) {
+            return "React";
+          }
+          if (id === "react-dom" || id.startsWith("react-dom/")) {
+            return "ReactDOM";
+          }
+          if (id === "styled-components") {
+            return "styled";
+          }
+          if (id === "@reduxjs/toolkit" || id.startsWith("@reduxjs/toolkit/")) {
+            return "window.__BUBLYS_SHARED__.Redux";
+          }
+          if (id === "react-redux") {
+            return "window.__BUBLYS_SHARED__.ReactRedux";
+          }
+          if (id === "@bublys-org/state-management") {
+            return "window.__BUBLYS_SHARED__.StateManagement";
+          }
+          if (id === "@bublys-org/bubbles-ui" || id.startsWith("@bublys-org/bubbles-ui/")) {
+            return "window.__BUBLYS_SHARED__.BubblesUI";
+          }
+          if (id.startsWith("@mui/material")) {
+            return "window.__BUBLYS_SHARED__.MuiMaterial";
+          }
+          if (id.startsWith("@mui/icons-material/")) {
+            const iconName = id.replace("@mui/icons-material/", "");
+            return `window.__BUBLYS_SHARED__.MuiIcons.${iconName}`;
+          }
+          if (id === "@mui/icons-material") {
+            return "window.__BUBLYS_SHARED__.MuiIcons";
+          }
+          if (id.startsWith("@mui/")) {
+            return "window.__BUBLYS_SHARED__.Mui";
+          }
+          if (id.startsWith("@emotion/")) {
+            return "window.__BUBLYS_SHARED__.Emotion";
+          }
+          if (id.startsWith("@bublys-org/")) {
+            console.warn(`[vite] Unknown @bublys-org package: ${id}`);
+            return `window.__BUBLYS_SHARED__["${id}"]`;
+          }
+          return id;
+        },
+      },
+    },
+    sourcemap: true,
+    minify: false,
+  },
+});

--- a/shift-puzzle-bubly/shift-puzzle-app/vite.config.mts
+++ b/shift-puzzle-bubly/shift-puzzle-app/vite.config.mts
@@ -1,0 +1,25 @@
+/// <reference types='vitest' />
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig(() => ({
+  root: import.meta.dirname,
+  cacheDir: '../../node_modules/.vite/shift-puzzle-bubly/shift-puzzle-app',
+  server: {
+    port: 4003,
+    host: 'localhost',
+  },
+  preview: {
+    port: 4003,
+    host: 'localhost',
+  },
+  plugins: [react()],
+  build: {
+    outDir: './dist',
+    emptyOutDir: true,
+    reportCompressedSize: true,
+    commonjsOptions: {
+      transformMixedEsModules: true,
+    },
+  },
+}));

--- a/shift-puzzle-bubly/shift-puzzle-libs/package.json
+++ b/shift-puzzle-bubly/shift-puzzle-libs/package.json
@@ -1,0 +1,33 @@
+{
+  "name": "@bublys-org/shift-puzzle-libs",
+  "version": "0.0.1",
+  "private": true,
+  "type": "module",
+  "main": "./dist/index.js",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "scripts": {
+    "build": "tsc -p tsconfig.lib.json",
+    "dev": "tsc -p tsconfig.lib.json --watch"
+  },
+  "exports": {
+    "./package.json": "./package.json",
+    ".": {
+      "@bublys-org/source": "./src/index.ts",
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "default": "./dist/index.js"
+    }
+  },
+  "dependencies": {
+    "tslib": "^2.3.0",
+    "@bublys-org/shift-puzzle-model": "*",
+    "@bublys-org/bubbles-ui": "*",
+    "@bublys-org/state-management": "*"
+  },
+  "nx": {
+    "targets": {
+      "dev": { "continuous": true }
+    }
+  }
+}

--- a/shift-puzzle-bubly/shift-puzzle-libs/src/domain/index.ts
+++ b/shift-puzzle-bubly/shift-puzzle-libs/src/domain/index.ts
@@ -1,0 +1,5 @@
+/**
+ * ドメインモデル再エクスポート
+ * @bublys-org/shift-puzzle-model から全てを再エクスポート
+ */
+export * from '@bublys-org/shift-puzzle-model';

--- a/shift-puzzle-bubly/shift-puzzle-libs/src/feature/EventDetailFeature.tsx
+++ b/shift-puzzle-bubly/shift-puzzle-libs/src/feature/EventDetailFeature.tsx
@@ -1,0 +1,157 @@
+'use client';
+import React from 'react';
+import styled from 'styled-components';
+import { useAppSelector } from '@bublys-org/state-management';
+import {
+  selectEventById,
+  selectMembersForEvent,
+  selectRolesForEvent,
+  selectShiftPlansForEvent,
+} from '../slice/index.js';
+
+interface EventDetailFeatureProps {
+  eventId: string;
+  onOpenMembers: () => void;
+  onOpenRoles: () => void;
+  onOpenShiftPlans: () => void;
+}
+
+/** イベント詳細（Phase 1 / Issue #39） */
+export const EventDetailFeature: React.FC<EventDetailFeatureProps> = ({
+  eventId,
+  onOpenMembers,
+  onOpenRoles,
+  onOpenShiftPlans,
+}) => {
+  const event = useAppSelector(selectEventById(eventId));
+  const members = useAppSelector(selectMembersForEvent(eventId));
+  const roles = useAppSelector(selectRolesForEvent(eventId));
+  const shiftPlans = useAppSelector(selectShiftPlansForEvent(eventId));
+
+  if (!event) {
+    return (
+      <div style={{ padding: 24, color: '#888', textAlign: 'center' }}>
+        イベントが見つかりません（ID: {eventId}）
+      </div>
+    );
+  }
+
+  return (
+    <StyledWrapper>
+      <div className="e-header">
+        <div className="e-event-name">{event.name}</div>
+        <div className="e-event-date">
+          {event.startDate}
+          {event.endDate !== event.startDate && ` 〜 ${event.endDate}`}
+        </div>
+        {event.description && (
+          <div className="e-event-desc">{event.description}</div>
+        )}
+      </div>
+
+      <div className="e-nav-list">
+        <button className="e-nav-card" onClick={onOpenMembers}>
+          <span className="e-nav-icon">👥</span>
+          <span className="e-nav-label">メンバー</span>
+          <span className="e-nav-count">{members.length}人</span>
+          <span className="e-nav-arrow">›</span>
+        </button>
+
+        <button className="e-nav-card" onClick={onOpenRoles}>
+          <span className="e-nav-icon">🏷️</span>
+          <span className="e-nav-label">役割</span>
+          <span className="e-nav-count">{roles.length}役割</span>
+          <span className="e-nav-arrow">›</span>
+        </button>
+
+        <button className="e-nav-card" onClick={onOpenShiftPlans}>
+          <span className="e-nav-icon">📅</span>
+          <span className="e-nav-label">シフト案</span>
+          <span className="e-nav-count">{shiftPlans.length}案</span>
+          <span className="e-nav-arrow">›</span>
+        </button>
+      </div>
+    </StyledWrapper>
+  );
+};
+
+const StyledWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  background: #fafafa;
+
+  .e-header {
+    padding: 14px 16px;
+    background: white;
+    border-bottom: 1px solid #eee;
+    flex-shrink: 0;
+  }
+
+  .e-event-name {
+    font-size: 1.1em;
+    font-weight: 700;
+    color: #222;
+  }
+
+  .e-event-date {
+    font-size: 0.82em;
+    color: #888;
+    margin-top: 3px;
+  }
+
+  .e-event-desc {
+    font-size: 0.85em;
+    color: #666;
+    margin-top: 6px;
+    line-height: 1.5;
+  }
+
+  .e-nav-list {
+    padding: 10px 14px;
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+  }
+
+  .e-nav-card {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    padding: 12px 14px;
+    background: white;
+    border: 1px solid #e0e0e0;
+    border-radius: 8px;
+    cursor: pointer;
+    text-align: left;
+    transition: border-color 0.15s, box-shadow 0.15s;
+    width: 100%;
+
+    &:hover {
+      border-color: #90caf9;
+      box-shadow: 0 1px 4px rgba(25, 118, 210, 0.1);
+    }
+  }
+
+  .e-nav-icon {
+    font-size: 1.2em;
+  }
+
+  .e-nav-label {
+    font-weight: 600;
+    font-size: 0.95em;
+    color: #333;
+    flex: 1;
+  }
+
+  .e-nav-count {
+    font-size: 0.85em;
+    color: #888;
+  }
+
+  .e-nav-arrow {
+    font-size: 1.1em;
+    color: #bbb;
+    margin-left: 2px;
+  }
+` as React.FC<React.HTMLAttributes<HTMLDivElement>>;

--- a/shift-puzzle-bubly/shift-puzzle-libs/src/feature/EventListFeature.tsx
+++ b/shift-puzzle-bubly/shift-puzzle-libs/src/feature/EventListFeature.tsx
@@ -1,0 +1,240 @@
+'use client';
+import React, { useState } from 'react';
+import styled from 'styled-components';
+import { useAppDispatch, useAppSelector } from '@bublys-org/state-management';
+import { Event } from '@bublys-org/shift-puzzle-model';
+import {
+  selectEvents,
+  selectCurrentEventId,
+  addEvent,
+  setCurrentEventId,
+} from '../slice/index.js';
+
+interface EventListFeatureProps {
+  onEventSelect: (eventId: string) => void;
+}
+
+/** イベント一覧・作成（Phase 1 / Issue #39） */
+export const EventListFeature: React.FC<EventListFeatureProps> = ({ onEventSelect }) => {
+  const dispatch = useAppDispatch();
+  const events = useAppSelector(selectEvents);
+  const currentEventId = useAppSelector(selectCurrentEventId);
+
+  const [creating, setCreating] = useState(false);
+  const [newName, setNewName] = useState('');
+  const [newStartDate, setNewStartDate] = useState(
+    new Date().toISOString().slice(0, 10)
+  );
+
+  const handleCreate = () => {
+    if (!newName.trim()) return;
+    const event = Event.create({
+      name: newName.trim(),
+      description: '',
+      startDate: newStartDate,
+      endDate: newStartDate,
+    });
+    dispatch(addEvent(event.toJSON()));
+    dispatch(setCurrentEventId(event.id));
+    setCreating(false);
+    setNewName('');
+    onEventSelect(event.id);
+  };
+
+  return (
+    <StyledWrapper>
+      <div className="e-header">
+        <span className="e-title">イベント一覧</span>
+        <button className="e-create-btn" onClick={() => setCreating(true)}>
+          ＋ 新規作成
+        </button>
+      </div>
+
+      {creating && (
+        <div className="e-create-form">
+          <input
+            className="e-input"
+            placeholder="イベント名（例: 第72回大学祭）"
+            value={newName}
+            onChange={(e) => setNewName(e.target.value)}
+            autoFocus
+            onKeyDown={(e) => e.key === 'Enter' && handleCreate()}
+          />
+          <input
+            className="e-input"
+            type="date"
+            value={newStartDate}
+            onChange={(e) => setNewStartDate(e.target.value)}
+          />
+          <div className="e-form-actions">
+            <button className="e-btn-primary" onClick={handleCreate} disabled={!newName.trim()}>
+              作成
+            </button>
+            <button className="e-btn-cancel" onClick={() => { setCreating(false); setNewName(''); }}>
+              キャンセル
+            </button>
+          </div>
+        </div>
+      )}
+
+      <div className="e-list">
+        {events.length === 0 && !creating && (
+          <div className="e-empty">
+            イベントがありません。「＋ 新規作成」から始めましょう。
+          </div>
+        )}
+        {events.map((ev) => (
+          <div
+            key={ev.id}
+            className={`e-event-card ${currentEventId === ev.id ? 'is-active' : ''}`}
+            onClick={() => {
+              dispatch(setCurrentEventId(ev.id));
+              onEventSelect(ev.id);
+            }}
+          >
+            <div className="e-event-name">{ev.name}</div>
+            <div className="e-event-date">
+              {ev.startDate}
+              {ev.endDate !== ev.startDate && ` 〜 ${ev.endDate}`}
+            </div>
+          </div>
+        ))}
+      </div>
+    </StyledWrapper>
+  );
+};
+
+const StyledWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  overflow: hidden;
+  background: #fafafa;
+
+  .e-header {
+    display: flex;
+    align-items: center;
+    padding: 12px 14px;
+    background: white;
+    border-bottom: 1px solid #eee;
+    flex-shrink: 0;
+  }
+
+  .e-title {
+    font-size: 1.05em;
+    font-weight: 700;
+    color: #222;
+  }
+
+  .e-create-btn {
+    margin-left: auto;
+    padding: 5px 12px;
+    background: #1976d2;
+    color: white;
+    border: none;
+    border-radius: 4px;
+    cursor: pointer;
+    font-size: 0.85em;
+    font-weight: 600;
+  }
+
+  .e-create-form {
+    padding: 12px 14px;
+    background: #f0f7ff;
+    border-bottom: 1px solid #b3d4f5;
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    flex-shrink: 0;
+  }
+
+  .e-input {
+    padding: 6px 10px;
+    border: 1px solid #ccc;
+    border-radius: 4px;
+    font-size: 0.9em;
+    outline: none;
+
+    &:focus {
+      border-color: #1976d2;
+    }
+  }
+
+  .e-form-actions {
+    display: flex;
+    gap: 6px;
+  }
+
+  .e-btn-primary {
+    padding: 5px 14px;
+    background: #1976d2;
+    color: white;
+    border: none;
+    border-radius: 4px;
+    cursor: pointer;
+    font-size: 0.85em;
+    font-weight: 600;
+
+    &:disabled {
+      opacity: 0.5;
+      cursor: not-allowed;
+    }
+  }
+
+  .e-btn-cancel {
+    padding: 5px 12px;
+    background: white;
+    border: 1px solid #ccc;
+    border-radius: 4px;
+    cursor: pointer;
+    font-size: 0.85em;
+    color: #555;
+  }
+
+  .e-list {
+    flex: 1;
+    overflow-y: auto;
+    padding: 10px 14px;
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+  }
+
+  .e-empty {
+    text-align: center;
+    color: #aaa;
+    font-size: 0.88em;
+    padding: 32px 0;
+  }
+
+  .e-event-card {
+    padding: 10px 12px;
+    background: white;
+    border: 1px solid #e0e0e0;
+    border-radius: 6px;
+    cursor: pointer;
+    transition: border-color 0.15s, box-shadow 0.15s;
+
+    &:hover {
+      border-color: #90caf9;
+      box-shadow: 0 1px 4px rgba(25, 118, 210, 0.1);
+    }
+
+    &.is-active {
+      border-color: #1976d2;
+      background: #f0f7ff;
+    }
+  }
+
+  .e-event-name {
+    font-weight: 600;
+    font-size: 0.95em;
+    color: #222;
+  }
+
+  .e-event-date {
+    font-size: 0.8em;
+    color: #888;
+    margin-top: 2px;
+  }
+` as React.FC<React.HTMLAttributes<HTMLDivElement>>;

--- a/shift-puzzle-bubly/shift-puzzle-libs/src/feature/MemberCollection.tsx
+++ b/shift-puzzle-bubly/shift-puzzle-libs/src/feature/MemberCollection.tsx
@@ -16,6 +16,8 @@ import { MemberForm } from '../ui/MemberCard/MemberForm.js';
 
 interface MemberCollectionProps {
   eventId: string;
+  /** F-4-1: メンバーカードタップで詳細バブルを開くコールバック */
+  onMemberTap?: (memberId: string) => void;
 }
 
 type EditingState =
@@ -24,7 +26,7 @@ type EditingState =
   | { mode: 'edit'; memberId: string };
 
 /** F-1-1〜F-1-4: メンバー一覧＋CRUD（Redux連携） */
-export const MemberCollection: React.FC<MemberCollectionProps> = ({ eventId }) => {
+export const MemberCollection: React.FC<MemberCollectionProps> = ({ eventId, onMemberTap }) => {
   const dispatch = useAppDispatch();
   const members = useAppSelector(selectMembersForEvent(eventId));
   const event = useAppSelector(selectEventById(eventId));
@@ -163,6 +165,7 @@ export const MemberCollection: React.FC<MemberCollectionProps> = ({ eventId }) =
                 timeSlots={timeSlots}
                 onEdit={(id) => setEditing({ mode: 'edit', memberId: id })}
                 onDelete={handleDelete}
+                onTap={onMemberTap}
               />
             ))
           )}

--- a/shift-puzzle-bubly/shift-puzzle-libs/src/feature/MemberCollection.tsx
+++ b/shift-puzzle-bubly/shift-puzzle-libs/src/feature/MemberCollection.tsx
@@ -1,0 +1,314 @@
+'use client';
+import React, { useMemo, useState } from 'react';
+import styled from 'styled-components';
+import { useAppDispatch, useAppSelector } from '@bublys-org/state-management';
+import { Member, type MemberState } from '@bublys-org/shift-puzzle-model';
+import {
+  selectMembersForEvent,
+  selectEventById,
+  selectTimeSlotsForEvent,
+  addMember,
+  updateMember,
+  deleteMember,
+} from '../slice/index.js';
+import { MemberCard } from '../ui/index.js';
+import { MemberForm } from '../ui/MemberCard/MemberForm.js';
+
+interface MemberCollectionProps {
+  eventId: string;
+}
+
+type EditingState =
+  | { mode: 'none' }
+  | { mode: 'add' }
+  | { mode: 'edit'; memberId: string };
+
+/** F-1-1〜F-1-4: メンバー一覧＋CRUD（Redux連携） */
+export const MemberCollection: React.FC<MemberCollectionProps> = ({ eventId }) => {
+  const dispatch = useAppDispatch();
+  const members = useAppSelector(selectMembersForEvent(eventId));
+  const event = useAppSelector(selectEventById(eventId));
+  const timeSlots = useAppSelector(selectTimeSlotsForEvent(eventId));
+  const [editing, setEditing] = useState<EditingState>({ mode: 'none' });
+  const [tagFilter, setTagFilter] = useState<string | null>(null);
+  const [searchText, setSearchText] = useState('');
+
+  const skillDefinitions = event?.state.skillDefinitions ?? [];
+
+  // 全タグ一覧（サジェスト用）
+  const allTags = useMemo(() => {
+    const set = new Set<string>();
+    for (const m of members) {
+      for (const tag of m.state.tags) set.add(tag);
+    }
+    return Array.from(set).sort();
+  }, [members]);
+
+  // フィルター済みメンバー
+  const filteredMembers = useMemo(() => {
+    return members.filter((m) => {
+      if (tagFilter && !m.state.tags.includes(tagFilter)) return false;
+      if (searchText) {
+        const q = searchText.toLowerCase();
+        if (!m.state.name.toLowerCase().includes(q)) return false;
+      }
+      return true;
+    });
+  }, [members, tagFilter, searchText]);
+
+  const editingMember = editing.mode === 'edit'
+    ? members.find((m) => m.state.id === editing.memberId)?.state
+    : undefined;
+
+  const handleSave = (data: Omit<MemberState, 'id' | 'eventId' | 'createdAt' | 'updatedAt'>) => {
+    if (editing.mode === 'add') {
+      const member = Member.create({ ...data, eventId });
+      dispatch(addMember(member.toJSON()));
+    } else if (editing.mode === 'edit' && editingMember) {
+      const updated = new Member({
+        ...editingMember,
+        ...data,
+        updatedAt: new Date().toISOString(),
+      });
+      dispatch(updateMember(updated.toJSON()));
+    }
+    setEditing({ mode: 'none' });
+  };
+
+  const handleDelete = (memberId: string) => {
+    if (window.confirm('このメンバーを削除しますか？')) {
+      dispatch(deleteMember(memberId));
+    }
+  };
+
+  return (
+    <StyledWrapper>
+      {/* ヘッダー */}
+      <div className="e-header">
+        <div className="e-header-left">
+          <span className="e-title">メンバー管理</span>
+          <span className="e-count">{members.length}名</span>
+        </div>
+        <button
+          className="e-add-btn"
+          onClick={() => setEditing({ mode: 'add' })}
+          disabled={editing.mode !== 'none'}
+        >
+          ＋ メンバーを追加
+        </button>
+      </div>
+
+      {/* 検索・タグフィルター */}
+      {editing.mode === 'none' && (
+        <div className="e-filter-bar">
+          <input
+            className="e-search"
+            type="text"
+            placeholder="名前で検索..."
+            value={searchText}
+            onChange={(e: React.ChangeEvent<HTMLInputElement>) => setSearchText(e.target.value)}
+          />
+          {allTags.length > 0 && (
+            <div className="e-tag-filters">
+              <button
+                className={`e-tag-filter-btn ${tagFilter === null ? 'is-active' : ''}`}
+                onClick={() => setTagFilter(null)}
+              >
+                すべて
+              </button>
+              {allTags.map((tag) => (
+                <button
+                  key={tag}
+                  className={`e-tag-filter-btn ${tagFilter === tag ? 'is-active' : ''}`}
+                  onClick={() => setTagFilter(tag === tagFilter ? null : tag)}
+                >
+                  {tag}
+                </button>
+              ))}
+            </div>
+          )}
+        </div>
+      )}
+
+      {/* フォーム（追加・編集） */}
+      {editing.mode !== 'none' && (
+        <div className="e-form-area">
+          <MemberForm
+            initial={editingMember}
+            eventId={eventId}
+            skillDefinitions={skillDefinitions}
+            timeSlots={timeSlots}
+            existingTags={allTags}
+            onSave={handleSave}
+            onCancel={() => setEditing({ mode: 'none' })}
+          />
+        </div>
+      )}
+
+      {/* メンバー一覧 */}
+      {editing.mode === 'none' && (
+        <div className="e-list">
+          {filteredMembers.length === 0 ? (
+            <div className="e-empty">
+              {members.length === 0
+                ? 'メンバーがいません。「＋ メンバーを追加」から追加してください。'
+                : '条件に合うメンバーが見つかりません。'}
+            </div>
+          ) : (
+            filteredMembers.map((m) => (
+              <MemberCard
+                key={m.state.id}
+                member={m.state}
+                skillDefinitions={skillDefinitions}
+                timeSlots={timeSlots}
+                onEdit={(id) => setEditing({ mode: 'edit', memberId: id })}
+                onDelete={handleDelete}
+              />
+            ))
+          )}
+        </div>
+      )}
+    </StyledWrapper>
+  );
+};
+
+const StyledWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  overflow: hidden;
+  background: #fafafa;
+
+  .e-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 10px 14px;
+    background: white;
+    border-bottom: 1px solid #eee;
+    flex-shrink: 0;
+    gap: 8px;
+  }
+
+  .e-header-left {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+  }
+
+  .e-title {
+    font-weight: 600;
+    font-size: 0.95em;
+    color: #222;
+  }
+
+  .e-count {
+    background: #f5f5f5;
+    color: #666;
+    padding: 1px 8px;
+    border-radius: 12px;
+    font-size: 0.78em;
+  }
+
+  .e-add-btn {
+    padding: 6px 14px;
+    background: #1976d2;
+    color: white;
+    border: none;
+    border-radius: 6px;
+    font-size: 0.85em;
+    cursor: pointer;
+    font-weight: 500;
+    white-space: nowrap;
+
+    &:hover:not(:disabled) {
+      background: #1565c0;
+    }
+
+    &:disabled {
+      opacity: 0.5;
+      cursor: not-allowed;
+    }
+  }
+
+  .e-filter-bar {
+    padding: 8px 14px;
+    background: white;
+    border-bottom: 1px solid #f0f0f0;
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+    flex-shrink: 0;
+  }
+
+  .e-search {
+    padding: 6px 10px;
+    border: 1px solid #ddd;
+    border-radius: 6px;
+    font-size: 0.88em;
+    font-family: inherit;
+    width: 100%;
+    box-sizing: border-box;
+
+    &:focus {
+      outline: none;
+      border-color: #1976d2;
+    }
+  }
+
+  .e-tag-filters {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 4px;
+  }
+
+  .e-tag-filter-btn {
+    padding: 2px 10px;
+    border: 1px solid #ddd;
+    border-radius: 12px;
+    background: white;
+    font-size: 0.78em;
+    cursor: pointer;
+    color: #666;
+
+    &.is-active {
+      background: #1976d2;
+      border-color: #1976d2;
+      color: white;
+    }
+
+    &:hover:not(.is-active) {
+      background: #e3f2fd;
+      border-color: #90caf9;
+    }
+  }
+
+  .e-form-area {
+    flex-shrink: 0;
+    padding: 12px;
+    background: #f9fafb;
+    border-bottom: 1px solid #eee;
+    overflow-y: auto;
+    max-height: 70vh;
+  }
+
+  .e-list {
+    flex: 1;
+    overflow-y: auto;
+    padding: 10px;
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+  }
+
+  .e-empty {
+    flex: 1;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    color: #999;
+    font-size: 0.9em;
+    text-align: center;
+    padding: 24px;
+  }
+`;

--- a/shift-puzzle-bubly/shift-puzzle-libs/src/feature/MemberCollection.tsx
+++ b/shift-puzzle-bubly/shift-puzzle-libs/src/feature/MemberCollection.tsx
@@ -2,22 +2,17 @@
 import React, { useMemo, useState } from 'react';
 import styled from 'styled-components';
 import { useAppDispatch, useAppSelector } from '@bublys-org/state-management';
-import { Assignment, Member, type AssignmentReasonState, type MemberState } from '@bublys-org/shift-puzzle-model';
+import { Member, type MemberState } from '@bublys-org/shift-puzzle-model';
 import {
   selectMembersForEvent,
   selectEventById,
   selectTimeSlotsForEvent,
-  selectRolesForEvent,
-  selectCurrentShiftPlanId,
-  selectAssignmentsForPlan,
   addMember,
   updateMember,
   deleteMember,
-  addAssignment,
 } from '../slice/index.js';
 import { MemberCard } from '../ui/index.js';
 import { MemberForm } from '../ui/MemberCard/MemberForm.js';
-import { ReasonInputDialog } from '../ui/GanttChart/ReasonInputDialog.js';
 
 interface MemberCollectionProps {
   eventId: string;
@@ -30,22 +25,14 @@ type EditingState =
   | { mode: 'add' }
   | { mode: 'edit'; memberId: string };
 
-type QuickAssignState =
-  | { open: false }
-  | { open: true; memberId: string; selectedRoleId: string; selectedTimeSlotId: string };
-
 /** F-1-1〜F-1-4: メンバー一覧＋CRUD（Redux連携） */
 export const MemberCollection: React.FC<MemberCollectionProps> = ({ eventId, onMemberTap }) => {
   const dispatch = useAppDispatch();
   const members = useAppSelector(selectMembersForEvent(eventId));
   const event = useAppSelector(selectEventById(eventId));
   const timeSlots = useAppSelector(selectTimeSlotsForEvent(eventId));
-  const roles = useAppSelector(selectRolesForEvent(eventId));
-  const currentShiftPlanId = useAppSelector(selectCurrentShiftPlanId);
-  const assignments = useAppSelector(selectAssignmentsForPlan(currentShiftPlanId ?? ''));
   const [editing, setEditing] = useState<EditingState>({ mode: 'none' });
   const [tagFilter, setTagFilter] = useState<string | null>(null);
-  const [quickAssign, setQuickAssign] = useState<QuickAssignState>({ open: false });
   const [searchText, setSearchText] = useState('');
 
   const skillDefinitions = event?.state.skillDefinitions ?? [];
@@ -95,48 +82,6 @@ export const MemberCollection: React.FC<MemberCollectionProps> = ({ eventId, onM
       dispatch(deleteMember(memberId));
     }
   };
-
-  // F-4-3: ダブルクリック → クイック配置ダイアログ
-  const handleMemberDoubleClick = (memberId: string) => {
-    setQuickAssign({ open: true, memberId, selectedRoleId: '', selectedTimeSlotId: '' });
-  };
-
-  const handleQuickAssignConfirm = (reason: AssignmentReasonState) => {
-    if (!quickAssign.open || !currentShiftPlanId) return;
-    const { memberId, selectedRoleId, selectedTimeSlotId } = quickAssign;
-    if (!selectedRoleId || !selectedTimeSlotId) return;
-
-    // 重複チェック
-    const exists = assignments.some(
-      (a) => a.state.memberId === memberId && a.state.timeSlotId === selectedTimeSlotId && a.state.roleId === selectedRoleId
-    );
-    if (!exists) {
-      const assignment = Assignment.create({
-        memberId,
-        roleId: selectedRoleId,
-        timeSlotId: selectedTimeSlotId,
-        shiftPlanId: currentShiftPlanId,
-        reason,
-      });
-      dispatch(addAssignment({ shiftPlanId: currentShiftPlanId, assignment: assignment.toJSON() }));
-    }
-    setQuickAssign({ open: false });
-  };
-
-  const formatSlotLabel = (slotId: string) => {
-    const slot = timeSlots.find((s) => s.id === slotId);
-    if (!slot) return slotId;
-    const h1 = Math.floor(slot.startMinute / 60);
-    const m1 = slot.startMinute % 60;
-    const end = slot.startMinute + slot.durationMinutes;
-    const h2 = Math.floor(end / 60);
-    const m2 = end % 60;
-    return `${h1}:${String(m1).padStart(2, '0')}〜${h2}:${String(m2).padStart(2, '0')}`;
-  };
-
-  const quickAssignMember = quickAssign.open
-    ? members.find((m) => m.state.id === quickAssign.memberId)
-    : undefined;
 
   return (
     <StyledWrapper>
@@ -221,7 +166,6 @@ export const MemberCollection: React.FC<MemberCollectionProps> = ({ eventId, onM
                 onEdit={(id) => setEditing({ mode: 'edit', memberId: id })}
                 onDelete={handleDelete}
                 onTap={onMemberTap}
-                onDoubleClick={currentShiftPlanId ? handleMemberDoubleClick : undefined}
                 dragUrl={`shift-puzzle/events/${eventId}/members/${m.state.id}`}
               />
             ))
@@ -229,23 +173,6 @@ export const MemberCollection: React.FC<MemberCollectionProps> = ({ eventId, onM
         </div>
       )}
 
-      {/* F-4-3: ダブルクリック クイック配置ダイアログ */}
-      <ReasonInputDialog
-        open={quickAssign.open}
-        memberName={quickAssignMember?.state.name}
-        roles={roles.map((r) => ({ id: r.state.id, name: r.state.name, color: r.state.color }))}
-        selectedRoleId={quickAssign.open ? quickAssign.selectedRoleId : ''}
-        onRoleChange={(roleId) =>
-          setQuickAssign((s) => s.open ? { ...s, selectedRoleId: roleId } : s)
-        }
-        timeSlots={timeSlots.map((s) => ({ id: s.id, label: formatSlotLabel(s.id) }))}
-        selectedTimeSlotId={quickAssign.open ? quickAssign.selectedTimeSlotId : ''}
-        onTimeSlotChange={(slotId) =>
-          setQuickAssign((s) => s.open ? { ...s, selectedTimeSlotId: slotId } : s)
-        }
-        onConfirm={handleQuickAssignConfirm}
-        onCancel={() => setQuickAssign({ open: false })}
-      />
     </StyledWrapper>
   );
 };

--- a/shift-puzzle-bubly/shift-puzzle-libs/src/feature/MemberCollection.tsx
+++ b/shift-puzzle-bubly/shift-puzzle-libs/src/feature/MemberCollection.tsx
@@ -7,9 +7,14 @@ import {
   selectMembersForEvent,
   selectEventById,
   selectTimeSlotsForEvent,
+  selectFilteredMembersForEvent,
+  selectMemberFilter,
+  selectCurrentShiftPlanId,
   addMember,
   updateMember,
   deleteMember,
+  setMemberFilter,
+  resetMemberFilter,
 } from '../slice/index.js';
 import { MemberCard } from '../ui/index.js';
 import { MemberForm } from '../ui/MemberCard/MemberForm.js';
@@ -25,19 +30,25 @@ type EditingState =
   | { mode: 'add' }
   | { mode: 'edit'; memberId: string };
 
-/** F-1-1〜F-1-4: メンバー一覧＋CRUD（Redux連携） */
+/** F-1-1〜F-1-4 + F-5-1〜F-5-4: メンバー一覧＋CRUD＋フィルタリング（Redux連携） */
 export const MemberCollection: React.FC<MemberCollectionProps> = ({ eventId, onMemberTap }) => {
   const dispatch = useAppDispatch();
   const members = useAppSelector(selectMembersForEvent(eventId));
   const event = useAppSelector(selectEventById(eventId));
   const timeSlots = useAppSelector(selectTimeSlotsForEvent(eventId));
+  const currentShiftPlanId = useAppSelector(selectCurrentShiftPlanId);
+  const memberFilter = useAppSelector(selectMemberFilter);
+  const filteredMembers = useAppSelector(
+    selectFilteredMembersForEvent(eventId, currentShiftPlanId ?? undefined)
+  );
+
   const [editing, setEditing] = useState<EditingState>({ mode: 'none' });
-  const [tagFilter, setTagFilter] = useState<string | null>(null);
   const [searchText, setSearchText] = useState('');
+  const [filterOpen, setFilterOpen] = useState(false);
 
   const skillDefinitions = event?.state.skillDefinitions ?? [];
 
-  // 全タグ一覧（サジェスト用）
+  // 全タグ一覧
   const allTags = useMemo(() => {
     const set = new Set<string>();
     for (const m of members) {
@@ -46,17 +57,19 @@ export const MemberCollection: React.FC<MemberCollectionProps> = ({ eventId, onM
     return Array.from(set).sort();
   }, [members]);
 
-  // フィルター済みメンバー
-  const filteredMembers = useMemo(() => {
-    return members.filter((m) => {
-      if (tagFilter && !m.state.tags.includes(tagFilter)) return false;
-      if (searchText) {
-        const q = searchText.toLowerCase();
-        if (!m.state.name.toLowerCase().includes(q)) return false;
-      }
-      return true;
-    });
-  }, [members, tagFilter, searchText]);
+  // テキスト検索はローカル（高速性優先）
+  const displayMembers = useMemo(() => {
+    if (!searchText.trim()) return filteredMembers;
+    const q = searchText.toLowerCase();
+    return filteredMembers.filter((m) => m.state.name.toLowerCase().includes(q));
+  }, [filteredMembers, searchText]);
+
+  // フィルターが有効かどうか
+  const isFiltered =
+    !!memberFilter.availableAtSlotId ||
+    memberFilter.requiredSkillIds.length > 0 ||
+    memberFilter.tags.length > 0 ||
+    !!memberFilter.assignmentStatus;
 
   const editingMember = editing.mode === 'edit'
     ? members.find((m) => m.state.id === editing.memberId)?.state
@@ -83,6 +96,12 @@ export const MemberCollection: React.FC<MemberCollectionProps> = ({ eventId, onM
     }
   };
 
+  const formatTime = (minutes: number) => {
+    const h = Math.floor(minutes / 60).toString().padStart(2, '0');
+    const m = (minutes % 60).toString().padStart(2, '0');
+    return `${h}:${m}`;
+  };
+
   return (
     <StyledWrapper>
       {/* ヘッダー */}
@@ -90,43 +109,150 @@ export const MemberCollection: React.FC<MemberCollectionProps> = ({ eventId, onM
         <div className="e-header-left">
           <span className="e-title">メンバー管理</span>
           <span className="e-count">{members.length}名</span>
+          {isFiltered && (
+            <span className="e-filtered-count">
+              ({displayMembers.length}名表示中)
+            </span>
+          )}
         </div>
         <button
           className="e-add-btn"
           onClick={() => setEditing({ mode: 'add' })}
           disabled={editing.mode !== 'none'}
         >
-          ＋ メンバーを追加
+          ＋ 追加
         </button>
       </div>
 
-      {/* 検索・タグフィルター */}
+      {/* 検索＋フィルターバー */}
       {editing.mode === 'none' && (
         <div className="e-filter-bar">
-          <input
-            className="e-search"
-            type="text"
-            placeholder="名前で検索..."
-            value={searchText}
-            onChange={(e: React.ChangeEvent<HTMLInputElement>) => setSearchText(e.target.value)}
-          />
-          {allTags.length > 0 && (
-            <div className="e-tag-filters">
+          <div className="e-search-row">
+            <input
+              className="e-search"
+              type="text"
+              placeholder="名前で検索..."
+              value={searchText}
+              onChange={(e: React.ChangeEvent<HTMLInputElement>) => setSearchText(e.target.value)}
+            />
+            <button
+              className={`e-filter-toggle ${filterOpen ? 'is-open' : ''} ${isFiltered ? 'is-active' : ''}`}
+              onClick={() => setFilterOpen((v) => !v)}
+            >
+              絞り込み{isFiltered ? ' ●' : ''}
+            </button>
+            {isFiltered && (
               <button
-                className={`e-tag-filter-btn ${tagFilter === null ? 'is-active' : ''}`}
-                onClick={() => setTagFilter(null)}
+                className="e-reset-btn"
+                onClick={() => dispatch(resetMemberFilter())}
+                title="フィルターをリセット"
               >
-                すべて
+                ×
               </button>
-              {allTags.map((tag) => (
-                <button
-                  key={tag}
-                  className={`e-tag-filter-btn ${tagFilter === tag ? 'is-active' : ''}`}
-                  onClick={() => setTagFilter(tag === tagFilter ? null : tag)}
-                >
-                  {tag}
-                </button>
-              ))}
+            )}
+          </div>
+
+          {/* F-5: 詳細フィルターパネル */}
+          {filterOpen && (
+            <div className="e-filter-panel">
+
+              {/* F-5-3: タグフィルター */}
+              {allTags.length > 0 && (
+                <div className="e-filter-section">
+                  <div className="e-filter-label">タグ</div>
+                  <div className="e-chip-row">
+                    {allTags.map((tag) => {
+                      const active = memberFilter.tags.includes(tag);
+                      return (
+                        <button
+                          key={tag}
+                          className={`e-chip ${active ? 'is-active' : ''}`}
+                          onClick={() => {
+                            const next = active
+                              ? memberFilter.tags.filter((t) => t !== tag)
+                              : [...memberFilter.tags, tag];
+                            dispatch(setMemberFilter({ tags: next }));
+                          }}
+                        >
+                          {tag}
+                        </button>
+                      );
+                    })}
+                  </div>
+                </div>
+              )}
+
+              {/* F-5-1: 時間帯フィルター */}
+              {timeSlots.length > 0 && (
+                <div className="e-filter-section">
+                  <div className="e-filter-label">参加可能な時間帯</div>
+                  <select
+                    className="e-select"
+                    value={memberFilter.availableAtSlotId ?? ''}
+                    onChange={(e) =>
+                      dispatch(setMemberFilter({ availableAtSlotId: e.target.value || undefined }))
+                    }
+                  >
+                    <option value="">すべての時間帯</option>
+                    {timeSlots.map((slot) => (
+                      <option key={slot.id} value={slot.id}>
+                        {formatTime(slot.startMinute)}〜{formatTime(slot.startMinute + slot.durationMinutes)}
+                      </option>
+                    ))}
+                  </select>
+                </div>
+              )}
+
+              {/* F-5-2: スキルフィルター */}
+              {skillDefinitions.length > 0 && (
+                <div className="e-filter-section">
+                  <div className="e-filter-label">必要スキル（AND）</div>
+                  <div className="e-chip-row">
+                    {skillDefinitions.map((skill) => {
+                      const active = memberFilter.requiredSkillIds.includes(skill.id);
+                      return (
+                        <button
+                          key={skill.id}
+                          className={`e-chip ${active ? 'is-active' : ''}`}
+                          onClick={() => {
+                            const next = active
+                              ? memberFilter.requiredSkillIds.filter((id) => id !== skill.id)
+                              : [...memberFilter.requiredSkillIds, skill.id];
+                            dispatch(setMemberFilter({ requiredSkillIds: next }));
+                          }}
+                        >
+                          {skill.label}
+                        </button>
+                      );
+                    })}
+                  </div>
+                </div>
+              )}
+
+              {/* F-5-4: 配置状況フィルター */}
+              {currentShiftPlanId && (
+                <div className="e-filter-section">
+                  <div className="e-filter-label">配置状況</div>
+                  <div className="e-chip-row">
+                    {(
+                      [
+                        { value: undefined, label: 'すべて' },
+                        { value: 'unassigned', label: '未配置' },
+                        { value: 'assigned', label: '配置済み' },
+                        { value: 'over_assigned', label: '過配置' },
+                      ] as const
+                    ).map(({ value, label }) => (
+                      <button
+                        key={label}
+                        className={`e-chip ${memberFilter.assignmentStatus === value ? 'is-active' : ''}`}
+                        onClick={() => dispatch(setMemberFilter({ assignmentStatus: value }))}
+                      >
+                        {label}
+                      </button>
+                    ))}
+                  </div>
+                </div>
+              )}
             </div>
           )}
         </div>
@@ -150,14 +276,14 @@ export const MemberCollection: React.FC<MemberCollectionProps> = ({ eventId, onM
       {/* メンバー一覧 */}
       {editing.mode === 'none' && (
         <div className="e-list">
-          {filteredMembers.length === 0 ? (
+          {displayMembers.length === 0 ? (
             <div className="e-empty">
               {members.length === 0
-                ? 'メンバーがいません。「＋ メンバーを追加」から追加してください。'
+                ? 'メンバーがいません。「＋ 追加」から追加してください。'
                 : '条件に合うメンバーが見つかりません。'}
             </div>
           ) : (
-            filteredMembers.map((m) => (
+            displayMembers.map((m) => (
               <MemberCard
                 key={m.state.id}
                 member={m.state}
@@ -172,7 +298,6 @@ export const MemberCollection: React.FC<MemberCollectionProps> = ({ eventId, onM
           )}
         </div>
       )}
-
     </StyledWrapper>
   );
 };
@@ -198,7 +323,7 @@ const StyledWrapper = styled.div`
   .e-header-left {
     display: flex;
     align-items: center;
-    gap: 8px;
+    gap: 6px;
   }
 
   .e-title {
@@ -215,8 +340,14 @@ const StyledWrapper = styled.div`
     font-size: 0.78em;
   }
 
+  .e-filtered-count {
+    font-size: 0.78em;
+    color: #1976d2;
+    font-weight: 500;
+  }
+
   .e-add-btn {
-    padding: 6px 14px;
+    padding: 5px 12px;
     background: #1976d2;
     color: white;
     border: none;
@@ -226,14 +357,8 @@ const StyledWrapper = styled.div`
     font-weight: 500;
     white-space: nowrap;
 
-    &:hover:not(:disabled) {
-      background: #1565c0;
-    }
-
-    &:disabled {
-      opacity: 0.5;
-      cursor: not-allowed;
-    }
+    &:hover:not(:disabled) { background: #1565c0; }
+    &:disabled { opacity: 0.5; cursor: not-allowed; }
   }
 
   .e-filter-bar {
@@ -246,14 +371,19 @@ const StyledWrapper = styled.div`
     flex-shrink: 0;
   }
 
+  .e-search-row {
+    display: flex;
+    gap: 6px;
+    align-items: center;
+  }
+
   .e-search {
+    flex: 1;
     padding: 6px 10px;
     border: 1px solid #ddd;
     border-radius: 6px;
     font-size: 0.88em;
     font-family: inherit;
-    width: 100%;
-    box-sizing: border-box;
 
     &:focus {
       outline: none;
@@ -261,20 +391,68 @@ const StyledWrapper = styled.div`
     }
   }
 
-  .e-tag-filters {
+  .e-filter-toggle {
+    padding: 5px 10px;
+    border: 1px solid #ddd;
+    border-radius: 6px;
+    background: white;
+    font-size: 0.82em;
+    cursor: pointer;
+    color: #555;
+    white-space: nowrap;
+
+    &.is-open { background: #e3f2fd; border-color: #90caf9; }
+    &.is-active { color: #1976d2; font-weight: 600; }
+  }
+
+  .e-reset-btn {
+    padding: 4px 8px;
+    border: none;
+    background: #fce4e4;
+    color: #c62828;
+    border-radius: 4px;
+    cursor: pointer;
+    font-size: 0.9em;
+    line-height: 1;
+    font-weight: 700;
+  }
+
+  .e-filter-panel {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+    padding: 8px 0 4px;
+    border-top: 1px solid #f0f0f0;
+  }
+
+  .e-filter-section {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+  }
+
+  .e-filter-label {
+    font-size: 0.72em;
+    font-weight: 600;
+    color: #888;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+  }
+
+  .e-chip-row {
     display: flex;
     flex-wrap: wrap;
     gap: 4px;
   }
 
-  .e-tag-filter-btn {
-    padding: 2px 10px;
+  .e-chip {
+    padding: 3px 10px;
     border: 1px solid #ddd;
     border-radius: 12px;
     background: white;
-    font-size: 0.78em;
+    font-size: 0.8em;
     cursor: pointer;
-    color: #666;
+    color: #555;
 
     &.is-active {
       background: #1976d2;
@@ -286,6 +464,18 @@ const StyledWrapper = styled.div`
       background: #e3f2fd;
       border-color: #90caf9;
     }
+  }
+
+  .e-select {
+    padding: 5px 8px;
+    border: 1px solid #ddd;
+    border-radius: 6px;
+    font-size: 0.85em;
+    font-family: inherit;
+    background: white;
+    cursor: pointer;
+
+    &:focus { outline: none; border-color: #1976d2; }
   }
 
   .e-form-area {

--- a/shift-puzzle-bubly/shift-puzzle-libs/src/feature/MemberDetailFeature.tsx
+++ b/shift-puzzle-bubly/shift-puzzle-libs/src/feature/MemberDetailFeature.tsx
@@ -1,0 +1,84 @@
+'use client';
+import React, { useCallback } from 'react';
+import {
+  useAppDispatch,
+  useAppSelector,
+  addPocketItem,
+  selectPocketItems,
+} from '@bublys-org/state-management';
+import { getDragType } from '@bublys-org/bubbles-ui';
+import {
+  selectMembersForEvent,
+  selectEventById,
+  selectTimeSlotsForEvent,
+  selectAssignmentsForPlan,
+  selectRolesForEvent,
+} from '../slice/index.js';
+import { MemberDetailView } from '../ui/MemberDetail/MemberDetailView.js';
+
+interface MemberDetailFeatureProps {
+  eventId: string;
+  memberId: string;
+  shiftPlanId?: string;
+}
+
+/** F-4-1: メンバー詳細（スキル・参加可能時間・現在の配置状況） + F-4-3: ポケット追加 */
+export const MemberDetailFeature: React.FC<MemberDetailFeatureProps> = ({
+  eventId,
+  memberId,
+  shiftPlanId,
+}) => {
+  const dispatch = useAppDispatch();
+  const members = useAppSelector(selectMembersForEvent(eventId));
+  const event = useAppSelector(selectEventById(eventId));
+  const timeSlots = useAppSelector(selectTimeSlotsForEvent(eventId));
+  const roles = useAppSelector(selectRolesForEvent(eventId));
+  const assignments = useAppSelector(selectAssignmentsForPlan(shiftPlanId ?? ''));
+  const pocketItems = useAppSelector(selectPocketItems);
+
+  const member = members.find((m) => m.state.id === memberId);
+  const skillDefinitions = event?.state.skillDefinitions ?? [];
+
+  const assignmentStates = assignments.map((a) => a.state);
+  const roleStates = roles.map((r) => r.state);
+
+  // ポケット内に既にこのメンバーが存在するか
+  const pocketUrl = shiftPlanId
+    ? `shift-puzzle/events/${eventId}/shift-plans/${shiftPlanId}/member/${memberId}`
+    : `shift-puzzle/events/${eventId}/members/${memberId}`;
+  const isPocketed = pocketItems.some((item) => item.url === pocketUrl);
+
+  const handleAddToPocket = useCallback(() => {
+    if (isPocketed || !member) return;
+    dispatch(
+      addPocketItem({
+        id: crypto.randomUUID(),
+        url: pocketUrl,
+        type: getDragType('Member'),
+        objectId: memberId,
+        label: member.state.name,
+        addedAt: Date.now(),
+      })
+    );
+  }, [dispatch, isPocketed, member, memberId, pocketUrl]);
+
+  if (!member) {
+    return (
+      <div style={{ padding: 24, color: '#888', textAlign: 'center' }}>
+        メンバーが見つかりません（ID: {memberId}）
+      </div>
+    );
+  }
+
+  return (
+    <MemberDetailView
+      member={member.state}
+      skillDefinitions={skillDefinitions}
+      timeSlots={timeSlots}
+      assignments={assignmentStates}
+      roles={roleStates}
+      isPocketed={isPocketed}
+      onAddToPocket={handleAddToPocket}
+    />
+  );
+};

--- a/shift-puzzle-bubly/shift-puzzle-libs/src/feature/ReasonListFeature.tsx
+++ b/shift-puzzle-bubly/shift-puzzle-libs/src/feature/ReasonListFeature.tsx
@@ -1,0 +1,116 @@
+'use client';
+import React, { useMemo } from 'react';
+import styled from 'styled-components';
+import { useAppSelector } from '@bublys-org/state-management';
+import {
+  selectShiftPlanById,
+  selectMembersForEvent,
+  selectRolesForEvent,
+  selectTimeSlotsForEvent,
+} from '../slice/index.js';
+import { ReasonList } from '../ui/index.js';
+
+interface ReasonListFeatureProps {
+  shiftPlanId: string;
+  eventId: string;
+}
+
+/** F-3-3: 配置理由一覧フィーチャー（Redux連携） */
+export const ReasonListFeature: React.FC<ReasonListFeatureProps> = ({
+  shiftPlanId,
+  eventId,
+}) => {
+  const shiftPlan = useAppSelector(selectShiftPlanById(shiftPlanId));
+  const members = useAppSelector(selectMembersForEvent(eventId));
+  const roles = useAppSelector(selectRolesForEvent(eventId));
+  const timeSlots = useAppSelector(selectTimeSlotsForEvent(eventId));
+
+  const memberMap = useMemo(
+    () => new Map(members.map((m) => [m.state.id, m.state])),
+    [members]
+  );
+
+  const roleMap = useMemo(
+    () => new Map(roles.map((r) => [r.state.id, r.state])),
+    [roles]
+  );
+
+  const timeSlotMap = useMemo(
+    () => new Map(timeSlots.map((s) => [s.id, s])),
+    [timeSlots]
+  );
+
+  if (!shiftPlan) {
+    return (
+      <div style={{ padding: 24, color: '#666', textAlign: 'center' }}>
+        シフト案を読み込み中...
+      </div>
+    );
+  }
+
+  const assignments = shiftPlan.state.assignments;
+
+  return (
+    <StyledWrapper>
+      <div className="e-header">
+        <span className="e-plan-name">{shiftPlan.name}</span>
+        {shiftPlan.scenarioLabel && (
+          <span className="e-scenario-label">{shiftPlan.scenarioLabel}</span>
+        )}
+        <span className="e-count">{assignments.length}件の配置</span>
+      </div>
+
+      <div className="e-body">
+        <ReasonList
+          assignments={[...assignments]}
+          memberMap={memberMap}
+          roleMap={roleMap}
+          timeSlotMap={timeSlotMap}
+        />
+      </div>
+    </StyledWrapper>
+  );
+};
+
+const StyledWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  overflow: hidden;
+
+  .e-header {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 10px 16px;
+    border-bottom: 1px solid #eee;
+    background: #fafafa;
+    flex-shrink: 0;
+    flex-wrap: wrap;
+  }
+
+  .e-plan-name {
+    font-weight: 600;
+    font-size: 0.95em;
+    color: #222;
+  }
+
+  .e-scenario-label {
+    background: #e8eaf6;
+    color: #3949ab;
+    padding: 2px 8px;
+    border-radius: 12px;
+    font-size: 0.8em;
+  }
+
+  .e-count {
+    margin-left: auto;
+    font-size: 0.82em;
+    color: #888;
+  }
+
+  .e-body {
+    flex: 1;
+    overflow: hidden;
+  }
+`;

--- a/shift-puzzle-bubly/shift-puzzle-libs/src/feature/RoleFulfillmentFeature.tsx
+++ b/shift-puzzle-bubly/shift-puzzle-libs/src/feature/RoleFulfillmentFeature.tsx
@@ -1,0 +1,54 @@
+'use client';
+import React from 'react';
+import { useAppSelector } from '@bublys-org/state-management';
+import {
+  selectRolesForEvent,
+  selectEventById,
+  selectTimeSlotsForEvent,
+  selectMembersForEvent,
+  selectAssignmentsForPlan,
+} from '../slice/index.js';
+import { RoleFulfillmentView } from '../ui/RoleFulfillment/RoleFulfillmentView.js';
+
+interface RoleFulfillmentFeatureProps {
+  eventId: string;
+  roleId: string;
+  shiftPlanId?: string;
+}
+
+/** F-4-2: 役割充足状況（配置人数/必要人数・スキル充足率） */
+export const RoleFulfillmentFeature: React.FC<RoleFulfillmentFeatureProps> = ({
+  eventId,
+  roleId,
+  shiftPlanId,
+}) => {
+  const roles = useAppSelector(selectRolesForEvent(eventId));
+  const event = useAppSelector(selectEventById(eventId));
+  const timeSlots = useAppSelector(selectTimeSlotsForEvent(eventId));
+  const members = useAppSelector(selectMembersForEvent(eventId));
+  const assignments = useAppSelector(selectAssignmentsForPlan(shiftPlanId ?? ''));
+
+  const role = roles.find((r) => r.state.id === roleId);
+  const skillDefinitions = event?.state.skillDefinitions ?? [];
+
+  const assignmentStates = assignments.map((a) => a.state);
+  const memberStates = members.map((m) => m.state);
+
+  if (!role) {
+    return (
+      <div style={{ padding: 24, color: '#888', textAlign: 'center' }}>
+        役割が見つかりません（ID: {roleId}）
+      </div>
+    );
+  }
+
+  return (
+    <RoleFulfillmentView
+      role={role.state}
+      assignments={assignmentStates}
+      timeSlots={timeSlots}
+      members={memberStates}
+      skillDefinitions={skillDefinitions}
+    />
+  );
+};

--- a/shift-puzzle-bubly/shift-puzzle-libs/src/feature/RoleListFeature.tsx
+++ b/shift-puzzle-bubly/shift-puzzle-libs/src/feature/RoleListFeature.tsx
@@ -1,0 +1,307 @@
+'use client';
+import React, { useState } from 'react';
+import styled from 'styled-components';
+import { useAppDispatch, useAppSelector } from '@bublys-org/state-management';
+import { Role } from '@bublys-org/shift-puzzle-model';
+import {
+  selectRolesForEvent,
+  addRole,
+  deleteRole,
+} from '../slice/index.js';
+
+interface RoleListFeatureProps {
+  eventId: string;
+  onRoleSelect?: (roleId: string) => void;
+}
+
+const ROLE_COLORS = [
+  '#4caf50', '#2196f3', '#ff9800', '#e91e63',
+  '#9c27b0', '#00bcd4', '#ff5722', '#607d8b',
+];
+
+/** 役割一覧・作成（Phase 1 / Issue #39） */
+export const RoleListFeature: React.FC<RoleListFeatureProps> = ({
+  eventId,
+  onRoleSelect,
+}) => {
+  const dispatch = useAppDispatch();
+  const roles = useAppSelector(selectRolesForEvent(eventId));
+
+  const [creating, setCreating] = useState(false);
+  const [newName, setNewName] = useState('');
+  const [newMin, setNewMin] = useState(1);
+  const [newColor, setNewColor] = useState(ROLE_COLORS[0]);
+
+  const handleCreate = () => {
+    if (!newName.trim()) return;
+    const role = Role.create({
+      name: newName.trim(),
+      eventId,
+      minRequired: newMin,
+      color: newColor,
+    });
+    dispatch(addRole(role.toJSON()));
+    setCreating(false);
+    setNewName('');
+    setNewMin(1);
+  };
+
+  return (
+    <StyledWrapper>
+      <div className="e-header">
+        <span className="e-title">役割一覧</span>
+        <button className="e-create-btn" onClick={() => setCreating(true)}>
+          ＋ 追加
+        </button>
+      </div>
+
+      {creating && (
+        <div className="e-create-form">
+          <div className="e-form-row">
+            <input
+              className="e-input e-input--grow"
+              placeholder="役割名（例: 受付係）"
+              value={newName}
+              onChange={(e) => setNewName(e.target.value)}
+              autoFocus
+              onKeyDown={(e) => e.key === 'Enter' && handleCreate()}
+            />
+            <input
+              className="e-input e-input--narrow"
+              type="number"
+              min={1}
+              max={99}
+              value={newMin}
+              onChange={(e) => setNewMin(Number(e.target.value))}
+              title="最小必要人数"
+            />
+            <span className="e-form-label">人以上</span>
+          </div>
+          <div className="e-color-picker">
+            {ROLE_COLORS.map((c) => (
+              <button
+                key={c}
+                className={`e-color-dot ${newColor === c ? 'is-selected' : ''}`}
+                style={{ background: c }}
+                onClick={() => setNewColor(c)}
+              />
+            ))}
+          </div>
+          <div className="e-form-actions">
+            <button className="e-btn-primary" onClick={handleCreate} disabled={!newName.trim()}>
+              追加
+            </button>
+            <button className="e-btn-cancel" onClick={() => { setCreating(false); setNewName(''); }}>
+              キャンセル
+            </button>
+          </div>
+        </div>
+      )}
+
+      <div className="e-list">
+        {roles.length === 0 && !creating && (
+          <div className="e-empty">役割が登録されていません。</div>
+        )}
+        {roles.map((role) => (
+          <div key={role.id} className="e-role-card">
+            <div className="e-role-dot" style={{ background: role.color }} />
+            <div className="e-role-info" onClick={() => onRoleSelect?.(role.id)}>
+              <div className="e-role-name">{role.name}</div>
+              <div className="e-role-req">
+                {role.minRequired}人以上
+                {role.maxRequired !== null && `・${role.maxRequired}人以下`}
+              </div>
+            </div>
+            <button
+              className="e-delete-btn"
+              onClick={() => dispatch(deleteRole(role.id))}
+              title="削除"
+            >
+              ×
+            </button>
+          </div>
+        ))}
+      </div>
+    </StyledWrapper>
+  );
+};
+
+const StyledWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  overflow: hidden;
+  background: #fafafa;
+
+  .e-header {
+    display: flex;
+    align-items: center;
+    padding: 12px 14px;
+    background: white;
+    border-bottom: 1px solid #eee;
+    flex-shrink: 0;
+  }
+
+  .e-title {
+    font-size: 1.05em;
+    font-weight: 700;
+    color: #222;
+  }
+
+  .e-create-btn {
+    margin-left: auto;
+    padding: 5px 12px;
+    background: #1976d2;
+    color: white;
+    border: none;
+    border-radius: 4px;
+    cursor: pointer;
+    font-size: 0.85em;
+    font-weight: 600;
+  }
+
+  .e-create-form {
+    padding: 12px 14px;
+    background: #f0f7ff;
+    border-bottom: 1px solid #b3d4f5;
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    flex-shrink: 0;
+  }
+
+  .e-form-row {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+  }
+
+  .e-input {
+    padding: 6px 10px;
+    border: 1px solid #ccc;
+    border-radius: 4px;
+    font-size: 0.9em;
+    outline: none;
+
+    &:focus { border-color: #1976d2; }
+    &.e-input--grow { flex: 1; }
+    &.e-input--narrow { width: 56px; text-align: center; }
+  }
+
+  .e-form-label {
+    font-size: 0.82em;
+    color: #666;
+    white-space: nowrap;
+  }
+
+  .e-color-picker {
+    display: flex;
+    gap: 6px;
+  }
+
+  .e-color-dot {
+    width: 22px;
+    height: 22px;
+    border-radius: 50%;
+    border: 2px solid transparent;
+    cursor: pointer;
+    padding: 0;
+
+    &.is-selected {
+      border-color: #333;
+      box-shadow: 0 0 0 2px white inset;
+    }
+  }
+
+  .e-form-actions {
+    display: flex;
+    gap: 6px;
+  }
+
+  .e-btn-primary {
+    padding: 5px 14px;
+    background: #1976d2;
+    color: white;
+    border: none;
+    border-radius: 4px;
+    cursor: pointer;
+    font-size: 0.85em;
+    font-weight: 600;
+    &:disabled { opacity: 0.5; cursor: not-allowed; }
+  }
+
+  .e-btn-cancel {
+    padding: 5px 12px;
+    background: white;
+    border: 1px solid #ccc;
+    border-radius: 4px;
+    cursor: pointer;
+    font-size: 0.85em;
+    color: #555;
+  }
+
+  .e-list {
+    flex: 1;
+    overflow-y: auto;
+    padding: 10px 14px;
+    display: flex;
+    flex-direction: column;
+    gap: 5px;
+  }
+
+  .e-empty {
+    text-align: center;
+    color: #aaa;
+    font-size: 0.88em;
+    padding: 24px 0;
+  }
+
+  .e-role-card {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    padding: 9px 12px;
+    background: white;
+    border: 1px solid #e0e0e0;
+    border-radius: 6px;
+  }
+
+  .e-role-dot {
+    width: 12px;
+    height: 12px;
+    border-radius: 50%;
+    flex-shrink: 0;
+  }
+
+  .e-role-info {
+    flex: 1;
+    cursor: pointer;
+
+    &:hover .e-role-name { color: #1976d2; }
+  }
+
+  .e-role-name {
+    font-weight: 600;
+    font-size: 0.92em;
+    color: #222;
+  }
+
+  .e-role-req {
+    font-size: 0.78em;
+    color: #888;
+    margin-top: 1px;
+  }
+
+  .e-delete-btn {
+    background: none;
+    border: none;
+    color: #bbb;
+    cursor: pointer;
+    font-size: 1.1em;
+    padding: 2px 6px;
+    border-radius: 3px;
+    line-height: 1;
+
+    &:hover { background: #fce4e4; color: #c62828; }
+  }
+` as React.FC<React.HTMLAttributes<HTMLDivElement>>;

--- a/shift-puzzle-bubly/shift-puzzle-libs/src/feature/RoleListFeature.tsx
+++ b/shift-puzzle-bubly/shift-puzzle-libs/src/feature/RoleListFeature.tsx
@@ -12,6 +12,11 @@ import {
 interface RoleListFeatureProps {
   eventId: string;
   onRoleSelect?: (roleId: string) => void;
+  /**
+   * 読み取り専用モード（ガントチャートから開いた場合）。
+   * true のとき「＋ 追加」「×」ボタンを非表示にし、役割カードをドラッグ可能にする。
+   */
+  readOnly?: boolean;
 }
 
 const ROLE_COLORS = [
@@ -23,6 +28,7 @@ const ROLE_COLORS = [
 export const RoleListFeature: React.FC<RoleListFeatureProps> = ({
   eventId,
   onRoleSelect,
+  readOnly = false,
 }) => {
   const dispatch = useAppDispatch();
   const roles = useAppSelector(selectRolesForEvent(eventId));
@@ -50,9 +56,12 @@ export const RoleListFeature: React.FC<RoleListFeatureProps> = ({
     <StyledWrapper>
       <div className="e-header">
         <span className="e-title">役割一覧</span>
-        <button className="e-create-btn" onClick={() => setCreating(true)}>
-          ＋ 追加
-        </button>
+        {readOnly && <span className="e-readonly-badge">配置用</span>}
+        {!readOnly && (
+          <button className="e-create-btn" onClick={() => setCreating(true)}>
+            ＋ 追加
+          </button>
+        )}
       </div>
 
       {creating && (
@@ -102,8 +111,20 @@ export const RoleListFeature: React.FC<RoleListFeatureProps> = ({
         {roles.length === 0 && !creating && (
           <div className="e-empty">役割が登録されていません。</div>
         )}
+        {readOnly && roles.length > 0 && (
+          <div className="e-drag-hint">役割をガントチャートにドラッグして配置</div>
+        )}
         {roles.map((role) => (
-          <div key={role.id} className="e-role-card">
+          <div
+            key={role.id}
+            className={`e-role-card ${readOnly ? 'is-draggable' : ''}`}
+            draggable={readOnly}
+            onDragStart={readOnly ? (e) => {
+              e.dataTransfer.setData('text/role-id', role.id);
+              e.dataTransfer.setData('text/plain', role.name);
+              e.dataTransfer.effectAllowed = 'copy';
+            } : undefined}
+          >
             <div className="e-role-dot" style={{ background: role.color }} />
             <div className="e-role-info" onClick={() => onRoleSelect?.(role.id)}>
               <div className="e-role-name">{role.name}</div>
@@ -112,13 +133,15 @@ export const RoleListFeature: React.FC<RoleListFeatureProps> = ({
                 {role.maxRequired !== null && `・${role.maxRequired}人以下`}
               </div>
             </div>
-            <button
-              className="e-delete-btn"
-              onClick={() => dispatch(deleteRole(role.id))}
-              title="削除"
-            >
-              ×
-            </button>
+            {!readOnly && (
+              <button
+                className="e-delete-btn"
+                onClick={() => dispatch(deleteRole(role.id))}
+                title="削除"
+              >
+                ×
+              </button>
+            )}
           </div>
         ))}
       </div>
@@ -146,6 +169,17 @@ const StyledWrapper = styled.div`
     font-size: 1.05em;
     font-weight: 700;
     color: #222;
+  }
+
+  .e-readonly-badge {
+    margin-left: 8px;
+    background: #e8f5e9;
+    color: #2e7d32;
+    border: 1px solid #a5d6a7;
+    border-radius: 10px;
+    padding: 1px 8px;
+    font-size: 0.72em;
+    font-weight: 600;
   }
 
   .e-create-btn {
@@ -256,6 +290,13 @@ const StyledWrapper = styled.div`
     padding: 24px 0;
   }
 
+  .e-drag-hint {
+    font-size: 0.75em;
+    color: #888;
+    text-align: center;
+    padding: 4px 0 8px;
+  }
+
   .e-role-card {
     display: flex;
     align-items: center;
@@ -264,6 +305,13 @@ const StyledWrapper = styled.div`
     background: white;
     border: 1px solid #e0e0e0;
     border-radius: 6px;
+
+    &.is-draggable {
+      cursor: grab;
+      border-style: dashed;
+      &:hover { background: #f1f8e9; border-color: #a5d6a7; }
+      &:active { cursor: grabbing; }
+    }
   }
 
   .e-role-dot {

--- a/shift-puzzle-bubly/shift-puzzle-libs/src/feature/ShiftPlanGanttEditor.tsx
+++ b/shift-puzzle-bubly/shift-puzzle-libs/src/feature/ShiftPlanGanttEditor.tsx
@@ -1,0 +1,318 @@
+'use client';
+import React, { useMemo } from 'react';
+import styled from 'styled-components';
+import { useAppDispatch, useAppSelector } from '@bublys-org/state-management';
+import {
+  Assignment,
+  type AssignmentReasonState,
+  type AssignmentState,
+} from '@bublys-org/shift-puzzle-model';
+import {
+  selectShiftPlanById,
+  selectMembersForEvent,
+  selectRolesForEvent,
+  selectTimeSlotsForEvent,
+  selectViolationsForPlan,
+  selectGanttHourPx,
+  selectGanttAxisMode,
+  selectGanttDayIndex,
+  addAssignment,
+  moveAssignment,
+  setGanttAxisMode,
+  setGanttDayIndex,
+  setGanttHourPx,
+} from '../slice/index.js';
+import { GanttChartView } from '../ui/index.js';
+
+interface ShiftPlanGanttEditorProps {
+  shiftPlanId: string;
+  eventId: string;
+  /** 配置クリック時のコールバック（理由詳細表示等） */
+  onAssignmentClick?: (assignmentId: string) => void;
+}
+
+/** ガントチャート編集画面（Redux連携） */
+export const ShiftPlanGanttEditor: React.FC<ShiftPlanGanttEditorProps> = ({
+  shiftPlanId,
+  eventId,
+  onAssignmentClick,
+}) => {
+  const dispatch = useAppDispatch();
+
+  const shiftPlan = useAppSelector(selectShiftPlanById(shiftPlanId));
+  const members = useAppSelector(selectMembersForEvent(eventId));
+  const roles = useAppSelector(selectRolesForEvent(eventId));
+  const timeSlots = useAppSelector(selectTimeSlotsForEvent(eventId));
+  const violations = useAppSelector(selectViolationsForPlan(shiftPlanId, eventId));
+  const hourPx = useAppSelector(selectGanttHourPx);
+  const axisMode = useAppSelector(selectGanttAxisMode);
+  const dayIndex = useAppSelector(selectGanttDayIndex);
+
+  // 利用可能なdayIndex一覧
+  const availableDays = useMemo(() => {
+    const indices = [...new Set(timeSlots.map((s) => s.dayIndex))].sort((a, b) => a - b);
+    return indices;
+  }, [timeSlots]);
+
+  const assignments = shiftPlan?.state.assignments ?? [];
+
+  // ========== ハンドラ ==========
+
+  const handleCreateAssignment = (
+    memberId: string,
+    timeSlotId: string,
+    roleId: string,
+    reason: AssignmentReasonState
+  ) => {
+    if (!shiftPlan) return;
+
+    // 重複チェック（同じメンバー × 時間帯 × 役割）
+    const exists = assignments.some(
+      (a: AssignmentState) => a.memberId === memberId && a.timeSlotId === timeSlotId && a.roleId === roleId
+    );
+    if (exists) return;
+
+    const assignment = Assignment.create({
+      memberId,
+      roleId,
+      timeSlotId,
+      shiftPlanId,
+      reason,
+    });
+
+    dispatch(addAssignment({ shiftPlanId, assignment: assignment.toJSON() }));
+  };
+
+  const handleMoveAssignment = (assignmentId: string, newTimeSlotId: string) => {
+    if (!shiftPlan) return;
+
+    // ロック確認
+    const target = assignments.find((a: AssignmentState) => a.id === assignmentId);
+    if (target?.locked) return;
+
+    dispatch(moveAssignment({ shiftPlanId, assignmentId, newTimeSlotId }));
+  };
+
+  if (!shiftPlan) {
+    return <div style={{ padding: 16, color: '#666' }}>シフト案を読み込み中...</div>;
+  }
+
+  return (
+    <StyledContainer>
+      {/* ツールバー */}
+      <div className="e-toolbar">
+        <span className="e-plan-name">{shiftPlan.name}</span>
+        {shiftPlan.scenarioLabel && (
+          <span className="e-scenario-label">{shiftPlan.scenarioLabel}</span>
+        )}
+
+        {/* 表示モード切替 */}
+        <div className="e-mode-switcher">
+          <button
+            className={`e-mode-btn ${axisMode === 'role' ? 'is-active' : ''}`}
+            onClick={() => dispatch(setGanttAxisMode('role'))}
+          >
+            役割ビュー
+          </button>
+          <button
+            className={`e-mode-btn ${axisMode === 'member' ? 'is-active' : ''}`}
+            onClick={() => dispatch(setGanttAxisMode('member'))}
+          >
+            メンバービュー
+          </button>
+        </div>
+
+        {/* 日付タブ（複数日の場合） */}
+        {availableDays.length > 1 && (
+          <div className="e-day-tabs">
+            {availableDays.map((d) => (
+              <button
+                key={d}
+                className={`e-day-tab ${dayIndex === d ? 'is-active' : ''}`}
+                onClick={() => dispatch(setGanttDayIndex(d))}
+              >
+                Day {d + 1}
+              </button>
+            ))}
+          </div>
+        )}
+
+        {/* ズーム */}
+        <div className="e-zoom">
+          <button
+            className="e-zoom-btn"
+            onClick={() => dispatch(setGanttHourPx(hourPx - 10))}
+            disabled={hourPx <= 40}
+          >
+            −
+          </button>
+          <span className="e-zoom-label">{hourPx}px/h</span>
+          <button
+            className="e-zoom-btn"
+            onClick={() => dispatch(setGanttHourPx(hourPx + 10))}
+            disabled={hourPx >= 120}
+          >
+            ＋
+          </button>
+        </div>
+
+        {/* 統計 */}
+        <div className="e-stats">
+          <span>配置数: {assignments.length}</span>
+          {violations.length > 0 && (
+            <span className="e-violation-badge">⚠ {violations.length}件の違反</span>
+          )}
+        </div>
+      </div>
+
+      {/* ガントチャート本体 */}
+      <div className="e-gantt-wrapper">
+        <GanttChartView
+          members={members.map((m) => m.state)}
+          roles={roles.map((r) => r.state)}
+          timeSlots={timeSlots}
+          assignments={[...assignments]}
+          violations={violations}
+          dayIndex={dayIndex}
+          hourPx={hourPx}
+          axisMode={axisMode}
+          onCreateAssignment={handleCreateAssignment}
+          onMoveAssignment={handleMoveAssignment}
+          onAssignmentClick={(id) => {
+            onAssignmentClick?.(id);
+          }}
+        />
+      </div>
+    </StyledContainer>
+  );
+};
+
+const StyledContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  overflow: hidden;
+
+  .e-toolbar {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    padding: 8px 12px;
+    border-bottom: 1px solid #eee;
+    background: #fafafa;
+    flex-shrink: 0;
+    flex-wrap: wrap;
+  }
+
+  .e-plan-name {
+    font-weight: 600;
+    font-size: 0.95em;
+  }
+
+  .e-scenario-label {
+    background: #e8eaf6;
+    color: #3949ab;
+    padding: 2px 8px;
+    border-radius: 12px;
+    font-size: 0.8em;
+  }
+
+  .e-mode-switcher {
+    display: flex;
+    border: 1px solid #ddd;
+    border-radius: 4px;
+    overflow: hidden;
+  }
+
+  .e-mode-btn {
+    padding: 4px 10px;
+    border: none;
+    background: white;
+    cursor: pointer;
+    font-size: 0.8em;
+    color: #555;
+
+    &.is-active {
+      background: #1976d2;
+      color: white;
+    }
+
+    &:not(:last-child) {
+      border-right: 1px solid #ddd;
+    }
+  }
+
+  .e-day-tabs {
+    display: flex;
+    gap: 4px;
+  }
+
+  .e-day-tab {
+    padding: 3px 10px;
+    border: 1px solid #ddd;
+    border-radius: 4px;
+    background: white;
+    cursor: pointer;
+    font-size: 0.8em;
+
+    &.is-active {
+      background: #1976d2;
+      color: white;
+      border-color: #1976d2;
+    }
+  }
+
+  .e-zoom {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+    margin-left: auto;
+  }
+
+  .e-zoom-btn {
+    width: 24px;
+    height: 24px;
+    border: 1px solid #ddd;
+    border-radius: 4px;
+    background: white;
+    cursor: pointer;
+    font-size: 0.9em;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+
+    &:disabled {
+      opacity: 0.4;
+      cursor: not-allowed;
+    }
+  }
+
+  .e-zoom-label {
+    font-size: 0.8em;
+    color: #777;
+    min-width: 50px;
+    text-align: center;
+  }
+
+  .e-stats {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    font-size: 0.85em;
+    color: #666;
+  }
+
+  .e-violation-badge {
+    background: #fff3e0;
+    color: #e65100;
+    padding: 2px 8px;
+    border-radius: 3px;
+    border: 1px solid #ff8f00;
+    font-weight: 500;
+  }
+
+  .e-gantt-wrapper {
+    flex: 1;
+    overflow: hidden;
+  }
+`;

--- a/shift-puzzle-bubly/shift-puzzle-libs/src/feature/ShiftPlanGanttEditor.tsx
+++ b/shift-puzzle-bubly/shift-puzzle-libs/src/feature/ShiftPlanGanttEditor.tsx
@@ -1,5 +1,5 @@
 'use client';
-import React, { useMemo } from 'react';
+import React, { useMemo, useState } from 'react';
 import styled from 'styled-components';
 import { useAppDispatch, useAppSelector } from '@bublys-org/state-management';
 import {
@@ -27,8 +27,13 @@ import { GanttChartView } from '../ui/index.js';
 interface ShiftPlanGanttEditorProps {
   shiftPlanId: string;
   eventId: string;
-  /** 配置クリック時のコールバック（理由詳細表示等） */
-  onAssignmentClick?: (assignmentId: string) => void;
+  /** 配置クリック時のコールバック（memberId・roleIdも含む） */
+  onAssignmentClick?: (assignmentId: string, memberId: string, roleId: string) => void;
+  /**
+   * セルクリック時の外部コールバック（バブル連携用）。
+   * 指定時は呼び出し元がバブルを開く。axisMode も渡される。
+   */
+  onCellClick?: (rowId: string, timeSlotId: string, axisMode: 'role' | 'member') => void;
 }
 
 /** ガントチャート編集画面（Redux連携） */
@@ -36,8 +41,11 @@ export const ShiftPlanGanttEditor: React.FC<ShiftPlanGanttEditorProps> = ({
   shiftPlanId,
   eventId,
   onAssignmentClick,
+  onCellClick,
 }) => {
   const dispatch = useAppDispatch();
+  // 配置理由ダイアログのトグル（デフォルト: 非表示）
+  const [showReasonDialog, setShowReasonDialog] = useState(false);
 
   const shiftPlan = useAppSelector(selectShiftPlanById(shiftPlanId));
   const members = useAppSelector(selectMembersForEvent(eventId));
@@ -163,6 +171,15 @@ export const ShiftPlanGanttEditor: React.FC<ShiftPlanGanttEditorProps> = ({
             <span className="e-violation-badge">⚠ {violations.length}件の違反</span>
           )}
         </div>
+
+        {/* 理由入力トグル */}
+        <button
+          className={`e-reason-toggle ${showReasonDialog ? 'is-active' : ''}`}
+          onClick={() => setShowReasonDialog((v) => !v)}
+          title="配置理由の入力ダイアログを表示するか切り替え"
+        >
+          📝 理由入力
+        </button>
       </div>
 
       {/* ガントチャート本体 */}
@@ -176,11 +193,15 @@ export const ShiftPlanGanttEditor: React.FC<ShiftPlanGanttEditorProps> = ({
           dayIndex={dayIndex}
           hourPx={hourPx}
           axisMode={axisMode}
+          showReasonDialog={showReasonDialog}
           onCreateAssignment={handleCreateAssignment}
           onMoveAssignment={handleMoveAssignment}
-          onAssignmentClick={(id) => {
-            onAssignmentClick?.(id);
-          }}
+          onAssignmentClick={onAssignmentClick}
+          onCellClick={
+            onCellClick
+              ? (rowId, timeSlotId) => onCellClick(rowId, timeSlotId, axisMode)
+              : undefined
+          }
         />
       </div>
     </StyledContainer>
@@ -309,6 +330,27 @@ const StyledContainer = styled.div`
     border-radius: 3px;
     border: 1px solid #ff8f00;
     font-weight: 500;
+  }
+
+  .e-reason-toggle {
+    padding: 3px 10px;
+    border: 1px solid #ddd;
+    border-radius: 4px;
+    background: white;
+    cursor: pointer;
+    font-size: 0.78em;
+    color: #666;
+
+    &.is-active {
+      background: #e8f5e9;
+      border-color: #a5d6a7;
+      color: #2e7d32;
+      font-weight: 600;
+    }
+
+    &:hover:not(.is-active) {
+      background: #f5f5f5;
+    }
   }
 
   .e-gantt-wrapper {

--- a/shift-puzzle-bubly/shift-puzzle-libs/src/feature/ShiftPlanListFeature.tsx
+++ b/shift-puzzle-bubly/shift-puzzle-libs/src/feature/ShiftPlanListFeature.tsx
@@ -1,0 +1,336 @@
+'use client';
+import React, { useState } from 'react';
+import styled from 'styled-components';
+import { useAppDispatch, useAppSelector } from '@bublys-org/state-management';
+import { ShiftPlan } from '@bublys-org/shift-puzzle-model';
+import {
+  selectShiftPlansForEvent,
+  selectCurrentShiftPlanId,
+  addShiftPlan,
+  deleteShiftPlan,
+  setCurrentShiftPlanId,
+} from '../slice/index.js';
+
+interface ShiftPlanListFeatureProps {
+  eventId: string;
+  onPlanSelect: (planId: string) => void;
+}
+
+/** シフト案一覧・作成・コピー（Phase 1 / Issue #39） */
+export const ShiftPlanListFeature: React.FC<ShiftPlanListFeatureProps> = ({
+  eventId,
+  onPlanSelect,
+}) => {
+  const dispatch = useAppDispatch();
+  const shiftPlans = useAppSelector(selectShiftPlansForEvent(eventId));
+  const currentPlanId = useAppSelector(selectCurrentShiftPlanId);
+
+  const [creating, setCreating] = useState(false);
+  const [newName, setNewName] = useState('');
+  const [newScenario, setNewScenario] = useState('');
+  const [forkSourceId, setForkSourceId] = useState<string | null>(null);
+
+  const handleCreate = () => {
+    if (!newName.trim()) return;
+    let plan: ShiftPlan;
+    if (forkSourceId) {
+      const source = shiftPlans.find((p) => p.id === forkSourceId);
+      plan = source
+        ? source.fork(newName.trim(), newScenario.trim())
+        : ShiftPlan.create({ name: newName.trim(), eventId, scenarioLabel: newScenario.trim() });
+      // forkはeventIdが引き継がれないので補正
+      plan = new ShiftPlan({ ...plan.state, eventId });
+    } else {
+      plan = ShiftPlan.create({ name: newName.trim(), eventId, scenarioLabel: newScenario.trim() });
+    }
+    dispatch(addShiftPlan(plan.toJSON()));
+    dispatch(setCurrentShiftPlanId(plan.id));
+    setCreating(false);
+    setNewName('');
+    setNewScenario('');
+    setForkSourceId(null);
+    onPlanSelect(plan.id);
+  };
+
+  const handleStartFork = (sourceId: string) => {
+    const source = shiftPlans.find((p) => p.id === sourceId);
+    setForkSourceId(sourceId);
+    setNewName(source ? `${source.name} (コピー)` : '');
+    setNewScenario('');
+    setCreating(true);
+  };
+
+  return (
+    <StyledWrapper>
+      <div className="e-header">
+        <span className="e-title">シフト案一覧</span>
+        <button className="e-create-btn" onClick={() => { setForkSourceId(null); setNewName(''); setCreating(true); }}>
+          ＋ 新規作成
+        </button>
+      </div>
+
+      {creating && (
+        <div className="e-create-form">
+          {forkSourceId && (
+            <div className="e-fork-note">
+              「{shiftPlans.find((p) => p.id === forkSourceId)?.name}」をコピー
+            </div>
+          )}
+          <input
+            className="e-input"
+            placeholder="シフト案名（例: シフト案 A）"
+            value={newName}
+            onChange={(e) => setNewName(e.target.value)}
+            autoFocus
+            onKeyDown={(e) => e.key === 'Enter' && handleCreate()}
+          />
+          <input
+            className="e-input"
+            placeholder="シナリオラベル（例: 晴天用・任意）"
+            value={newScenario}
+            onChange={(e) => setNewScenario(e.target.value)}
+          />
+          <div className="e-form-actions">
+            <button className="e-btn-primary" onClick={handleCreate} disabled={!newName.trim()}>
+              {forkSourceId ? 'コピー作成' : '作成'}
+            </button>
+            <button className="e-btn-cancel" onClick={() => { setCreating(false); setForkSourceId(null); }}>
+              キャンセル
+            </button>
+          </div>
+        </div>
+      )}
+
+      <div className="e-list">
+        {shiftPlans.length === 0 && !creating && (
+          <div className="e-empty">シフト案がありません。「＋ 新規作成」から始めましょう。</div>
+        )}
+        {shiftPlans.map((plan) => (
+          <div
+            key={plan.id}
+            className={`e-plan-card ${currentPlanId === plan.id ? 'is-active' : ''}`}
+          >
+            <div
+              className="e-plan-main"
+              onClick={() => {
+                dispatch(setCurrentShiftPlanId(plan.id));
+                onPlanSelect(plan.id);
+              }}
+            >
+              <div className="e-plan-name">{plan.name}</div>
+              {plan.scenarioLabel && (
+                <span className="e-scenario-badge">{plan.scenarioLabel}</span>
+              )}
+              <div className="e-plan-meta">
+                配置 {plan.state.assignments.length}件
+              </div>
+            </div>
+            <div className="e-plan-actions">
+              <button
+                className="e-fork-btn"
+                onClick={() => handleStartFork(plan.id)}
+                title="コピーして新しいシフト案を作成"
+              >
+                分岐
+              </button>
+              <button
+                className="e-delete-btn"
+                onClick={() => {
+                  if (window.confirm(`「${plan.name}」を削除しますか？`)) {
+                    dispatch(deleteShiftPlan(plan.id));
+                  }
+                }}
+                title="削除"
+              >
+                ×
+              </button>
+            </div>
+          </div>
+        ))}
+      </div>
+    </StyledWrapper>
+  );
+};
+
+const StyledWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  overflow: hidden;
+  background: #fafafa;
+
+  .e-header {
+    display: flex;
+    align-items: center;
+    padding: 12px 14px;
+    background: white;
+    border-bottom: 1px solid #eee;
+    flex-shrink: 0;
+  }
+
+  .e-title {
+    font-size: 1.05em;
+    font-weight: 700;
+    color: #222;
+  }
+
+  .e-create-btn {
+    margin-left: auto;
+    padding: 5px 12px;
+    background: #1976d2;
+    color: white;
+    border: none;
+    border-radius: 4px;
+    cursor: pointer;
+    font-size: 0.85em;
+    font-weight: 600;
+  }
+
+  .e-create-form {
+    padding: 12px 14px;
+    background: #f0f7ff;
+    border-bottom: 1px solid #b3d4f5;
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    flex-shrink: 0;
+  }
+
+  .e-fork-note {
+    font-size: 0.82em;
+    color: #1565c0;
+    background: #e3f2fd;
+    padding: 4px 8px;
+    border-radius: 4px;
+  }
+
+  .e-input {
+    padding: 6px 10px;
+    border: 1px solid #ccc;
+    border-radius: 4px;
+    font-size: 0.9em;
+    outline: none;
+    &:focus { border-color: #1976d2; }
+  }
+
+  .e-form-actions {
+    display: flex;
+    gap: 6px;
+  }
+
+  .e-btn-primary {
+    padding: 5px 14px;
+    background: #1976d2;
+    color: white;
+    border: none;
+    border-radius: 4px;
+    cursor: pointer;
+    font-size: 0.85em;
+    font-weight: 600;
+    &:disabled { opacity: 0.5; cursor: not-allowed; }
+  }
+
+  .e-btn-cancel {
+    padding: 5px 12px;
+    background: white;
+    border: 1px solid #ccc;
+    border-radius: 4px;
+    cursor: pointer;
+    font-size: 0.85em;
+    color: #555;
+  }
+
+  .e-list {
+    flex: 1;
+    overflow-y: auto;
+    padding: 10px 14px;
+    display: flex;
+    flex-direction: column;
+    gap: 5px;
+  }
+
+  .e-empty {
+    text-align: center;
+    color: #aaa;
+    font-size: 0.88em;
+    padding: 24px 0;
+  }
+
+  .e-plan-card {
+    display: flex;
+    align-items: center;
+    background: white;
+    border: 1px solid #e0e0e0;
+    border-radius: 6px;
+    overflow: hidden;
+    transition: border-color 0.15s;
+
+    &.is-active {
+      border-color: #1976d2;
+      background: #f0f7ff;
+    }
+  }
+
+  .e-plan-main {
+    flex: 1;
+    padding: 9px 12px;
+    cursor: pointer;
+    display: flex;
+    flex-direction: column;
+    gap: 3px;
+
+    &:hover .e-plan-name { color: #1976d2; }
+  }
+
+  .e-plan-name {
+    font-weight: 600;
+    font-size: 0.92em;
+    color: #222;
+  }
+
+  .e-scenario-badge {
+    align-self: flex-start;
+    background: #e8eaf6;
+    color: #3949ab;
+    padding: 1px 7px;
+    border-radius: 10px;
+    font-size: 0.76em;
+  }
+
+  .e-plan-meta {
+    font-size: 0.78em;
+    color: #888;
+  }
+
+  .e-plan-actions {
+    display: flex;
+    gap: 2px;
+    padding: 0 6px;
+  }
+
+  .e-fork-btn {
+    padding: 4px 8px;
+    background: #e8f5e9;
+    color: #2e7d32;
+    border: 1px solid #a5d6a7;
+    border-radius: 3px;
+    cursor: pointer;
+    font-size: 0.76em;
+    font-weight: 600;
+
+    &:hover { background: #c8e6c9; }
+  }
+
+  .e-delete-btn {
+    background: none;
+    border: none;
+    color: #bbb;
+    cursor: pointer;
+    font-size: 1.1em;
+    padding: 2px 6px;
+    border-radius: 3px;
+    line-height: 1;
+
+    &:hover { background: #fce4e4; color: #c62828; }
+  }
+` as React.FC<React.HTMLAttributes<HTMLDivElement>>;

--- a/shift-puzzle-bubly/shift-puzzle-libs/src/feature/ShiftPlanManager.tsx
+++ b/shift-puzzle-bubly/shift-puzzle-libs/src/feature/ShiftPlanManager.tsx
@@ -1,0 +1,491 @@
+'use client';
+import React, { useState } from 'react';
+import styled from 'styled-components';
+import { useAppDispatch, useAppSelector } from '@bublys-org/state-management';
+import { ShiftPlan } from '@bublys-org/shift-puzzle-model';
+import {
+  selectShiftPlansForEvent,
+  selectCurrentShiftPlanId,
+  addShiftPlan,
+  updateShiftPlan,
+  deleteShiftPlan,
+  setCurrentShiftPlanId,
+} from '../slice/index.js';
+
+interface ShiftPlanManagerProps {
+  eventId: string;
+  onPlanSelect: (planId: string) => void;
+}
+
+type EditingPlan = {
+  id: string;
+  name: string;
+  scenarioLabel: string;
+};
+
+/**
+ * F-6-1〜F-6-3: シフト案管理（Issue #41）
+ * - 複数案の並行管理・切り替え
+ * - コピー（配置・理由ごと）分岐
+ * - 名前・シナリオラベルのインライン編集
+ */
+export const ShiftPlanManager: React.FC<ShiftPlanManagerProps> = ({
+  eventId,
+  onPlanSelect,
+}) => {
+  const dispatch = useAppDispatch();
+  const shiftPlans = useAppSelector(selectShiftPlansForEvent(eventId));
+  const currentPlanId = useAppSelector(selectCurrentShiftPlanId);
+
+  // 新規作成フォーム
+  const [creating, setCreating] = useState(false);
+  const [newName, setNewName] = useState('');
+  const [newScenario, setNewScenario] = useState('');
+  const [forkSourceId, setForkSourceId] = useState<string | null>(null);
+
+  // インライン編集
+  const [editingPlan, setEditingPlan] = useState<EditingPlan | null>(null);
+
+  // ── 新規作成 ──────────────────────────────────────
+  const handleCreate = () => {
+    if (!newName.trim()) return;
+    let plan: ShiftPlan;
+
+    if (forkSourceId) {
+      const source = shiftPlans.find((p) => p.id === forkSourceId);
+      const forked = source
+        ? source.fork(newName.trim(), newScenario.trim())
+        : ShiftPlan.create({ name: newName.trim(), eventId, scenarioLabel: newScenario.trim() });
+      // fork は eventId を引き継がないため補正
+      plan = new ShiftPlan({ ...forked.state, eventId });
+    } else {
+      plan = ShiftPlan.create({
+        name: newName.trim(),
+        eventId,
+        scenarioLabel: newScenario.trim(),
+      });
+    }
+
+    dispatch(addShiftPlan(plan.toJSON()));
+    dispatch(setCurrentShiftPlanId(plan.id));
+    resetCreateForm();
+    onPlanSelect(plan.id);
+  };
+
+  const resetCreateForm = () => {
+    setCreating(false);
+    setNewName('');
+    setNewScenario('');
+    setForkSourceId(null);
+  };
+
+  const startFork = (sourceId: string) => {
+    const source = shiftPlans.find((p) => p.id === sourceId);
+    setForkSourceId(sourceId);
+    setNewName(source ? `${source.name}（コピー）` : '');
+    setNewScenario('');
+    setCreating(true);
+  };
+
+  // ── インライン編集 ────────────────────────────────
+  const startEdit = (plan: ShiftPlan) => {
+    setEditingPlan({
+      id: plan.id,
+      name: plan.name,
+      scenarioLabel: plan.scenarioLabel,
+    });
+  };
+
+  const commitEdit = () => {
+    if (!editingPlan) return;
+    const source = shiftPlans.find((p) => p.id === editingPlan.id);
+    if (!source) return;
+    const updated = source
+      .withName(editingPlan.name.trim() || source.name)
+      .withScenarioLabel(editingPlan.scenarioLabel.trim());
+    dispatch(updateShiftPlan(updated.toJSON()));
+    setEditingPlan(null);
+  };
+
+  // ── 削除 ─────────────────────────────────────────
+  const handleDelete = (plan: ShiftPlan) => {
+    if (!window.confirm(`「${plan.name}」を削除しますか？\n配置データも全て失われます。`)) return;
+    dispatch(deleteShiftPlan(plan.id));
+  };
+
+  return (
+    <StyledWrapper>
+      {/* ヘッダー */}
+      <div className="e-header">
+        <span className="e-title">シフト案管理</span>
+        <span className="e-count">{shiftPlans.length}案</span>
+        <button
+          className="e-create-btn"
+          onClick={() => { setForkSourceId(null); setNewName(''); setNewScenario(''); setCreating(true); }}
+        >
+          ＋ 新規作成
+        </button>
+      </div>
+
+      {/* 新規作成フォーム */}
+      {creating && (
+        <div className="e-create-form">
+          {forkSourceId && (
+            <div className="e-fork-note">
+              「{shiftPlans.find((p) => p.id === forkSourceId)?.name}」をコピーして作成
+            </div>
+          )}
+          <input
+            className="e-input"
+            placeholder="シフト案名（例: シフト案 A）"
+            value={newName}
+            onChange={(e) => setNewName(e.target.value)}
+            autoFocus
+            onKeyDown={(e) => e.key === 'Enter' && handleCreate()}
+          />
+          <input
+            className="e-input"
+            placeholder="シナリオラベル（例: 晴天用）任意"
+            value={newScenario}
+            onChange={(e) => setNewScenario(e.target.value)}
+            onKeyDown={(e) => e.key === 'Enter' && handleCreate()}
+          />
+          <div className="e-form-actions">
+            <button
+              className="e-btn-primary"
+              onClick={handleCreate}
+              disabled={!newName.trim()}
+            >
+              {forkSourceId ? '分岐して作成' : '作成'}
+            </button>
+            <button className="e-btn-cancel" onClick={resetCreateForm}>
+              キャンセル
+            </button>
+          </div>
+        </div>
+      )}
+
+      {/* シフト案リスト */}
+      <div className="e-list">
+        {shiftPlans.length === 0 && !creating && (
+          <div className="e-empty">
+            シフト案がありません。「＋ 新規作成」から作成してください。
+          </div>
+        )}
+
+        {shiftPlans.map((plan) => {
+          const isActive = plan.id === currentPlanId;
+          const isEditing = editingPlan?.id === plan.id;
+
+          return (
+            <div key={plan.id} className={`e-plan-card ${isActive ? 'is-active' : ''}`}>
+              {isEditing ? (
+                /* インライン編集モード */
+                <div className="e-edit-form">
+                  <input
+                    className="e-input"
+                    value={editingPlan.name}
+                    onChange={(e) => setEditingPlan({ ...editingPlan, name: e.target.value })}
+                    placeholder="シフト案名"
+                    autoFocus
+                    onKeyDown={(e) => e.key === 'Enter' && commitEdit()}
+                  />
+                  <input
+                    className="e-input e-input--scenario"
+                    value={editingPlan.scenarioLabel}
+                    onChange={(e) => setEditingPlan({ ...editingPlan, scenarioLabel: e.target.value })}
+                    placeholder="シナリオラベル（例: 晴天用）任意"
+                    onKeyDown={(e) => e.key === 'Enter' && commitEdit()}
+                  />
+                  <div className="e-form-actions">
+                    <button className="e-btn-primary" onClick={commitEdit}>保存</button>
+                    <button className="e-btn-cancel" onClick={() => setEditingPlan(null)}>キャンセル</button>
+                  </div>
+                </div>
+              ) : (
+                /* 通常表示モード */
+                <>
+                  <div
+                    className="e-plan-main"
+                    onClick={() => {
+                      dispatch(setCurrentShiftPlanId(plan.id));
+                      onPlanSelect(plan.id);
+                    }}
+                  >
+                    <div className="e-plan-header">
+                      {isActive && <span className="e-active-dot" />}
+                      <span className="e-plan-name">{plan.name}</span>
+                    </div>
+                    {plan.scenarioLabel && (
+                      <span className="e-scenario-badge">{plan.scenarioLabel}</span>
+                    )}
+                    <div className="e-plan-meta">
+                      配置 {plan.state.assignments.length}件
+                    </div>
+                  </div>
+
+                  <div className="e-plan-actions">
+                    <button
+                      className="e-action-btn e-action-btn--edit"
+                      onClick={() => startEdit(plan)}
+                      title="名前・ラベルを編集"
+                    >
+                      編集
+                    </button>
+                    <button
+                      className="e-action-btn e-action-btn--fork"
+                      onClick={() => startFork(plan.id)}
+                      title="この案をコピーして分岐"
+                    >
+                      分岐
+                    </button>
+                    <button
+                      className="e-action-btn e-action-btn--delete"
+                      onClick={() => handleDelete(plan)}
+                      title="削除"
+                    >
+                      ×
+                    </button>
+                  </div>
+                </>
+              )}
+            </div>
+          );
+        })}
+      </div>
+    </StyledWrapper>
+  );
+};
+
+// ── スタイル ──────────────────────────────────────────
+
+const StyledWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  overflow: hidden;
+  background: #fafafa;
+
+  .e-header {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    padding: 12px 14px;
+    background: white;
+    border-bottom: 1px solid #eee;
+    flex-shrink: 0;
+  }
+
+  .e-title {
+    font-size: 1.05em;
+    font-weight: 700;
+    color: #222;
+  }
+
+  .e-count {
+    background: #f5f5f5;
+    color: #666;
+    padding: 1px 8px;
+    border-radius: 12px;
+    font-size: 0.78em;
+  }
+
+  .e-create-btn {
+    margin-left: auto;
+    padding: 5px 12px;
+    background: #1976d2;
+    color: white;
+    border: none;
+    border-radius: 4px;
+    cursor: pointer;
+    font-size: 0.85em;
+    font-weight: 600;
+
+    &:hover { background: #1565c0; }
+  }
+
+  .e-create-form,
+  .e-edit-form {
+    padding: 12px 14px;
+    background: #f0f7ff;
+    border-bottom: 1px solid #b3d4f5;
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    flex-shrink: 0;
+  }
+
+  .e-fork-note {
+    font-size: 0.82em;
+    color: #1565c0;
+    background: #e3f2fd;
+    padding: 4px 8px;
+    border-radius: 4px;
+  }
+
+  .e-input {
+    padding: 7px 10px;
+    border: 1px solid #ccc;
+    border-radius: 4px;
+    font-size: 0.9em;
+    font-family: inherit;
+    outline: none;
+
+    &:focus { border-color: #1976d2; }
+
+    &.e-input--scenario {
+      font-size: 0.85em;
+    }
+  }
+
+  .e-form-actions {
+    display: flex;
+    gap: 6px;
+  }
+
+  .e-btn-primary {
+    padding: 5px 14px;
+    background: #1976d2;
+    color: white;
+    border: none;
+    border-radius: 4px;
+    cursor: pointer;
+    font-size: 0.85em;
+    font-weight: 600;
+
+    &:disabled { opacity: 0.5; cursor: not-allowed; }
+    &:not(:disabled):hover { background: #1565c0; }
+  }
+
+  .e-btn-cancel {
+    padding: 5px 12px;
+    background: white;
+    border: 1px solid #ccc;
+    border-radius: 4px;
+    cursor: pointer;
+    font-size: 0.85em;
+    color: #555;
+
+    &:hover { background: #f5f5f5; }
+  }
+
+  .e-list {
+    flex: 1;
+    overflow-y: auto;
+    padding: 10px 14px;
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+  }
+
+  .e-empty {
+    text-align: center;
+    color: #aaa;
+    font-size: 0.88em;
+    padding: 32px 0;
+  }
+
+  .e-plan-card {
+    background: white;
+    border: 1px solid #e0e0e0;
+    border-radius: 8px;
+    overflow: hidden;
+    transition: border-color 0.15s, box-shadow 0.15s;
+
+    &.is-active {
+      border-color: #1976d2;
+      box-shadow: 0 0 0 2px rgba(25, 118, 210, 0.15);
+    }
+
+    .e-edit-form {
+      border-bottom: none;
+      border-radius: 8px;
+    }
+  }
+
+  .e-plan-main {
+    padding: 10px 12px;
+    cursor: pointer;
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+
+    &:hover .e-plan-name { color: #1976d2; }
+  }
+
+  .e-plan-header {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+  }
+
+  .e-active-dot {
+    width: 7px;
+    height: 7px;
+    border-radius: 50%;
+    background: #1976d2;
+    flex-shrink: 0;
+  }
+
+  .e-plan-name {
+    font-weight: 600;
+    font-size: 0.95em;
+    color: #222;
+    transition: color 0.1s;
+  }
+
+  .e-scenario-badge {
+    align-self: flex-start;
+    background: #e8eaf6;
+    color: #3949ab;
+    padding: 2px 8px;
+    border-radius: 10px;
+    font-size: 0.76em;
+    font-weight: 500;
+  }
+
+  .e-plan-meta {
+    font-size: 0.78em;
+    color: #aaa;
+  }
+
+  .e-plan-actions {
+    display: flex;
+    gap: 4px;
+    padding: 6px 10px;
+    border-top: 1px solid #f5f5f5;
+    background: #fafafa;
+  }
+
+  .e-action-btn {
+    padding: 3px 10px;
+    border-radius: 4px;
+    border: 1px solid transparent;
+    cursor: pointer;
+    font-size: 0.78em;
+    font-weight: 500;
+    transition: background 0.1s;
+
+    &.e-action-btn--edit {
+      background: #f5f5f5;
+      border-color: #e0e0e0;
+      color: #555;
+      &:hover { background: #e3f2fd; border-color: #90caf9; color: #1976d2; }
+    }
+
+    &.e-action-btn--fork {
+      background: #e8f5e9;
+      border-color: #a5d6a7;
+      color: #2e7d32;
+      &:hover { background: #c8e6c9; }
+    }
+
+    &.e-action-btn--delete {
+      margin-left: auto;
+      background: none;
+      border-color: transparent;
+      color: #bbb;
+      &:hover { background: #fce4e4; border-color: #ef9a9a; color: #c62828; }
+    }
+  }
+` as React.FC<React.HTMLAttributes<HTMLDivElement>>;

--- a/shift-puzzle-bubly/shift-puzzle-libs/src/feature/ShiftPlanSummary.tsx
+++ b/shift-puzzle-bubly/shift-puzzle-libs/src/feature/ShiftPlanSummary.tsx
@@ -1,0 +1,35 @@
+'use client';
+import React from 'react';
+import { useAppSelector } from '@bublys-org/state-management';
+import {
+  selectMembersForEvent,
+  selectRolesForEvent,
+  selectTimeSlotsForEvent,
+  selectAssignmentsForPlan,
+} from '../slice/index.js';
+import { ShiftPlanSummaryView } from '../ui/Summary/ShiftPlanSummaryView.js';
+
+interface ShiftPlanSummaryProps {
+  eventId: string;
+  shiftPlanId: string;
+}
+
+/** F-7-1〜F-7-3: シフト案評価サマリー（Redux連携） */
+export const ShiftPlanSummary: React.FC<ShiftPlanSummaryProps> = ({
+  eventId,
+  shiftPlanId,
+}) => {
+  const members = useAppSelector(selectMembersForEvent(eventId));
+  const roles = useAppSelector(selectRolesForEvent(eventId));
+  const timeSlots = useAppSelector(selectTimeSlotsForEvent(eventId));
+  const assignments = useAppSelector(selectAssignmentsForPlan(shiftPlanId));
+
+  return (
+    <ShiftPlanSummaryView
+      members={members.map((m) => m.state)}
+      roles={roles.map((r) => r.state)}
+      timeSlots={timeSlots}
+      assignments={assignments.map((a) => a.state)}
+    />
+  );
+};

--- a/shift-puzzle-bubly/shift-puzzle-libs/src/feature/index.ts
+++ b/shift-puzzle-bubly/shift-puzzle-libs/src/feature/index.ts
@@ -1,3 +1,5 @@
 export { ShiftPlanGanttEditor } from './ShiftPlanGanttEditor.js';
 export { ReasonListFeature } from './ReasonListFeature.js';
 export { MemberCollection } from './MemberCollection.js';
+export { MemberDetailFeature } from './MemberDetailFeature.js';
+export { RoleFulfillmentFeature } from './RoleFulfillmentFeature.js';

--- a/shift-puzzle-bubly/shift-puzzle-libs/src/feature/index.ts
+++ b/shift-puzzle-bubly/shift-puzzle-libs/src/feature/index.ts
@@ -1,1 +1,2 @@
 export { ShiftPlanGanttEditor } from './ShiftPlanGanttEditor.js';
+export { ReasonListFeature } from './ReasonListFeature.js';

--- a/shift-puzzle-bubly/shift-puzzle-libs/src/feature/index.ts
+++ b/shift-puzzle-bubly/shift-puzzle-libs/src/feature/index.ts
@@ -1,0 +1,1 @@
+export { ShiftPlanGanttEditor } from './ShiftPlanGanttEditor.js';

--- a/shift-puzzle-bubly/shift-puzzle-libs/src/feature/index.ts
+++ b/shift-puzzle-bubly/shift-puzzle-libs/src/feature/index.ts
@@ -1,2 +1,3 @@
 export { ShiftPlanGanttEditor } from './ShiftPlanGanttEditor.js';
 export { ReasonListFeature } from './ReasonListFeature.js';
+export { MemberCollection } from './MemberCollection.js';

--- a/shift-puzzle-bubly/shift-puzzle-libs/src/feature/index.ts
+++ b/shift-puzzle-bubly/shift-puzzle-libs/src/feature/index.ts
@@ -4,3 +4,9 @@ export { MemberCollection } from './MemberCollection.js';
 export { MemberDetailFeature } from './MemberDetailFeature.js';
 export { RoleFulfillmentFeature } from './RoleFulfillmentFeature.js';
 export { ShiftPlanSummary } from './ShiftPlanSummary.js';
+
+// Issue #39: イベント管理・ルート基盤
+export { EventListFeature } from './EventListFeature.js';
+export { EventDetailFeature } from './EventDetailFeature.js';
+export { RoleListFeature } from './RoleListFeature.js';
+export { ShiftPlanListFeature } from './ShiftPlanListFeature.js';

--- a/shift-puzzle-bubly/shift-puzzle-libs/src/feature/index.ts
+++ b/shift-puzzle-bubly/shift-puzzle-libs/src/feature/index.ts
@@ -10,3 +10,6 @@ export { EventListFeature } from './EventListFeature.js';
 export { EventDetailFeature } from './EventDetailFeature.js';
 export { RoleListFeature } from './RoleListFeature.js';
 export { ShiftPlanListFeature } from './ShiftPlanListFeature.js';
+
+// Issue #41: F-6 シフト案管理
+export { ShiftPlanManager } from './ShiftPlanManager.js';

--- a/shift-puzzle-bubly/shift-puzzle-libs/src/feature/index.ts
+++ b/shift-puzzle-bubly/shift-puzzle-libs/src/feature/index.ts
@@ -3,3 +3,4 @@ export { ReasonListFeature } from './ReasonListFeature.js';
 export { MemberCollection } from './MemberCollection.js';
 export { MemberDetailFeature } from './MemberDetailFeature.js';
 export { RoleFulfillmentFeature } from './RoleFulfillmentFeature.js';
+export { ShiftPlanSummary } from './ShiftPlanSummary.js';

--- a/shift-puzzle-bubly/shift-puzzle-libs/src/index.ts
+++ b/shift-puzzle-bubly/shift-puzzle-libs/src/index.ts
@@ -1,0 +1,14 @@
+// Object type registration (副作用)
+// import './object-type-registration.js';  // Phase 2で追加予定
+
+// Domain models (re-exported from @bublys-org/shift-puzzle-model)
+export * from './domain/index.js';
+
+// UI components
+export * from './ui/index.js';
+
+// Feature components
+export * from './feature/index.js';
+
+// Redux slice
+export * from './slice/index.js';

--- a/shift-puzzle-bubly/shift-puzzle-libs/src/slice/index.ts
+++ b/shift-puzzle-bubly/shift-puzzle-libs/src/slice/index.ts
@@ -1,0 +1,1 @@
+export * from './shift-puzzle-main-slice.js';

--- a/shift-puzzle-bubly/shift-puzzle-libs/src/slice/shift-puzzle-main-slice.ts
+++ b/shift-puzzle-bubly/shift-puzzle-libs/src/slice/shift-puzzle-main-slice.ts
@@ -1,0 +1,309 @@
+import { createSlice, createSelector, type WithSlice } from '@reduxjs/toolkit';
+import type { PayloadAction } from '@reduxjs/toolkit';
+import { rootReducer, type RootState } from '@bublys-org/state-management';
+import {
+  Member,
+  Role,
+  ShiftPlan,
+  Assignment,
+  ConstraintChecker,
+  type EventJSON,
+  type MemberJSON,
+  type RoleJSON,
+  type TimeSlotJSON,
+  type ShiftPlanJSON,
+  type AssignmentJSON,
+  type AssignmentReasonState,
+  type ConstraintViolation,
+} from '@bublys-org/shift-puzzle-model';
+
+// ========== State ==========
+
+type ShiftPuzzleMainState = {
+  events: EventJSON[];
+  members: MemberJSON[];
+  roles: RoleJSON[];
+  timeSlots: TimeSlotJSON[];
+  shiftPlans: ShiftPlanJSON[];
+  currentEventId: string | null;
+  currentShiftPlanId: string | null;
+  /** ガントチャートUI設定 */
+  ganttHourPx: number;
+  ganttAxisMode: 'role' | 'member';
+  /** ガントチャートで表示するdayIndex */
+  ganttDayIndex: number;
+};
+
+const initialState: ShiftPuzzleMainState = {
+  events: [],
+  members: [],
+  roles: [],
+  timeSlots: [],
+  shiftPlans: [],
+  currentEventId: null,
+  currentShiftPlanId: null,
+  ganttHourPx: 80,
+  ganttAxisMode: 'role',
+  ganttDayIndex: 0,
+};
+
+// ========== Helper ==========
+
+function toMutableShiftPlan(plan: ShiftPlanJSON) {
+  return {
+    ...plan,
+    assignments: [...plan.assignments],
+  };
+}
+
+// ========== Slice ==========
+
+export const shiftPuzzleMainSlice = createSlice({
+  name: 'shiftPuzzleMain',
+  initialState,
+  reducers: {
+    // --- Events ---
+    addEvent: (state, action: PayloadAction<EventJSON>) => {
+      state.events.push(action.payload);
+    },
+    updateEvent: (state, action: PayloadAction<EventJSON>) => {
+      const idx = state.events.findIndex((e) => e.id === action.payload.id);
+      if (idx !== -1) state.events[idx] = action.payload;
+    },
+    deleteEvent: (state, action: PayloadAction<string>) => {
+      state.events = state.events.filter((e) => e.id !== action.payload);
+      if (state.currentEventId === action.payload) state.currentEventId = null;
+    },
+    setCurrentEventId: (state, action: PayloadAction<string | null>) => {
+      state.currentEventId = action.payload;
+    },
+
+    // --- Members ---
+    addMember: (state, action: PayloadAction<MemberJSON>) => {
+      state.members.push(action.payload);
+    },
+    updateMember: (state, action: PayloadAction<MemberJSON>) => {
+      const idx = state.members.findIndex((m) => m.id === action.payload.id);
+      if (idx !== -1) state.members[idx] = action.payload;
+    },
+    deleteMember: (state, action: PayloadAction<string>) => {
+      state.members = state.members.filter((m) => m.id !== action.payload);
+    },
+    setMembersForEvent: (state, action: PayloadAction<{ eventId: string; members: MemberJSON[] }>) => {
+      state.members = [
+        ...state.members.filter((m) => m.eventId !== action.payload.eventId),
+        ...action.payload.members,
+      ];
+    },
+
+    // --- Roles ---
+    addRole: (state, action: PayloadAction<RoleJSON>) => {
+      state.roles.push(action.payload);
+    },
+    updateRole: (state, action: PayloadAction<RoleJSON>) => {
+      const idx = state.roles.findIndex((r) => r.id === action.payload.id);
+      if (idx !== -1) state.roles[idx] = action.payload;
+    },
+    deleteRole: (state, action: PayloadAction<string>) => {
+      state.roles = state.roles.filter((r) => r.id !== action.payload);
+    },
+    setRolesForEvent: (state, action: PayloadAction<{ eventId: string; roles: RoleJSON[] }>) => {
+      state.roles = [
+        ...state.roles.filter((r) => r.eventId !== action.payload.eventId),
+        ...action.payload.roles,
+      ];
+    },
+
+    // --- TimeSlots ---
+    setTimeSlotsForEvent: (state, action: PayloadAction<{ eventId: string; timeSlots: TimeSlotJSON[] }>) => {
+      state.timeSlots = [
+        ...state.timeSlots.filter((s) => s.eventId !== action.payload.eventId),
+        ...action.payload.timeSlots,
+      ];
+    },
+    addTimeSlots: (state, action: PayloadAction<TimeSlotJSON[]>) => {
+      state.timeSlots.push(...action.payload);
+    },
+
+    // --- ShiftPlans ---
+    addShiftPlan: (state, action: PayloadAction<ShiftPlanJSON>) => {
+      state.shiftPlans.push(toMutableShiftPlan(action.payload));
+    },
+    updateShiftPlan: (state, action: PayloadAction<ShiftPlanJSON>) => {
+      const idx = state.shiftPlans.findIndex((p) => p.id === action.payload.id);
+      if (idx !== -1) state.shiftPlans[idx] = toMutableShiftPlan(action.payload);
+    },
+    deleteShiftPlan: (state, action: PayloadAction<string>) => {
+      state.shiftPlans = state.shiftPlans.filter((p) => p.id !== action.payload);
+      if (state.currentShiftPlanId === action.payload) {
+        state.currentShiftPlanId = state.shiftPlans[0]?.id ?? null;
+      }
+    },
+    setCurrentShiftPlanId: (state, action: PayloadAction<string | null>) => {
+      state.currentShiftPlanId = action.payload;
+    },
+
+    // --- Assignments（ShiftPlan内の配置を直接操作） ---
+    addAssignment: (
+      state,
+      action: PayloadAction<{ shiftPlanId: string; assignment: AssignmentJSON }>
+    ) => {
+      const plan = state.shiftPlans.find((p) => p.id === action.payload.shiftPlanId);
+      if (plan) plan.assignments.push(action.payload.assignment);
+    },
+    removeAssignment: (
+      state,
+      action: PayloadAction<{ shiftPlanId: string; assignmentId: string }>
+    ) => {
+      const plan = state.shiftPlans.find((p) => p.id === action.payload.shiftPlanId);
+      if (plan) {
+        plan.assignments = plan.assignments.filter(
+          (a) => a.id !== action.payload.assignmentId
+        );
+      }
+    },
+    moveAssignment: (
+      state,
+      action: PayloadAction<{ shiftPlanId: string; assignmentId: string; newTimeSlotId: string }>
+    ) => {
+      const plan = state.shiftPlans.find((p) => p.id === action.payload.shiftPlanId);
+      if (!plan) return;
+      const assignment = plan.assignments.find((a) => a.id === action.payload.assignmentId);
+      if (assignment) {
+        (assignment as AssignmentJSON).timeSlotId = action.payload.newTimeSlotId;
+        (assignment as AssignmentJSON).updatedAt = new Date().toISOString();
+      }
+    },
+    updateAssignmentReason: (
+      state,
+      action: PayloadAction<{
+        shiftPlanId: string;
+        assignmentId: string;
+        reason: AssignmentReasonState;
+      }>
+    ) => {
+      const plan = state.shiftPlans.find((p) => p.id === action.payload.shiftPlanId);
+      if (!plan) return;
+      const assignment = plan.assignments.find((a) => a.id === action.payload.assignmentId);
+      if (assignment) {
+        (assignment as AssignmentJSON).reason = action.payload.reason;
+        (assignment as AssignmentJSON).updatedAt = new Date().toISOString();
+      }
+    },
+
+    // --- UI設定 ---
+    setGanttHourPx: (state, action: PayloadAction<number>) => {
+      state.ganttHourPx = Math.max(40, Math.min(120, action.payload));
+    },
+    setGanttAxisMode: (state, action: PayloadAction<'role' | 'member'>) => {
+      state.ganttAxisMode = action.payload;
+    },
+    setGanttDayIndex: (state, action: PayloadAction<number>) => {
+      state.ganttDayIndex = action.payload;
+    },
+  },
+});
+
+export const {
+  addEvent, updateEvent, deleteEvent, setCurrentEventId,
+  addMember, updateMember, deleteMember, setMembersForEvent,
+  addRole, updateRole, deleteRole, setRolesForEvent,
+  setTimeSlotsForEvent, addTimeSlots,
+  addShiftPlan, updateShiftPlan, deleteShiftPlan, setCurrentShiftPlanId,
+  addAssignment, removeAssignment, moveAssignment, updateAssignmentReason,
+  setGanttHourPx, setGanttAxisMode, setGanttDayIndex,
+} = shiftPuzzleMainSlice.actions;
+
+// LazyLoadedSlicesを拡張
+declare module '@bublys-org/state-management' {
+  export interface LazyLoadedSlices extends WithSlice<typeof shiftPuzzleMainSlice> {}
+}
+
+// rootReducerに注入
+shiftPuzzleMainSlice.injectInto(rootReducer);
+
+// ========== Selectors ==========
+
+type StateWithShiftPuzzleMain = RootState & { shiftPuzzleMain: ShiftPuzzleMainState };
+
+const selectSlice = (state: StateWithShiftPuzzleMain): ShiftPuzzleMainState =>
+  state.shiftPuzzleMain ?? initialState;
+
+// --- Events ---
+export const selectEvents = createSelector(
+  [selectSlice],
+  (s) => s.events
+);
+export const selectCurrentEventId = (state: StateWithShiftPuzzleMain) =>
+  selectSlice(state).currentEventId;
+export const selectCurrentEvent = createSelector([selectSlice], (s) =>
+  s.events.find((e) => e.id === s.currentEventId) ?? null
+);
+
+// --- Members ---
+export const selectMembersForEvent = (eventId: string) =>
+  createSelector([selectSlice], (s) =>
+    s.members.filter((m) => m.eventId === eventId).map((m) => new Member(m))
+  );
+
+// --- Roles ---
+export const selectRolesForEvent = (eventId: string) =>
+  createSelector([selectSlice], (s) =>
+    s.roles.filter((r) => r.eventId === eventId).map((r) => new Role(r))
+  );
+
+// --- TimeSlots ---
+export const selectTimeSlotsForEvent = (eventId: string) =>
+  createSelector([selectSlice], (s) =>
+    s.timeSlots.filter((ts) => ts.eventId === eventId)
+  );
+
+// --- ShiftPlans ---
+export const selectShiftPlans = createSelector([selectSlice], (s) =>
+  s.shiftPlans.map((p) => new ShiftPlan(p))
+);
+export const selectCurrentShiftPlanId = (state: StateWithShiftPuzzleMain) =>
+  selectSlice(state).currentShiftPlanId;
+export const selectShiftPlanById = (id: string) =>
+  createSelector([selectSlice], (s) => {
+    const json = s.shiftPlans.find((p) => p.id === id);
+    return json ? new ShiftPlan(json) : undefined;
+  });
+export const selectCurrentShiftPlan = createSelector([selectSlice], (s) => {
+  const id = s.currentShiftPlanId;
+  if (!id) return undefined;
+  const json = s.shiftPlans.find((p) => p.id === id);
+  return json ? new ShiftPlan(json) : undefined;
+});
+
+// --- Assignments ---
+export const selectAssignmentsForPlan = (planId: string) =>
+  createSelector([selectSlice], (s) => {
+    const plan = s.shiftPlans.find((p) => p.id === planId);
+    return (plan?.assignments ?? []).map((a) => new Assignment(a));
+  });
+
+// --- 制約違反（computed） ---
+export const selectViolationsForPlan = (planId: string, eventId: string) =>
+  createSelector([selectSlice], (s): ConstraintViolation[] => {
+    const plan = s.shiftPlans.find((p) => p.id === planId);
+    if (!plan) return [];
+    const members = s.members.filter((m) => m.eventId === eventId);
+    const roles = s.roles.filter((r) => r.eventId === eventId);
+    const timeSlots = s.timeSlots.filter((ts) => ts.eventId === eventId);
+    const checker = ConstraintChecker.create(
+      plan.assignments,
+      members,
+      roles,
+      timeSlots
+    );
+    return checker.computeViolations();
+  });
+
+// --- UI設定 ---
+export const selectGanttHourPx = (state: StateWithShiftPuzzleMain) =>
+  selectSlice(state).ganttHourPx;
+export const selectGanttAxisMode = (state: StateWithShiftPuzzleMain) =>
+  selectSlice(state).ganttAxisMode;
+export const selectGanttDayIndex = (state: StateWithShiftPuzzleMain) =>
+  selectSlice(state).ganttDayIndex;

--- a/shift-puzzle-bubly/shift-puzzle-libs/src/slice/shift-puzzle-main-slice.ts
+++ b/shift-puzzle-bubly/shift-puzzle-libs/src/slice/shift-puzzle-main-slice.ts
@@ -6,6 +6,7 @@ import {
   Role,
   ShiftPlan,
   Assignment,
+  Event,
   ConstraintChecker,
   type EventJSON,
   type MemberJSON,
@@ -239,6 +240,11 @@ export const selectCurrentEventId = (state: StateWithShiftPuzzleMain) =>
 export const selectCurrentEvent = createSelector([selectSlice], (s) =>
   s.events.find((e) => e.id === s.currentEventId) ?? null
 );
+export const selectEventById = (id: string) =>
+  createSelector([selectSlice], (s) => {
+    const json = s.events.find((e) => e.id === id);
+    return json ? new Event(json) : undefined;
+  });
 
 // --- Members ---
 export const selectMembersForEvent = (eventId: string) =>

--- a/shift-puzzle-bubly/shift-puzzle-libs/src/slice/shift-puzzle-main-slice.ts
+++ b/shift-puzzle-bubly/shift-puzzle-libs/src/slice/shift-puzzle-main-slice.ts
@@ -268,6 +268,10 @@ export const selectTimeSlotsForEvent = (eventId: string) =>
 export const selectShiftPlans = createSelector([selectSlice], (s) =>
   s.shiftPlans.map((p) => new ShiftPlan(p))
 );
+export const selectShiftPlansForEvent = (eventId: string) =>
+  createSelector([selectSlice], (s) =>
+    s.shiftPlans.filter((p) => p.eventId === eventId).map((p) => new ShiftPlan(p))
+  );
 export const selectCurrentShiftPlanId = (state: StateWithShiftPuzzleMain) =>
   selectSlice(state).currentShiftPlanId;
 export const selectShiftPlanById = (id: string) =>

--- a/shift-puzzle-bubly/shift-puzzle-libs/src/slice/shift-puzzle-main-slice.ts
+++ b/shift-puzzle-bubly/shift-puzzle-libs/src/slice/shift-puzzle-main-slice.ts
@@ -8,6 +8,7 @@ import {
   Assignment,
   Event,
   ConstraintChecker,
+  MemberFilter,
   type EventJSON,
   type MemberJSON,
   type RoleJSON,
@@ -16,9 +17,16 @@ import {
   type AssignmentJSON,
   type AssignmentReasonState,
   type ConstraintViolation,
+  type MemberFilterState,
 } from '@bublys-org/shift-puzzle-model';
 
 // ========== State ==========
+
+/** F-5: メンバーフィルター初期状態 */
+const EMPTY_MEMBER_FILTER: MemberFilterState = {
+  requiredSkillIds: [],
+  tags: [],
+};
 
 type ShiftPuzzleMainState = {
   events: EventJSON[];
@@ -33,6 +41,8 @@ type ShiftPuzzleMainState = {
   ganttAxisMode: 'role' | 'member';
   /** ガントチャートで表示するdayIndex */
   ganttDayIndex: number;
+  /** F-5: メンバーフィルター状態（バブル遷移後も保持） */
+  memberFilter: MemberFilterState;
 };
 
 const initialState: ShiftPuzzleMainState = {
@@ -46,6 +56,7 @@ const initialState: ShiftPuzzleMainState = {
   ganttHourPx: 80,
   ganttAxisMode: 'role',
   ganttDayIndex: 0,
+  memberFilter: EMPTY_MEMBER_FILTER,
 };
 
 // ========== Helper ==========
@@ -202,6 +213,16 @@ export const shiftPuzzleMainSlice = createSlice({
     setGanttDayIndex: (state, action: PayloadAction<number>) => {
       state.ganttDayIndex = action.payload;
     },
+
+    // --- F-5: メンバーフィルター ---
+    setMemberFilter: (state, action: PayloadAction<Partial<MemberFilterState>>) => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      state.memberFilter = { ...state.memberFilter, ...action.payload } as any;
+    },
+    resetMemberFilter: (state) => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      state.memberFilter = EMPTY_MEMBER_FILTER as any;
+    },
   },
 });
 
@@ -213,6 +234,7 @@ export const {
   addShiftPlan, updateShiftPlan, deleteShiftPlan, setCurrentShiftPlanId,
   addAssignment, removeAssignment, moveAssignment, updateAssignmentReason,
   setGanttHourPx, setGanttAxisMode, setGanttDayIndex,
+  setMemberFilter, resetMemberFilter,
 } = shiftPuzzleMainSlice.actions;
 
 // LazyLoadedSlicesを拡張
@@ -317,3 +339,29 @@ export const selectGanttAxisMode = (state: StateWithShiftPuzzleMain) =>
   selectSlice(state).ganttAxisMode;
 export const selectGanttDayIndex = (state: StateWithShiftPuzzleMain) =>
   selectSlice(state).ganttDayIndex;
+
+// --- F-5: メンバーフィルター ---
+export const selectMemberFilter = (state: StateWithShiftPuzzleMain): MemberFilterState =>
+  selectSlice(state).memberFilter ?? EMPTY_MEMBER_FILTER;
+
+/** F-5: フィルター適用済みメンバー（memoized） */
+export const selectFilteredMembersForEvent = (eventId: string, planId?: string) =>
+  createSelector([selectSlice], (s): Member[] => {
+    const allMembers = s.members.filter((m) => m.eventId === eventId).map((m) => new Member(m));
+    const filter = new MemberFilter(s.memberFilter ?? EMPTY_MEMBER_FILTER);
+
+    // 配置状況フィルター用: memberId → 配置数マップ
+    let assignedCountMap: ReadonlyMap<string, number> | undefined;
+    if (s.memberFilter?.assignmentStatus && planId) {
+      const plan = s.shiftPlans.find((p) => p.id === planId);
+      if (plan) {
+        const countMap = new Map<string, number>();
+        for (const a of plan.assignments) {
+          countMap.set(a.memberId, (countMap.get(a.memberId) ?? 0) + 1);
+        }
+        assignedCountMap = countMap;
+      }
+    }
+
+    return filter.apply(allMembers, assignedCountMap);
+  });

--- a/shift-puzzle-bubly/shift-puzzle-libs/src/ui/GanttChart/AssignmentBlock.tsx
+++ b/shift-puzzle-bubly/shift-puzzle-libs/src/ui/GanttChart/AssignmentBlock.tsx
@@ -1,0 +1,138 @@
+'use client';
+import React from 'react';
+import styled from 'styled-components';
+import type {
+  AssignmentState,
+  RoleState,
+  MemberState,
+  ConstraintViolation,
+} from '@bublys-org/shift-puzzle-model';
+
+interface AssignmentBlockProps {
+  assignment: AssignmentState;
+  /** バーに表示するラベル元（役割名 or メンバー名） */
+  role: RoleState | undefined;
+  member: MemberState | undefined;
+  left: number;
+  width: number;
+  rowHeight: number;
+  violation?: ConstraintViolation;
+  onClick?: (assignmentId: string) => void;
+}
+
+/** ガントチャート上の配置ブロック（ドラッグ可能） */
+export const AssignmentBlock: React.FC<AssignmentBlockProps> = ({
+  assignment,
+  role,
+  member,
+  left,
+  width,
+  rowHeight,
+  violation,
+  onClick,
+}) => {
+  const bgColor = role?.color ?? '#1976d2';
+
+  const handleDragStart = (e: React.DragEvent<HTMLDivElement>) => {
+    e.dataTransfer.setData('text/assignment-id', assignment.id);
+    e.dataTransfer.setData('text/member-id', assignment.memberId);
+    e.dataTransfer.setData('text/role-id', assignment.roleId);
+    e.dataTransfer.effectAllowed = 'move';
+    e.stopPropagation();
+  };
+
+  const hasReason = assignment.reason.text.length > 0;
+  const outlineColor = violation ? violationOutlineColor(violation.type) : 'transparent';
+
+  return (
+    <StyledBlock
+      style={{
+        left,
+        width: Math.max(width - 2, 4),
+        height: rowHeight - 8,
+        top: 4,
+        backgroundColor: bgColor,
+        outlineColor,
+        outlineWidth: violation ? 2 : 0,
+        outlineStyle: violation ? 'solid' : 'none',
+        outlineOffset: -2,
+      }}
+      draggable
+      onDragStart={handleDragStart}
+      onClick={(e: React.MouseEvent<HTMLDivElement>) => {
+        e.stopPropagation();
+        onClick?.(assignment.id);
+      }}
+      title={buildTooltip(assignment, role, member, violation)}
+    >
+      <span className="e-label">{role?.name ?? member?.name ?? '?'}</span>
+      {hasReason && (
+        <span className="e-reason-dot" title={`理由: ${assignment.reason.text}`}>
+          ●
+        </span>
+      )}
+    </StyledBlock>
+  );
+};
+
+function violationOutlineColor(type: ConstraintViolation['type']): string {
+  switch (type) {
+    case 'duplicate_member_in_timeslot': return '#f44336';
+    case 'outside_availability':         return '#ff9800';
+    case 'skill_mismatch':               return '#ffc107';
+    default:                             return '#9e9e9e';
+  }
+}
+
+function buildTooltip(
+  assignment: AssignmentState,
+  role: RoleState | undefined,
+  member: MemberState | undefined,
+  violation: ConstraintViolation | undefined
+): string {
+  const lines = [
+    `役割: ${role?.name ?? '-'}`,
+    `担当: ${member?.name ?? '-'}`,
+  ];
+  if (assignment.reason.text) lines.push(`理由: ${assignment.reason.text}`);
+  if (violation) lines.push(`⚠ ${violation.message}`);
+  if (assignment.locked) lines.push('🔒 ロック済み');
+  return lines.join('\n');
+}
+
+const StyledBlock = styled.div`
+  position: absolute;
+  border-radius: 3px;
+  display: flex;
+  align-items: center;
+  gap: 3px;
+  padding: 0 6px;
+  color: white;
+  font-size: 0.8em;
+  cursor: grab;
+  overflow: hidden;
+  white-space: nowrap;
+  transition: box-shadow 0.15s;
+  z-index: 2;
+
+  &:active {
+    cursor: grabbing;
+  }
+
+  &:hover {
+    box-shadow: 0 2px 6px rgba(0, 0, 0, 0.3);
+    z-index: 3;
+  }
+
+  .e-label {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    flex: 1;
+  }
+
+  .e-reason-dot {
+    font-size: 0.5em;
+    opacity: 0.7;
+    flex-shrink: 0;
+  }
+` as React.FC<React.HTMLAttributes<HTMLDivElement> & { draggable?: boolean }>;

--- a/shift-puzzle-bubly/shift-puzzle-libs/src/ui/GanttChart/ConflictHighlight.tsx
+++ b/shift-puzzle-bubly/shift-puzzle-libs/src/ui/GanttChart/ConflictHighlight.tsx
@@ -1,0 +1,44 @@
+'use client';
+import React from 'react';
+import styled from 'styled-components';
+import type { ConstraintViolation } from '@bublys-org/shift-puzzle-model';
+
+interface ConflictHighlightProps {
+  violation: ConstraintViolation;
+  left: number;
+  width: number;
+  rowHeight: number;
+}
+
+/** 制約違反を視覚的にハイライト表示するオーバーレイ */
+export const ConflictHighlight: React.FC<ConflictHighlightProps> = ({
+  violation,
+  left,
+  width,
+  rowHeight,
+}) => {
+  const color = violationColor(violation.type);
+  return (
+    <StyledHighlight
+      style={{ left, width, height: rowHeight - 8, top: 4, borderColor: color, backgroundColor: `${color}22` }}
+      title={violation.message}
+    />
+  );
+};
+
+function violationColor(type: ConstraintViolation['type']): string {
+  switch (type) {
+    case 'duplicate_member_in_timeslot': return '#f44336';
+    case 'outside_availability':         return '#ff9800';
+    case 'skill_mismatch':               return '#ffc107';
+    default:                             return '#9e9e9e';
+  }
+}
+
+const StyledHighlight = styled.div`
+  position: absolute;
+  border-radius: 3px;
+  border: 2px solid;
+  pointer-events: none;
+  z-index: 4;
+` as React.FC<React.HTMLAttributes<HTMLDivElement>>;

--- a/shift-puzzle-bubly/shift-puzzle-libs/src/ui/GanttChart/GanttChartView.tsx
+++ b/shift-puzzle-bubly/shift-puzzle-libs/src/ui/GanttChart/GanttChartView.tsx
@@ -1,0 +1,388 @@
+'use client';
+import React, { useMemo, useRef, useState } from 'react';
+import styled from 'styled-components';
+import {
+  getDragType,
+  DRAG_KEYS,
+} from '@bublys-org/bubbles-ui';
+import type {
+  MemberState,
+  RoleState,
+  TimeSlotState,
+  AssignmentState,
+  AssignmentReasonState,
+  ConstraintViolation,
+} from '@bublys-org/shift-puzzle-model';
+import { TimeAxis } from './TimeAxis.js';
+import { MemberRow } from './MemberRow.js';
+import { ReasonInputDialog } from './ReasonInputDialog.js';
+
+// ========== Props ==========
+
+export interface GanttChartViewProps {
+  /** メンバー一覧 */
+  members: MemberState[];
+  /** 役割一覧 */
+  roles: RoleState[];
+  /** このシフト案のTimeSlot一覧 */
+  timeSlots: TimeSlotState[];
+  /** 配置一覧 */
+  assignments: AssignmentState[];
+  /** 制約違反一覧（F-2-6） */
+  violations?: ConstraintViolation[];
+  /** 表示するdayIndex（デフォルト: 0） */
+  dayIndex?: number;
+  /** 1時間あたりのピクセル幅 */
+  hourPx?: number;
+  /** 行の高さ */
+  rowHeight?: number;
+  /** 行モード: role = 役割行（メンバーをD&D配置）/ member = メンバー行（配置を確認） */
+  axisMode?: 'role' | 'member';
+  /** 新規配置コールバック */
+  onCreateAssignment?: (
+    memberId: string,
+    timeSlotId: string,
+    roleId: string,
+    reason: AssignmentReasonState
+  ) => void;
+  /** 配置移動コールバック（timeSlotId変更） */
+  onMoveAssignment?: (assignmentId: string, newTimeSlotId: string) => void;
+  /** 配置クリックコールバック */
+  onAssignmentClick?: (assignmentId: string) => void;
+}
+
+// ========== 内部型 ==========
+
+interface PendingDrop {
+  memberId: string;
+  timeSlotId: string;
+  /** roleモード時のrowId（roleId）*/
+  rowId: string;
+}
+
+// ========== コンポーネント ==========
+
+const LABEL_WIDTH = 140;
+const AXIS_HEIGHT = 36;
+
+export const GanttChartView: React.FC<GanttChartViewProps> = ({
+  members,
+  roles,
+  timeSlots,
+  assignments,
+  violations = [],
+  dayIndex = 0,
+  hourPx = 80,
+  rowHeight = 48,
+  axisMode = 'role',
+  onCreateAssignment,
+  onMoveAssignment,
+  onAssignmentClick,
+}) => {
+  const scrollRef = useRef<HTMLDivElement>(null);
+  const [pendingDrop, setPendingDrop] = useState<PendingDrop | null>(null);
+  const [pendingRoleId, setPendingRoleId] = useState<string>('');
+
+  // このdayのTimeSlot一覧
+  const daySlots = useMemo(
+    () => timeSlots.filter((s) => s.dayIndex === dayIndex),
+    [timeSlots, dayIndex]
+  );
+
+  // 時刻範囲の計算
+  const { dayStartMinute, dayEndMinute, dayWidth } = useMemo(() => {
+    if (daySlots.length === 0) {
+      return { dayStartMinute: 540, dayEndMinute: 1200, dayWidth: 0 };
+    }
+    const starts = daySlots.map((s) => s.startMinute);
+    const ends = daySlots.map((s) => s.startMinute + s.durationMinutes);
+    const start = Math.min(...starts);
+    const end = Math.max(...ends);
+    const width = (end - start) * (hourPx / 60);
+    return { dayStartMinute: start, dayEndMinute: end, dayWidth: width };
+  }, [daySlots, hourPx]);
+
+  const minutePx = hourPx / 60;
+
+  // ルックアップマップ
+  const roleMap = useMemo(() => new Map(roles.map((r) => [r.id, r])), [roles]);
+  const memberMap = useMemo(() => new Map(members.map((m) => [m.id, m])), [members]);
+
+  // ========== 行データ ==========
+
+  type RowData = {
+    id: string;
+    label: string;
+    assignments: AssignmentState[];
+    availableSlotIds?: ReadonlyArray<string>;
+  };
+
+  const rows: RowData[] = useMemo(() => {
+    if (axisMode === 'role') {
+      return roles.map((role) => ({
+        id: role.id,
+        label: role.name,
+        assignments: assignments.filter(
+          (a) => a.roleId === role.id && daySlots.some((s) => s.id === a.timeSlotId)
+        ),
+      }));
+    } else {
+      return members.map((member) => ({
+        id: member.id,
+        label: member.name,
+        assignments: assignments.filter(
+          (a) => a.memberId === member.id && daySlots.some((s) => s.id === a.timeSlotId)
+        ),
+        availableSlotIds: member.availableSlotIds,
+      }));
+    }
+  }, [axisMode, roles, members, assignments, daySlots]);
+
+  // ========== D&D ハンドラ ==========
+
+  const handleDragOver = (e: React.DragEvent<HTMLDivElement>) => {
+    const types = Array.from(e.dataTransfer.types);
+    const memberDragType = getDragType('Member');
+    const isInternal = types.includes('text/assignment-id');
+    const isMemberDrag = types.includes(memberDragType);
+    if (isInternal || isMemberDrag || types.includes('text/member-id')) {
+      e.preventDefault();
+    }
+  };
+
+  const handleDrop = (e: React.DragEvent<HTMLDivElement>, rowId: string) => {
+    e.preventDefault();
+
+    const scrollEl = scrollRef.current;
+    if (!scrollEl) return;
+
+    // ドロップ位置 → TimeSlot特定
+    const rect = scrollEl.getBoundingClientRect();
+    const px = e.clientX - rect.left + scrollEl.scrollLeft - LABEL_WIDTH;
+    const targetSlot = findSlotAtPx(px);
+    if (!targetSlot) return;
+
+    // 内部移動（既存配置のドラッグ）
+    const assignmentId = e.dataTransfer.getData('text/assignment-id');
+    if (assignmentId) {
+      onMoveAssignment?.(assignmentId, targetSlot.id);
+      return;
+    }
+
+    // ObjectViewからのメンバードラッグ（新規配置）
+    const memberDragType = getDragType('Member');
+    const types = Array.from(e.dataTransfer.types);
+    let memberId: string | null = null;
+
+    if (types.includes('text/member-id')) {
+      memberId = e.dataTransfer.getData('text/member-id');
+    } else if (types.includes(memberDragType)) {
+      const url =
+        e.dataTransfer.getData(memberDragType) || e.dataTransfer.getData(DRAG_KEYS.url);
+      const match = url.match(/members?\/([^/]+)/);
+      if (match) memberId = match[1];
+    }
+
+    if (!memberId) return;
+
+    // roleモード: rowId = roleId として直接使用
+    // memberモード: ダイアログで役割を選択
+    const roleId = axisMode === 'role' ? rowId : '';
+
+    setPendingDrop({ memberId, timeSlotId: targetSlot.id, rowId });
+    setPendingRoleId(roleId);
+  };
+
+  const findSlotAtPx = (px: number): TimeSlotState | undefined => {
+    const minute = px / minutePx + dayStartMinute;
+    return daySlots.find(
+      (s) => s.startMinute <= minute && minute < s.startMinute + s.durationMinutes
+    );
+  };
+
+  // 配置確定
+  const handleConfirmReason = (reason: AssignmentReasonState) => {
+    if (!pendingDrop) return;
+    const roleId = pendingRoleId || pendingDrop.rowId;
+    if (!roleId) return;
+    onCreateAssignment?.(pendingDrop.memberId, pendingDrop.timeSlotId, roleId, reason);
+    setPendingDrop(null);
+    setPendingRoleId('');
+  };
+
+  // ダイアログ用情報
+  const pendingMember = pendingDrop ? memberMap.get(pendingDrop.memberId) : undefined;
+  const pendingRole =
+    pendingDrop && axisMode === 'role' ? roleMap.get(pendingDrop.rowId) : undefined;
+
+  // ========== 役割充足状況バッジ（F-2-6補足） ==========
+
+  const roleFulfillment = useMemo(() => {
+    if (axisMode !== 'role') return new Map<string, boolean>();
+    const map = new Map<string, boolean>();
+    for (const role of roles) {
+      for (const slot of daySlots) {
+        const count = assignments.filter(
+          (a) => a.roleId === role.id && a.timeSlotId === slot.id
+        ).length;
+        if (count < role.minRequired) {
+          map.set(role.id, false);
+          break;
+        }
+        map.set(role.id, true);
+      }
+    }
+    return map;
+  }, [axisMode, roles, assignments, daySlots]);
+
+  // ========== レンダリング ==========
+
+  return (
+    <StyledGantt>
+      {/* ヘッダー行 */}
+      <div className="e-header-row" style={{ height: AXIS_HEIGHT }}>
+        <div className="e-label-header" style={{ width: LABEL_WIDTH }} />
+        <div className="e-timeline-header-scroll">
+          <div className="e-timeline-header-inner" style={{ width: dayWidth }}>
+            <TimeAxis
+              dayStartMinute={dayStartMinute}
+              dayEndMinute={dayEndMinute}
+              hourPx={hourPx}
+            />
+          </div>
+        </div>
+      </div>
+
+      {/* ボディ */}
+      <div className="e-body" ref={scrollRef}>
+        {/* ラベル列（固定） */}
+        <div className="e-label-column" style={{ width: LABEL_WIDTH }}>
+          {rows.map((row) => (
+            <div key={row.id} className="e-row-label" style={{ height: rowHeight }}>
+              <span className="e-label-text">{row.label}</span>
+              {axisMode === 'role' && roleFulfillment.get(row.id) === false && (
+                <span className="e-badge-shortage">不足</span>
+              )}
+            </div>
+          ))}
+        </div>
+
+        {/* タイムライン列 */}
+        <div className="e-timeline-column" style={{ width: dayWidth }}>
+          {rows.map((row) => (
+            <MemberRow
+              key={row.id}
+              label={row.label}
+              availableSlotIds={row.availableSlotIds}
+              assignments={row.assignments}
+              roleMap={roleMap}
+              memberMap={memberMap}
+              dayTimeSlots={daySlots}
+              violations={violations}
+              rowHeight={rowHeight}
+              dayStartMinute={dayStartMinute}
+              hourPx={hourPx}
+              dayWidth={dayWidth}
+              barLabelMode={axisMode === 'role' ? 'member' : 'role'}
+              onAssignmentClick={onAssignmentClick}
+              onDragOver={handleDragOver}
+              onDrop={(e) => handleDrop(e, row.id)}
+            />
+          ))}
+        </div>
+      </div>
+
+      {/* F-2-5: 配置理由入力ダイアログ */}
+      <ReasonInputDialog
+        open={pendingDrop !== null}
+        memberName={pendingMember?.name}
+        roleName={pendingRole?.name}
+        roles={axisMode === 'member' ? roles.map((r) => ({ id: r.id, name: r.name, color: r.color })) : undefined}
+        selectedRoleId={pendingRoleId}
+        onRoleChange={setPendingRoleId}
+        onConfirm={handleConfirmReason}
+        onCancel={() => { setPendingDrop(null); setPendingRoleId(''); }}
+      />
+    </StyledGantt>
+  );
+};
+
+// ========== スタイル ==========
+
+const StyledGantt = styled.div`
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  overflow: hidden;
+  font-size: 0.85em;
+  background: white;
+
+  .e-header-row {
+    display: flex;
+    flex-shrink: 0;
+    border-bottom: 2px solid #c5cae9;
+    background: #f5f5f5;
+  }
+
+  .e-label-header {
+    flex-shrink: 0;
+    border-right: 1px solid #ddd;
+    background: #f5f5f5;
+  }
+
+  .e-timeline-header-scroll {
+    flex: 1;
+    overflow: hidden;
+  }
+
+  .e-timeline-header-inner {
+    height: 100%;
+  }
+
+  .e-body {
+    flex: 1;
+    overflow: auto;
+    display: flex;
+  }
+
+  .e-label-column {
+    flex-shrink: 0;
+    position: sticky;
+    left: 0;
+    z-index: 5;
+    background: #fafafa;
+    border-right: 1px solid #ddd;
+  }
+
+  .e-row-label {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    padding: 0 10px;
+    border-bottom: 1px solid #eee;
+    font-weight: 500;
+    font-size: 0.9em;
+
+    .e-label-text {
+      flex: 1;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+
+    .e-badge-shortage {
+      background: #ffecb3;
+      color: #e65100;
+      font-size: 0.7em;
+      font-weight: bold;
+      padding: 1px 5px;
+      border-radius: 3px;
+      border: 1px solid #ff8f00;
+      white-space: nowrap;
+    }
+  }
+
+  .e-timeline-column {
+    flex-shrink: 0;
+  }
+` as React.FC<React.HTMLAttributes<HTMLDivElement>>;

--- a/shift-puzzle-bubly/shift-puzzle-libs/src/ui/GanttChart/GanttChartView.tsx
+++ b/shift-puzzle-bubly/shift-puzzle-libs/src/ui/GanttChart/GanttChartView.tsx
@@ -161,7 +161,8 @@ export const GanttChartView: React.FC<GanttChartViewProps> = ({
     const memberDragType = getDragType('Member');
     const isInternal = types.includes('text/assignment-id');
     const isMemberDrag = types.includes(memberDragType);
-    if (isInternal || isMemberDrag || types.includes('text/member-id')) {
+    const isRoleDrag = types.includes('text/role-id');
+    if (isInternal || isMemberDrag || types.includes('text/member-id') || isRoleDrag) {
       e.preventDefault();
     }
   };
@@ -185,9 +186,30 @@ export const GanttChartView: React.FC<GanttChartViewProps> = ({
       return;
     }
 
+    const types = Array.from(e.dataTransfer.types);
+
+    // 役割リストからのドロップ（メンバービューで役割を配置）
+    if (types.includes('text/role-id') && axisMode === 'member') {
+      const roleId = e.dataTransfer.getData('text/role-id');
+      const memberId = rowId;
+      if (roleId && memberId) {
+        if (!showReasonDialog) {
+          onCreateAssignment?.(memberId, targetSlot.id, roleId, {
+            category: 'other',
+            text: '',
+            createdBy: '',
+            createdAt: new Date().toISOString(),
+          });
+          return;
+        }
+        setPendingDrop({ memberId, timeSlotId: targetSlot.id, rowId });
+        setPendingRoleId(roleId);
+        return;
+      }
+    }
+
     // ObjectViewからのメンバードラッグ（新規配置）
     const memberDragType = getDragType('Member');
-    const types = Array.from(e.dataTransfer.types);
     let memberId: string | null = null;
 
     if (types.includes('text/member-id')) {

--- a/shift-puzzle-bubly/shift-puzzle-libs/src/ui/GanttChart/GanttChartView.tsx
+++ b/shift-puzzle-bubly/shift-puzzle-libs/src/ui/GanttChart/GanttChartView.tsx
@@ -48,8 +48,18 @@ export interface GanttChartViewProps {
   ) => void;
   /** 配置移動コールバック（timeSlotId変更） */
   onMoveAssignment?: (assignmentId: string, newTimeSlotId: string) => void;
-  /** 配置クリックコールバック */
-  onAssignmentClick?: (assignmentId: string) => void;
+  /** 配置クリックコールバック（memberId・roleIdも含む） */
+  onAssignmentClick?: (assignmentId: string, memberId: string, roleId: string) => void;
+  /**
+   * セルクリック時の外部コールバック（バブル連携用）。
+   * 指定時はローカルのPlacementPickerDialogを表示せず、呼び出し元がバブルを開く。
+   */
+  onCellClick?: (rowId: string, timeSlotId: string) => void;
+  /**
+   * 配置理由ダイアログを表示するか。
+   * false（デフォルト）の場合、D&D後に理由なしで即座に配置を確定する。
+   */
+  showReasonDialog?: boolean;
 }
 
 // ========== 内部型 ==========
@@ -79,6 +89,8 @@ export const GanttChartView: React.FC<GanttChartViewProps> = ({
   onCreateAssignment,
   onMoveAssignment,
   onAssignmentClick,
+  onCellClick,
+  showReasonDialog = false,
 }) => {
   const scrollRef = useRef<HTMLDivElement>(null);
   const [pendingDrop, setPendingDrop] = useState<PendingDrop | null>(null);
@@ -193,6 +205,17 @@ export const GanttChartView: React.FC<GanttChartViewProps> = ({
     // memberモード: ダイアログで役割を選択
     const roleId = axisMode === 'role' ? rowId : '';
 
+    if (!showReasonDialog && roleId) {
+      // 理由ダイアログなし: 即座に配置確定（理由は空）
+      onCreateAssignment?.(memberId, targetSlot.id, roleId, {
+        category: 'other',
+        text: '',
+        createdBy: '',
+        createdAt: new Date().toISOString(),
+      });
+      return;
+    }
+
     setPendingDrop({ memberId, timeSlotId: targetSlot.id, rowId });
     setPendingRoleId(roleId);
   };
@@ -213,7 +236,14 @@ export const GanttChartView: React.FC<GanttChartViewProps> = ({
     const px = e.clientX - rect.left + scrollEl.scrollLeft - LABEL_WIDTH;
     const targetSlot = findSlotAtPx(px);
     if (!targetSlot) return;
-    setClickedCell({ rowId, timeSlotId: targetSlot.id });
+
+    if (onCellClick) {
+      // バブル連携モード: 呼び出し元がバブルを開く
+      onCellClick(rowId, targetSlot.id);
+    } else {
+      // ローカルモーダルモード（後方互換）
+      setClickedCell({ rowId, timeSlotId: targetSlot.id });
+    }
   };
 
   const handlePickerSelect = (selectedId: string) => {

--- a/shift-puzzle-bubly/shift-puzzle-libs/src/ui/GanttChart/MemberRow.tsx
+++ b/shift-puzzle-bubly/shift-puzzle-libs/src/ui/GanttChart/MemberRow.tsx
@@ -93,6 +93,8 @@ export const MemberRow: React.FC<MemberRowProps> = ({
               assignment={assignment}
               role={barLabelMode === 'role' ? undefined : role}
               member={barLabelMode === 'member' ? undefined : member}
+              memberName={member?.name}
+              roleName={role?.name}
               left={left}
               width={width}
               rowHeight={rowHeight}

--- a/shift-puzzle-bubly/shift-puzzle-libs/src/ui/GanttChart/MemberRow.tsx
+++ b/shift-puzzle-bubly/shift-puzzle-libs/src/ui/GanttChart/MemberRow.tsx
@@ -30,6 +30,7 @@ interface MemberRowProps {
   onAssignmentClick?: (assignmentId: string) => void;
   onDragOver?: (e: React.DragEvent<HTMLDivElement>) => void;
   onDrop?: (e: React.DragEvent<HTMLDivElement>) => void;
+  onRowClick?: (e: React.MouseEvent<HTMLDivElement>) => void;
 }
 
 /** ガントチャートの1行（メンバー or 役割） */
@@ -48,6 +49,7 @@ export const MemberRow: React.FC<MemberRowProps> = ({
   onAssignmentClick,
   onDragOver,
   onDrop,
+  onRowClick,
 }) => {
   const minutePx = hourPx / 60;
 
@@ -68,6 +70,7 @@ export const MemberRow: React.FC<MemberRowProps> = ({
       style={{ height: rowHeight, width: dayWidth }}
       onDragOver={onDragOver}
       onDrop={onDrop}
+      onClick={onRowClick}
     >
       {/* F-2-7: 参加可能時間帯のオーバーレイ */}
       {availableRects.map((rect, i) => (

--- a/shift-puzzle-bubly/shift-puzzle-libs/src/ui/GanttChart/MemberRow.tsx
+++ b/shift-puzzle-bubly/shift-puzzle-libs/src/ui/GanttChart/MemberRow.tsx
@@ -1,0 +1,137 @@
+'use client';
+import React from 'react';
+import styled from 'styled-components';
+import type {
+  AssignmentState,
+  RoleState,
+  MemberState,
+  TimeSlotState,
+  ConstraintViolation,
+} from '@bublys-org/shift-puzzle-model';
+import { AssignmentBlock } from './AssignmentBlock.js';
+import { ConflictHighlight } from './ConflictHighlight.js';
+
+interface MemberRowProps {
+  label: string;
+  /** F-2-7: このメンバーが参加可能なTimeSlot.id群 */
+  availableSlotIds?: ReadonlyArray<string>;
+  assignments: AssignmentState[];
+  roleMap: Map<string, RoleState>;
+  memberMap: Map<string, MemberState>;
+  /** 同日のTimeSlot一覧 */
+  dayTimeSlots: TimeSlotState[];
+  violations: ConstraintViolation[];
+  rowHeight: number;
+  dayStartMinute: number;
+  hourPx: number;
+  dayWidth: number;
+  /** バーラベルモード: 役割名 or メンバー名 */
+  barLabelMode: 'role' | 'member';
+  onAssignmentClick?: (assignmentId: string) => void;
+  onDragOver?: (e: React.DragEvent<HTMLDivElement>) => void;
+  onDrop?: (e: React.DragEvent<HTMLDivElement>) => void;
+}
+
+/** ガントチャートの1行（メンバー or 役割） */
+export const MemberRow: React.FC<MemberRowProps> = ({
+  availableSlotIds,
+  assignments,
+  roleMap,
+  memberMap,
+  dayTimeSlots,
+  violations,
+  rowHeight,
+  dayStartMinute,
+  hourPx,
+  dayWidth,
+  barLabelMode,
+  onAssignmentClick,
+  onDragOver,
+  onDrop,
+}) => {
+  const minutePx = hourPx / 60;
+
+  const slotToRect = (slot: TimeSlotState) => ({
+    left: (slot.startMinute - dayStartMinute) * minutePx,
+    width: slot.durationMinutes * minutePx,
+  });
+
+  const findViolation = (assignmentId: string) =>
+    violations.find((v) => v.assignmentId === assignmentId);
+
+  const availableRects = availableSlotIds
+    ? dayTimeSlots.filter((s) => availableSlotIds.includes(s.id)).map(slotToRect)
+    : [];
+
+  return (
+    <StyledRow
+      style={{ height: rowHeight, width: dayWidth }}
+      onDragOver={onDragOver}
+      onDrop={onDrop}
+    >
+      {/* F-2-7: 参加可能時間帯のオーバーレイ */}
+      {availableRects.map((rect, i) => (
+        <div
+          key={i}
+          className="e-available-overlay"
+          style={{ left: rect.left, width: rect.width }}
+        />
+      ))}
+
+      {/* 配置ブロック */}
+      {assignments.map((assignment) => {
+        const slot = dayTimeSlots.find((s) => s.id === assignment.timeSlotId);
+        if (!slot) return null;
+        const { left, width } = slotToRect(slot);
+        const violation = findViolation(assignment.id);
+        const role = roleMap.get(assignment.roleId);
+        const member = memberMap.get(assignment.memberId);
+
+        return (
+          <React.Fragment key={assignment.id}>
+            <AssignmentBlock
+              assignment={assignment}
+              role={barLabelMode === 'role' ? undefined : role}
+              member={barLabelMode === 'member' ? undefined : member}
+              left={left}
+              width={width}
+              rowHeight={rowHeight}
+              violation={violation}
+              onClick={onAssignmentClick}
+            />
+            {/* F-2-6: 制約違反ハイライト */}
+            {violation && (
+              <ConflictHighlight
+                violation={violation}
+                left={left}
+                width={width}
+                rowHeight={rowHeight}
+              />
+            )}
+          </React.Fragment>
+        );
+      })}
+    </StyledRow>
+  );
+};
+
+const StyledRow = styled.div`
+  position: relative;
+  border-bottom: 1px solid #eee;
+  cursor: crosshair;
+
+  &:hover {
+    background-color: rgba(25, 118, 210, 0.04);
+  }
+
+  .e-available-overlay {
+    position: absolute;
+    top: 2px;
+    height: calc(100% - 4px);
+    background-color: rgba(76, 175, 80, 0.12);
+    border: 1px solid rgba(76, 175, 80, 0.3);
+    border-radius: 2px;
+    pointer-events: none;
+    z-index: 1;
+  }
+` as React.FC<React.HTMLAttributes<HTMLDivElement>>;

--- a/shift-puzzle-bubly/shift-puzzle-libs/src/ui/GanttChart/MemberRow.tsx
+++ b/shift-puzzle-bubly/shift-puzzle-libs/src/ui/GanttChart/MemberRow.tsx
@@ -27,7 +27,7 @@ interface MemberRowProps {
   dayWidth: number;
   /** バーラベルモード: 役割名 or メンバー名 */
   barLabelMode: 'role' | 'member';
-  onAssignmentClick?: (assignmentId: string) => void;
+  onAssignmentClick?: (assignmentId: string, memberId: string, roleId: string) => void;
   onDragOver?: (e: React.DragEvent<HTMLDivElement>) => void;
   onDrop?: (e: React.DragEvent<HTMLDivElement>) => void;
   onRowClick?: (e: React.MouseEvent<HTMLDivElement>) => void;
@@ -94,15 +94,17 @@ export const MemberRow: React.FC<MemberRowProps> = ({
           <React.Fragment key={assignment.id}>
             <AssignmentBlock
               assignment={assignment}
-              role={barLabelMode === 'role' ? undefined : role}
-              member={barLabelMode === 'member' ? undefined : member}
+              role={barLabelMode === 'member' ? undefined : role}
+              member={barLabelMode === 'role' ? undefined : member}
               memberName={member?.name}
               roleName={role?.name}
               left={left}
               width={width}
               rowHeight={rowHeight}
               violation={violation}
-              onClick={onAssignmentClick}
+              onClick={(assignmentId) =>
+                onAssignmentClick?.(assignmentId, assignment.memberId, assignment.roleId)
+              }
             />
             {/* F-2-6: 制約違反ハイライト */}
             {violation && (

--- a/shift-puzzle-bubly/shift-puzzle-libs/src/ui/GanttChart/PlacementPickerDialog.tsx
+++ b/shift-puzzle-bubly/shift-puzzle-libs/src/ui/GanttChart/PlacementPickerDialog.tsx
@@ -1,0 +1,157 @@
+'use client';
+import React from 'react';
+import styled from 'styled-components';
+
+export interface PickerItem {
+  id: string;
+  name: string;
+  /** 役割の場合に使う色ドット */
+  color?: string;
+  /** 補足テキスト（参加可否など） */
+  subtitle?: string;
+}
+
+interface PlacementPickerDialogProps {
+  open: boolean;
+  title: string;
+  items: PickerItem[];
+  onSelect: (id: string) => void;
+  onCancel: () => void;
+}
+
+/** セルクリック時に表示するメンバー or 役割ピッカー */
+export const PlacementPickerDialog: React.FC<PlacementPickerDialogProps> = ({
+  open,
+  title,
+  items,
+  onSelect,
+  onCancel,
+}) => {
+  if (!open) return null;
+
+  return (
+    <Overlay onClick={onCancel}>
+      <Panel onClick={(e) => e.stopPropagation()}>
+        <div className="e-header">
+          <span className="e-title">{title}</span>
+          <button className="e-close" onClick={onCancel} aria-label="閉じる">
+            ✕
+          </button>
+        </div>
+        {items.length === 0 ? (
+          <div className="e-empty">対応可能な候補がありません</div>
+        ) : (
+          <ul className="e-list">
+            {items.map((item) => (
+              <li key={item.id} className="e-item" onClick={() => onSelect(item.id)}>
+                {item.color && (
+                  <span className="e-dot" style={{ background: item.color }} />
+                )}
+                <span className="e-name">{item.name}</span>
+                {item.subtitle && <span className="e-sub">{item.subtitle}</span>}
+              </li>
+            ))}
+          </ul>
+        )}
+      </Panel>
+    </Overlay>
+  );
+};
+
+const Overlay = styled.div`
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.35);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 200;
+` as React.FC<React.HTMLAttributes<HTMLDivElement>>;
+
+const Panel = styled.div`
+  background: white;
+  border-radius: 10px;
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.18);
+  min-width: 280px;
+  max-width: 360px;
+  max-height: 480px;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+
+  .e-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 14px 16px 12px;
+    border-bottom: 1px solid #eee;
+    flex-shrink: 0;
+  }
+
+  .e-title {
+    font-size: 0.95em;
+    font-weight: 600;
+    color: #222;
+  }
+
+  .e-close {
+    background: none;
+    border: none;
+    cursor: pointer;
+    font-size: 0.9em;
+    color: #999;
+    padding: 4px 6px;
+    border-radius: 4px;
+
+    &:hover {
+      background: #f5f5f5;
+      color: #333;
+    }
+  }
+
+  .e-empty {
+    padding: 32px 24px;
+    text-align: center;
+    color: #999;
+    font-size: 0.88em;
+  }
+
+  .e-list {
+    list-style: none;
+    margin: 0;
+    padding: 6px 0;
+    overflow-y: auto;
+    flex: 1;
+  }
+
+  .e-item {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    padding: 10px 16px;
+    cursor: pointer;
+    transition: background 0.1s;
+
+    &:hover {
+      background: #e3f2fd;
+    }
+  }
+
+  .e-dot {
+    width: 12px;
+    height: 12px;
+    border-radius: 50%;
+    flex-shrink: 0;
+  }
+
+  .e-name {
+    flex: 1;
+    font-size: 0.9em;
+    color: #222;
+  }
+
+  .e-sub {
+    font-size: 0.76em;
+    color: #888;
+  }
+` as React.FC<React.HTMLAttributes<HTMLDivElement>>;

--- a/shift-puzzle-bubly/shift-puzzle-libs/src/ui/GanttChart/ReasonInputDialog.tsx
+++ b/shift-puzzle-bubly/shift-puzzle-libs/src/ui/GanttChart/ReasonInputDialog.tsx
@@ -7,10 +7,14 @@ export interface ReasonInputDialogProps {
   open: boolean;
   memberName?: string;
   roleName?: string;
-  /** 役割選択が必要な場合（memberモード時） */
+  /** 役割選択が必要な場合 */
   roles?: Array<{ id: string; name: string; color: string }>;
   selectedRoleId?: string;
   onRoleChange?: (roleId: string) => void;
+  /** 時間帯選択が必要な場合（MemberCardダブルクリック等） */
+  timeSlots?: Array<{ id: string; label: string }>;
+  selectedTimeSlotId?: string;
+  onTimeSlotChange?: (slotId: string) => void;
   onConfirm: (reason: AssignmentReasonState) => void;
   onCancel: () => void;
 }
@@ -31,6 +35,9 @@ export const ReasonInputDialog: React.FC<ReasonInputDialogProps> = ({
   roles,
   selectedRoleId,
   onRoleChange,
+  timeSlots,
+  selectedTimeSlotId,
+  onTimeSlotChange,
   onConfirm,
   onCancel,
 }) => {
@@ -39,7 +46,12 @@ export const ReasonInputDialog: React.FC<ReasonInputDialogProps> = ({
 
   if (!open) return null;
 
+  const canConfirm =
+    (!roles || roles.length === 0 || !!selectedRoleId) &&
+    (!timeSlots || timeSlots.length === 0 || !!selectedTimeSlotId);
+
   const handleConfirm = () => {
+    if (!canConfirm) return;
     onConfirm({
       category,
       text,
@@ -68,7 +80,7 @@ export const ReasonInputDialog: React.FC<ReasonInputDialogProps> = ({
           {roleName && <><span className="e-arrow">→</span><span className="e-chip e-role">{roleName}</span></>}
         </div>
 
-        {/* 役割選択（memberモード時） */}
+        {/* 役割選択 */}
         {roles && roles.length > 0 && (
           <div className="e-field">
             <label className="e-field-label">役割</label>
@@ -80,6 +92,23 @@ export const ReasonInputDialog: React.FC<ReasonInputDialogProps> = ({
               <option value="">選択してください</option>
               {roles.map((r) => (
                 <option key={r.id} value={r.id}>{r.name}</option>
+              ))}
+            </select>
+          </div>
+        )}
+
+        {/* 時間帯選択 */}
+        {timeSlots && timeSlots.length > 0 && (
+          <div className="e-field">
+            <label className="e-field-label">時間帯</label>
+            <select
+              className="e-select"
+              value={selectedTimeSlotId ?? ''}
+              onChange={(e: React.ChangeEvent<HTMLSelectElement>) => onTimeSlotChange?.(e.target.value)}
+            >
+              <option value="">選択してください</option>
+              {timeSlots.map((s) => (
+                <option key={s.id} value={s.id}>{s.label}</option>
               ))}
             </select>
           </div>
@@ -118,7 +147,7 @@ export const ReasonInputDialog: React.FC<ReasonInputDialogProps> = ({
           <button className="e-btn e-btn-cancel" onClick={handleCancel}>
             キャンセル
           </button>
-          <button className="e-btn e-btn-confirm" onClick={handleConfirm}>
+          <button className="e-btn e-btn-confirm" onClick={handleConfirm} disabled={!canConfirm}>
             配置を確定
           </button>
         </div>
@@ -277,8 +306,13 @@ const StyledPanel = styled.div`
     background: #1976d2;
     color: white;
 
-    &:hover {
+    &:hover:not(:disabled) {
       background: #1565c0;
+    }
+
+    &:disabled {
+      opacity: 0.4;
+      cursor: not-allowed;
     }
   }
 ` as React.FC<React.HTMLAttributes<HTMLDivElement>>;

--- a/shift-puzzle-bubly/shift-puzzle-libs/src/ui/GanttChart/ReasonInputDialog.tsx
+++ b/shift-puzzle-bubly/shift-puzzle-libs/src/ui/GanttChart/ReasonInputDialog.tsx
@@ -1,0 +1,284 @@
+'use client';
+import React, { useState } from 'react';
+import styled from 'styled-components';
+import type { AssignmentReasonState, ReasonCategory } from '@bublys-org/shift-puzzle-model';
+
+export interface ReasonInputDialogProps {
+  open: boolean;
+  memberName?: string;
+  roleName?: string;
+  /** 役割選択が必要な場合（memberモード時） */
+  roles?: Array<{ id: string; name: string; color: string }>;
+  selectedRoleId?: string;
+  onRoleChange?: (roleId: string) => void;
+  onConfirm: (reason: AssignmentReasonState) => void;
+  onCancel: () => void;
+}
+
+const CATEGORY_LABELS: Record<ReasonCategory, string> = {
+  skill_match:     'スキル適合',
+  training:        '育成目的',
+  compatibility:   '相性考慮',
+  availability:    '参加可能なため',
+  other:           'その他',
+};
+
+/** F-2-5: 配置理由入力ダイアログ */
+export const ReasonInputDialog: React.FC<ReasonInputDialogProps> = ({
+  open,
+  memberName,
+  roleName,
+  roles,
+  selectedRoleId,
+  onRoleChange,
+  onConfirm,
+  onCancel,
+}) => {
+  const [category, setCategory] = useState<ReasonCategory>('skill_match');
+  const [text, setText] = useState('');
+
+  if (!open) return null;
+
+  const handleConfirm = () => {
+    onConfirm({
+      category,
+      text,
+      createdBy: '',
+      createdAt: new Date().toISOString(),
+    });
+    setText('');
+    setCategory('skill_match');
+  };
+
+  const handleCancel = () => {
+    setText('');
+    setCategory('skill_match');
+    onCancel();
+  };
+
+  return (
+    <StyledOverlay onClick={(e: React.MouseEvent<HTMLDivElement>) => e.stopPropagation()}>
+      <StyledPanel>
+        <div className="e-header">
+          <span className="e-title">配置理由を入力</span>
+        </div>
+
+        <div className="e-info">
+          {memberName && <span className="e-chip">{memberName}</span>}
+          {roleName && <><span className="e-arrow">→</span><span className="e-chip e-role">{roleName}</span></>}
+        </div>
+
+        {/* 役割選択（memberモード時） */}
+        {roles && roles.length > 0 && (
+          <div className="e-field">
+            <label className="e-field-label">役割</label>
+            <select
+              className="e-select"
+              value={selectedRoleId ?? ''}
+              onChange={(e: React.ChangeEvent<HTMLSelectElement>) => onRoleChange?.(e.target.value)}
+            >
+              <option value="">選択してください</option>
+              {roles.map((r) => (
+                <option key={r.id} value={r.id}>{r.name}</option>
+              ))}
+            </select>
+          </div>
+        )}
+
+        <div className="e-field">
+          <label className="e-field-label">理由カテゴリ</label>
+          <div className="e-category-list">
+            {(Object.entries(CATEGORY_LABELS) as [ReasonCategory, string][]).map(([key, label]) => (
+              <label key={key} className={`e-category-btn ${category === key ? 'is-selected' : ''}`}>
+                <input
+                  type="radio"
+                  name="category"
+                  value={key}
+                  checked={category === key}
+                  onChange={() => setCategory(key)}
+                />
+                {label}
+              </label>
+            ))}
+          </div>
+        </div>
+
+        <div className="e-field">
+          <label className="e-field-label">詳細メモ（任意）</label>
+          <textarea
+            className="e-textarea"
+            rows={2}
+            placeholder="配置の背景・理由を記入..."
+            value={text}
+            onChange={(e: React.ChangeEvent<HTMLTextAreaElement>) => setText(e.target.value)}
+          />
+        </div>
+
+        <div className="e-actions">
+          <button className="e-btn e-btn-cancel" onClick={handleCancel}>
+            キャンセル
+          </button>
+          <button className="e-btn e-btn-confirm" onClick={handleConfirm}>
+            配置を確定
+          </button>
+        </div>
+      </StyledPanel>
+    </StyledOverlay>
+  );
+};
+
+const StyledOverlay = styled.div`
+  position: fixed;
+  inset: 0;
+  background-color: rgba(0, 0, 0, 0.3);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 100;
+` as React.FC<React.HTMLAttributes<HTMLDivElement>>;
+
+const StyledPanel = styled.div`
+  background: white;
+  border-radius: 8px;
+  padding: 16px;
+  width: 360px;
+  box-shadow: 0 4px 24px rgba(0, 0, 0, 0.2);
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+
+  .e-header {
+    .e-title {
+      font-size: 1em;
+      font-weight: 600;
+      color: #333;
+    }
+  }
+
+  .e-info {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    flex-wrap: wrap;
+
+    .e-chip {
+      background: #e3f2fd;
+      color: #1565c0;
+      padding: 2px 8px;
+      border-radius: 12px;
+      font-size: 0.85em;
+      font-weight: 500;
+    }
+
+    .e-chip.e-role {
+      background: #f3e5f5;
+      color: #6a1b9a;
+    }
+
+    .e-arrow {
+      color: #888;
+      font-size: 0.9em;
+    }
+  }
+
+  .e-field {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+  }
+
+  .e-field-label {
+    font-size: 0.8em;
+    color: #666;
+    font-weight: 500;
+  }
+
+  .e-select {
+    padding: 6px 8px;
+    border: 1px solid #ddd;
+    border-radius: 4px;
+    font-size: 0.9em;
+    background: white;
+  }
+
+  .e-category-list {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 6px;
+  }
+
+  .e-category-btn {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+    padding: 4px 10px;
+    border: 1px solid #ddd;
+    border-radius: 16px;
+    font-size: 0.82em;
+    cursor: pointer;
+    background: white;
+
+    input[type="radio"] {
+      display: none;
+    }
+
+    &.is-selected {
+      background: #1976d2;
+      border-color: #1976d2;
+      color: white;
+    }
+
+    &:hover:not(.is-selected) {
+      background: #f0f4ff;
+      border-color: #90caf9;
+    }
+  }
+
+  .e-textarea {
+    padding: 6px 8px;
+    border: 1px solid #ddd;
+    border-radius: 4px;
+    font-size: 0.9em;
+    resize: vertical;
+    font-family: inherit;
+
+    &:focus {
+      outline: none;
+      border-color: #1976d2;
+    }
+  }
+
+  .e-actions {
+    display: flex;
+    justify-content: flex-end;
+    gap: 8px;
+    margin-top: 4px;
+  }
+
+  .e-btn {
+    padding: 7px 16px;
+    border: none;
+    border-radius: 4px;
+    font-size: 0.9em;
+    cursor: pointer;
+    font-weight: 500;
+  }
+
+  .e-btn-cancel {
+    background: #f5f5f5;
+    color: #555;
+
+    &:hover {
+      background: #e0e0e0;
+    }
+  }
+
+  .e-btn-confirm {
+    background: #1976d2;
+    color: white;
+
+    &:hover {
+      background: #1565c0;
+    }
+  }
+` as React.FC<React.HTMLAttributes<HTMLDivElement>>;

--- a/shift-puzzle-bubly/shift-puzzle-libs/src/ui/GanttChart/TimeAxis.tsx
+++ b/shift-puzzle-bubly/shift-puzzle-libs/src/ui/GanttChart/TimeAxis.tsx
@@ -1,0 +1,79 @@
+'use client';
+import React from 'react';
+import styled from 'styled-components';
+
+interface TimeAxisProps {
+  /** 表示開始時刻（0:00からの経過分数。例: 540 = 9:00） */
+  dayStartMinute: number;
+  /** 表示終了時刻（0:00からの経過分数。例: 1200 = 20:00） */
+  dayEndMinute: number;
+  /** 1時間あたりのピクセル幅 */
+  hourPx: number;
+}
+
+/** 横スクロール領域内の時刻ラベル・グリッド線 */
+export const TimeAxis: React.FC<TimeAxisProps> = ({ dayStartMinute, dayEndMinute, hourPx }) => {
+  const minutePx = hourPx / 60;
+  const totalWidth = (dayEndMinute - dayStartMinute) * minutePx;
+
+  const startHour = Math.floor(dayStartMinute / 60);
+  const endHour = Math.ceil(dayEndMinute / 60);
+
+  const hourMarkers: { left: number; label: string }[] = [];
+  const halfHourMarkers: { left: number }[] = [];
+
+  for (let h = startHour; h <= endHour; h++) {
+    const minute = h * 60;
+    if (minute >= dayStartMinute && minute <= dayEndMinute) {
+      const left = (minute - dayStartMinute) * minutePx;
+      hourMarkers.push({ left, label: `${String(h).padStart(2, '0')}:00` });
+    }
+    const halfMinute = h * 60 + 30;
+    if (halfMinute > dayStartMinute && halfMinute < dayEndMinute) {
+      const left = (halfMinute - dayStartMinute) * minutePx;
+      halfHourMarkers.push({ left });
+    }
+  }
+
+  return (
+    <StyledTimeAxis style={{ width: totalWidth }}>
+      {hourMarkers.map((m) => (
+        <div key={m.left} className="e-hour-mark" style={{ left: m.left }}>
+          <span className="e-label">{m.label}</span>
+        </div>
+      ))}
+      {halfHourMarkers.map((m, i) => (
+        <div key={i} className="e-half-mark" style={{ left: m.left }} />
+      ))}
+    </StyledTimeAxis>
+  );
+};
+
+const StyledTimeAxis = styled.div`
+  position: relative;
+  height: 100%;
+
+  .e-hour-mark {
+    position: absolute;
+    top: 0;
+    height: 100%;
+    border-left: 1px solid #c5cae9;
+
+    .e-label {
+      display: block;
+      padding-left: 3px;
+      font-size: 0.75em;
+      color: #555;
+      white-space: nowrap;
+      line-height: 1;
+      padding-top: 4px;
+    }
+  }
+
+  .e-half-mark {
+    position: absolute;
+    top: 0;
+    height: 100%;
+    border-left: 1px dashed #e0e0e0;
+  }
+` as React.FC<React.HTMLAttributes<HTMLDivElement>>;

--- a/shift-puzzle-bubly/shift-puzzle-libs/src/ui/MemberCard/MemberCard.tsx
+++ b/shift-puzzle-bubly/shift-puzzle-libs/src/ui/MemberCard/MemberCard.tsx
@@ -1,0 +1,223 @@
+'use client';
+import React from 'react';
+import styled from 'styled-components';
+import type {
+  MemberState,
+  TimeSlotState,
+  SkillDefinitionState,
+} from '@bublys-org/shift-puzzle-model';
+
+export interface MemberCardProps {
+  member: MemberState;
+  skillDefinitions?: ReadonlyArray<SkillDefinitionState>;
+  timeSlots?: ReadonlyArray<TimeSlotState>;
+  onEdit?: (memberId: string) => void;
+  onDelete?: (memberId: string) => void;
+}
+
+/** F-1-1: メンバー情報の表示カード */
+export const MemberCard: React.FC<MemberCardProps> = ({
+  member,
+  skillDefinitions = [],
+  timeSlots = [],
+  onEdit,
+  onDelete,
+}) => {
+  const skillLabels = member.skills
+    .map((skillId) => skillDefinitions.find((d) => d.id === skillId)?.label ?? skillId)
+    .filter(Boolean);
+
+  const availableCount = member.availableSlotIds.length;
+  const totalCount = timeSlots.length;
+
+  return (
+    <StyledCard>
+      <div className="e-header">
+        <div className="e-name">{member.name}</div>
+        <div className="e-actions">
+          {onEdit && (
+            <button className="e-btn-icon" onClick={() => onEdit(member.id)} title="編集">
+              ✏️
+            </button>
+          )}
+          {onDelete && (
+            <button
+              className="e-btn-icon e-btn-delete"
+              onClick={() => onDelete(member.id)}
+              title="削除"
+            >
+              🗑️
+            </button>
+          )}
+        </div>
+      </div>
+
+      {/* F-1-4: タグ */}
+      {member.tags.length > 0 && (
+        <div className="e-tags">
+          {member.tags.map((tag) => (
+            <span key={tag} className="e-tag">
+              {tag}
+            </span>
+          ))}
+        </div>
+      )}
+
+      {/* F-1-2: スキル */}
+      {skillLabels.length > 0 && (
+        <div className="e-skills">
+          {skillLabels.map((label) => (
+            <span key={label} className="e-skill-badge">
+              ✓ {label}
+            </span>
+          ))}
+        </div>
+      )}
+
+      {/* F-1-3: 参加可能時間帯サマリー */}
+      {totalCount > 0 && (
+        <div className="e-availability">
+          <span className={`e-avail-bar-wrap`}>
+            <span
+              className="e-avail-bar"
+              style={{ width: `${(availableCount / totalCount) * 100}%` }}
+            />
+          </span>
+          <span className="e-avail-text">
+            {availableCount}/{totalCount} 時間帯参加可
+          </span>
+        </div>
+      )}
+
+      {/* メモ */}
+      {member.memo && (
+        <div className="e-memo" title={member.memo}>
+          📝 {member.memo}
+        </div>
+      )}
+    </StyledCard>
+  );
+};
+
+const StyledCard = styled.div`
+  background: white;
+  border: 1px solid #e0e0e0;
+  border-radius: 8px;
+  padding: 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  transition: box-shadow 0.15s;
+
+  &:hover {
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+    border-color: #bdbdbd;
+  }
+
+  .e-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 8px;
+  }
+
+  .e-name {
+    font-size: 1em;
+    font-weight: 600;
+    color: #222;
+  }
+
+  .e-actions {
+    display: flex;
+    gap: 4px;
+    opacity: 0;
+    transition: opacity 0.15s;
+  }
+
+  &:hover .e-actions {
+    opacity: 1;
+  }
+
+  .e-btn-icon {
+    background: none;
+    border: none;
+    cursor: pointer;
+    padding: 3px 5px;
+    border-radius: 4px;
+    font-size: 0.9em;
+
+    &:hover {
+      background: #f5f5f5;
+    }
+  }
+
+  .e-btn-delete:hover {
+    background: #fce4e4;
+  }
+
+  .e-tags {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 4px;
+  }
+
+  .e-tag {
+    background: #e3f2fd;
+    color: #1565c0;
+    padding: 1px 8px;
+    border-radius: 12px;
+    font-size: 0.78em;
+    font-weight: 500;
+  }
+
+  .e-skills {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 4px;
+  }
+
+  .e-skill-badge {
+    background: #e8f5e9;
+    color: #2e7d32;
+    padding: 1px 8px;
+    border-radius: 4px;
+    font-size: 0.76em;
+    font-weight: 500;
+  }
+
+  .e-availability {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+  }
+
+  .e-avail-bar-wrap {
+    flex: 1;
+    height: 4px;
+    background: #e0e0e0;
+    border-radius: 2px;
+    overflow: hidden;
+    max-width: 80px;
+  }
+
+  .e-avail-bar {
+    display: block;
+    height: 100%;
+    background: #4caf50;
+    border-radius: 2px;
+    transition: width 0.3s;
+  }
+
+  .e-avail-text {
+    font-size: 0.76em;
+    color: #888;
+  }
+
+  .e-memo {
+    font-size: 0.78em;
+    color: #999;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+` as React.FC<React.HTMLAttributes<HTMLDivElement>>;

--- a/shift-puzzle-bubly/shift-puzzle-libs/src/ui/MemberCard/MemberCard.tsx
+++ b/shift-puzzle-bubly/shift-puzzle-libs/src/ui/MemberCard/MemberCard.tsx
@@ -13,6 +13,8 @@ export interface MemberCardProps {
   timeSlots?: ReadonlyArray<TimeSlotState>;
   onEdit?: (memberId: string) => void;
   onDelete?: (memberId: string) => void;
+  /** F-4-1: タップで詳細バブルを開く */
+  onTap?: (memberId: string) => void;
 }
 
 /** F-1-1: メンバー情報の表示カード */
@@ -22,6 +24,7 @@ export const MemberCard: React.FC<MemberCardProps> = ({
   timeSlots = [],
   onEdit,
   onDelete,
+  onTap,
 }) => {
   const skillLabels = member.skills
     .map((skillId) => skillDefinitions.find((d) => d.id === skillId)?.label ?? skillId)
@@ -31,19 +34,19 @@ export const MemberCard: React.FC<MemberCardProps> = ({
   const totalCount = timeSlots.length;
 
   return (
-    <StyledCard>
+    <StyledCard onClick={onTap ? () => onTap(member.id) : undefined} style={onTap ? { cursor: 'pointer' } : undefined}>
       <div className="e-header">
         <div className="e-name">{member.name}</div>
         <div className="e-actions">
           {onEdit && (
-            <button className="e-btn-icon" onClick={() => onEdit(member.id)} title="編集">
+            <button className="e-btn-icon" onClick={(e) => { e.stopPropagation(); onEdit(member.id); }} title="編集">
               ✏️
             </button>
           )}
           {onDelete && (
             <button
               className="e-btn-icon e-btn-delete"
-              onClick={() => onDelete(member.id)}
+              onClick={(e) => { e.stopPropagation(); onDelete(member.id); }}
               title="削除"
             >
               🗑️

--- a/shift-puzzle-bubly/shift-puzzle-libs/src/ui/MemberCard/MemberCard.tsx
+++ b/shift-puzzle-bubly/shift-puzzle-libs/src/ui/MemberCard/MemberCard.tsx
@@ -1,5 +1,5 @@
 'use client';
-import React, { useRef } from 'react';
+import React from 'react';
 import styled from 'styled-components';
 import { setDragPayload, getDragType } from '@bublys-org/bubbles-ui';
 import type {
@@ -16,8 +16,6 @@ export interface MemberCardProps {
   onDelete?: (memberId: string) => void;
   /** F-4-1: タップで詳細バブルを開く */
   onTap?: (memberId: string) => void;
-  /** F-4-3: ダブルクリックでクイック配置ダイアログを開く */
-  onDoubleClick?: (memberId: string) => void;
   /** F-4-3: ドラッグ&ドロップ用URL（設定するとカードがドラッグ可能になる） */
   dragUrl?: string;
 }
@@ -30,11 +28,8 @@ export const MemberCard: React.FC<MemberCardProps> = ({
   onEdit,
   onDelete,
   onTap,
-  onDoubleClick,
   dragUrl,
 }) => {
-  const clickTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-
   const skillLabels = member.skills
     .map((skillId) => skillDefinitions.find((d) => d.id === skillId)?.label ?? skillId)
     .filter(Boolean);
@@ -43,24 +38,7 @@ export const MemberCard: React.FC<MemberCardProps> = ({
   const totalCount = timeSlots.length;
 
   const handleClick = () => {
-    if (!onTap) return;
-    if (onDoubleClick) {
-      // ダブルクリックと区別するため 250ms 待つ
-      clickTimerRef.current = setTimeout(() => {
-        clickTimerRef.current = null;
-        onTap(member.id);
-      }, 250);
-    } else {
-      onTap(member.id);
-    }
-  };
-
-  const handleDoubleClick = () => {
-    if (clickTimerRef.current) {
-      clearTimeout(clickTimerRef.current);
-      clickTimerRef.current = null;
-    }
-    onDoubleClick?.(member.id);
+    onTap?.(member.id);
   };
 
   const handleDragStart = (e: React.DragEvent<HTMLDivElement>) => {
@@ -76,7 +54,6 @@ export const MemberCard: React.FC<MemberCardProps> = ({
   return (
     <StyledCard
       onClick={onTap ? handleClick : undefined}
-      onDoubleClick={onDoubleClick ? handleDoubleClick : undefined}
       draggable={!!dragUrl}
       onDragStart={dragUrl ? handleDragStart : undefined}
       style={{

--- a/shift-puzzle-bubly/shift-puzzle-libs/src/ui/MemberCard/MemberForm.tsx
+++ b/shift-puzzle-bubly/shift-puzzle-libs/src/ui/MemberCard/MemberForm.tsx
@@ -1,0 +1,586 @@
+'use client';
+import React, { useState } from 'react';
+import styled from 'styled-components';
+import type {
+  MemberState,
+  TimeSlotState,
+  SkillDefinitionState,
+} from '@bublys-org/shift-puzzle-model';
+
+export interface MemberFormProps {
+  /** 編集対象（undefined = 新規作成） */
+  initial?: MemberState;
+  eventId: string;
+  skillDefinitions: ReadonlyArray<SkillDefinitionState>;
+  timeSlots: ReadonlyArray<TimeSlotState>;
+  /** 既存タグ（サジェスト用） */
+  existingTags?: string[];
+  onSave: (data: Omit<MemberState, 'id' | 'eventId' | 'createdAt' | 'updatedAt'>) => void;
+  onCancel: () => void;
+}
+
+/** F-1-1〜F-1-4: メンバー追加・編集フォーム */
+export const MemberForm: React.FC<MemberFormProps> = ({
+  initial,
+  skillDefinitions,
+  timeSlots,
+  existingTags = [],
+  onSave,
+  onCancel,
+}) => {
+  const [name, setName] = useState(initial?.name ?? '');
+  const [memo, setMemo] = useState(initial?.memo ?? '');
+  const [tags, setTags] = useState<string[]>(initial ? [...initial.tags] : []);
+  const [tagInput, setTagInput] = useState('');
+  const [skills, setSkills] = useState<string[]>(initial ? [...initial.skills] : []);
+  const [availableSlotIds, setAvailableSlotIds] = useState<string[]>(
+    initial ? [...initial.availableSlotIds] : []
+  );
+
+  // 日ごとにスロットをグループ化
+  const dayGroups = groupSlotsByDay(timeSlots);
+
+  const handleAddTag = (tag: string) => {
+    const trimmed = tag.trim();
+    if (trimmed && !tags.includes(trimmed)) {
+      setTags((prev) => [...prev, trimmed]);
+    }
+    setTagInput('');
+  };
+
+  const handleRemoveTag = (tag: string) => {
+    setTags((prev) => prev.filter((t) => t !== tag));
+  };
+
+  const handleTagInputKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === 'Enter' || e.key === ',') {
+      e.preventDefault();
+      handleAddTag(tagInput);
+    }
+  };
+
+  const toggleSkill = (skillId: string) => {
+    setSkills((prev) =>
+      prev.includes(skillId) ? prev.filter((id) => id !== skillId) : [...prev, skillId]
+    );
+  };
+
+  const toggleSlot = (slotId: string) => {
+    setAvailableSlotIds((prev) =>
+      prev.includes(slotId) ? prev.filter((id) => id !== slotId) : [...prev, slotId]
+    );
+  };
+
+  const toggleAllDay = (daySlots: TimeSlotState[]) => {
+    const allSelected = daySlots.every((s) => availableSlotIds.includes(s.id));
+    if (allSelected) {
+      setAvailableSlotIds((prev) => prev.filter((id) => !daySlots.some((s) => s.id === id)));
+    } else {
+      const toAdd = daySlots.map((s) => s.id).filter((id) => !availableSlotIds.includes(id));
+      setAvailableSlotIds((prev) => [...prev, ...toAdd]);
+    }
+  };
+
+  const handleSave = () => {
+    if (!name.trim()) return;
+    onSave({ name: name.trim(), memo, tags, skills, availableSlotIds });
+  };
+
+  const suggestTags = existingTags.filter((t) => !tags.includes(t) && t.toLowerCase().includes(tagInput.toLowerCase()));
+
+  return (
+    <StyledForm>
+      <div className="e-title">{initial ? 'メンバーを編集' : '新しいメンバーを追加'}</div>
+
+      {/* F-1-1: 名前 */}
+      <div className="e-field">
+        <label className="e-field-label">名前 <span className="e-required">*</span></label>
+        <input
+          className="e-input"
+          type="text"
+          placeholder="例: 田中 太郎"
+          value={name}
+          onChange={(e: React.ChangeEvent<HTMLInputElement>) => setName(e.target.value)}
+          autoFocus
+        />
+      </div>
+
+      {/* F-1-4: タグ */}
+      <div className="e-field">
+        <label className="e-field-label">タグ（部門・学年・役職等）</label>
+        <div className="e-tag-area">
+          {tags.map((tag) => (
+            <span key={tag} className="e-tag">
+              {tag}
+              <button
+                className="e-tag-remove"
+                onClick={() => handleRemoveTag(tag)}
+                type="button"
+              >
+                ×
+              </button>
+            </span>
+          ))}
+          <div className="e-tag-input-wrap">
+            <input
+              className="e-tag-input"
+              type="text"
+              placeholder="タグを入力..."
+              value={tagInput}
+              onChange={(e: React.ChangeEvent<HTMLInputElement>) => setTagInput(e.target.value)}
+              onKeyDown={handleTagInputKeyDown}
+            />
+            {tagInput && (
+              <button
+                className="e-tag-add-btn"
+                type="button"
+                onClick={() => handleAddTag(tagInput)}
+              >
+                追加
+              </button>
+            )}
+          </div>
+        </div>
+        {suggestTags.length > 0 && tagInput && (
+          <div className="e-tag-suggests">
+            {suggestTags.slice(0, 5).map((t) => (
+              <button key={t} className="e-suggest-btn" type="button" onClick={() => handleAddTag(t)}>
+                {t}
+              </button>
+            ))}
+          </div>
+        )}
+        {existingTags.filter((t) => !tags.includes(t)).length > 0 && !tagInput && (
+          <div className="e-tag-suggests">
+            <span className="e-suggest-label">既存のタグ:</span>
+            {existingTags.filter((t) => !tags.includes(t)).slice(0, 6).map((t) => (
+              <button key={t} className="e-suggest-btn" type="button" onClick={() => handleAddTag(t)}>
+                {t}
+              </button>
+            ))}
+          </div>
+        )}
+      </div>
+
+      {/* F-1-2: スキル */}
+      {skillDefinitions.length > 0 && (
+        <div className="e-field">
+          <label className="e-field-label">スキル</label>
+          <div className="e-skill-list">
+            {skillDefinitions.map((def) => (
+              <label key={def.id} className={`e-skill-btn ${skills.includes(def.id) ? 'is-selected' : ''}`}>
+                <input
+                  type="checkbox"
+                  checked={skills.includes(def.id)}
+                  onChange={() => toggleSkill(def.id)}
+                />
+                {def.label}
+              </label>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {/* F-1-3: 参加可能時間帯 */}
+      {timeSlots.length > 0 && (
+        <div className="e-field">
+          <label className="e-field-label">
+            参加可能時間帯
+            <span className="e-slot-count">（{availableSlotIds.length}/{timeSlots.length} 選択中）</span>
+          </label>
+          <div className="e-slot-days">
+            {dayGroups.map(({ dayIndex, slots }) => {
+              const allSelected = slots.every((s) => availableSlotIds.includes(s.id));
+              return (
+                <div key={dayIndex} className="e-slot-day">
+                  <div className="e-slot-day-header">
+                    <button
+                      className={`e-day-toggle ${allSelected ? 'is-all' : ''}`}
+                      type="button"
+                      onClick={() => toggleAllDay(slots)}
+                    >
+                      Day {dayIndex + 1}
+                    </button>
+                  </div>
+                  <div className="e-slot-row">
+                    {slots.map((slot) => {
+                      const selected = availableSlotIds.includes(slot.id);
+                      return (
+                        <button
+                          key={slot.id}
+                          className={`e-slot-btn ${selected ? 'is-selected' : ''}`}
+                          type="button"
+                          onClick={() => toggleSlot(slot.id)}
+                          title={`${formatMin(slot.startMinute)}〜${formatMin(slot.startMinute + slot.durationMinutes)}`}
+                        >
+                          {formatMin(slot.startMinute)}
+                        </button>
+                      );
+                    })}
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+        </div>
+      )}
+
+      {/* メモ */}
+      <div className="e-field">
+        <label className="e-field-label">メモ（内部用・非公開）</label>
+        <textarea
+          className="e-textarea"
+          rows={2}
+          placeholder="性格・得意なこと・注意事項など..."
+          value={memo}
+          onChange={(e: React.ChangeEvent<HTMLTextAreaElement>) => setMemo(e.target.value)}
+        />
+      </div>
+
+      <div className="e-actions">
+        <button className="e-btn e-btn-cancel" type="button" onClick={onCancel}>
+          キャンセル
+        </button>
+        <button
+          className="e-btn e-btn-save"
+          type="button"
+          onClick={handleSave}
+          disabled={!name.trim()}
+        >
+          {initial ? '更新' : '追加'}
+        </button>
+      </div>
+    </StyledForm>
+  );
+};
+
+// ========== ユーティリティ ==========
+
+function formatMin(minutes: number): string {
+  const h = Math.floor(minutes / 60);
+  const m = minutes % 60;
+  return `${String(h).padStart(2, '0')}:${String(m).padStart(2, '0')}`;
+}
+
+function groupSlotsByDay(slots: ReadonlyArray<TimeSlotState>): { dayIndex: number; slots: TimeSlotState[] }[] {
+  const map = new Map<number, TimeSlotState[]>();
+  for (const slot of slots) {
+    if (!map.has(slot.dayIndex)) map.set(slot.dayIndex, []);
+    map.get(slot.dayIndex)!.push(slot);
+  }
+  return Array.from(map.entries())
+    .sort(([a], [b]) => a - b)
+    .map(([dayIndex, s]) => ({ dayIndex, slots: s.sort((a, b) => a.startMinute - b.startMinute) }));
+}
+
+// ========== スタイル ==========
+
+const StyledForm = styled.div`
+  background: white;
+  border-radius: 8px;
+  padding: 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+
+  .e-title {
+    font-size: 1em;
+    font-weight: 600;
+    color: #222;
+    padding-bottom: 4px;
+    border-bottom: 1px solid #f0f0f0;
+  }
+
+  .e-field {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+  }
+
+  .e-field-label {
+    font-size: 0.8em;
+    color: #555;
+    font-weight: 600;
+  }
+
+  .e-required {
+    color: #e53935;
+  }
+
+  .e-slot-count {
+    font-weight: 400;
+    color: #999;
+    margin-left: 4px;
+  }
+
+  .e-input {
+    padding: 7px 10px;
+    border: 1px solid #ddd;
+    border-radius: 6px;
+    font-size: 0.9em;
+    font-family: inherit;
+
+    &:focus {
+      outline: none;
+      border-color: #1976d2;
+    }
+  }
+
+  .e-textarea {
+    padding: 7px 10px;
+    border: 1px solid #ddd;
+    border-radius: 6px;
+    font-size: 0.9em;
+    font-family: inherit;
+    resize: vertical;
+
+    &:focus {
+      outline: none;
+      border-color: #1976d2;
+    }
+  }
+
+  /* タグ */
+  .e-tag-area {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 6px;
+    align-items: center;
+    padding: 6px;
+    border: 1px solid #ddd;
+    border-radius: 6px;
+    min-height: 38px;
+    cursor: text;
+
+    &:focus-within {
+      border-color: #1976d2;
+    }
+  }
+
+  .e-tag {
+    display: inline-flex;
+    align-items: center;
+    gap: 3px;
+    background: #e3f2fd;
+    color: #1565c0;
+    padding: 2px 8px;
+    border-radius: 12px;
+    font-size: 0.82em;
+    font-weight: 500;
+  }
+
+  .e-tag-remove {
+    background: none;
+    border: none;
+    cursor: pointer;
+    color: #1565c0;
+    padding: 0 2px;
+    font-size: 0.9em;
+    line-height: 1;
+
+    &:hover {
+      color: #c62828;
+    }
+  }
+
+  .e-tag-input-wrap {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+    flex: 1;
+    min-width: 100px;
+  }
+
+  .e-tag-input {
+    border: none;
+    outline: none;
+    font-size: 0.85em;
+    font-family: inherit;
+    flex: 1;
+    min-width: 80px;
+  }
+
+  .e-tag-add-btn {
+    padding: 2px 8px;
+    background: #1976d2;
+    color: white;
+    border: none;
+    border-radius: 4px;
+    font-size: 0.78em;
+    cursor: pointer;
+    white-space: nowrap;
+  }
+
+  .e-tag-suggests {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 4px;
+    align-items: center;
+  }
+
+  .e-suggest-label {
+    font-size: 0.75em;
+    color: #aaa;
+  }
+
+  .e-suggest-btn {
+    padding: 2px 8px;
+    background: #f5f5f5;
+    color: #555;
+    border: 1px solid #e0e0e0;
+    border-radius: 12px;
+    font-size: 0.78em;
+    cursor: pointer;
+
+    &:hover {
+      background: #e3f2fd;
+      border-color: #90caf9;
+      color: #1565c0;
+    }
+  }
+
+  /* スキル */
+  .e-skill-list {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 6px;
+  }
+
+  .e-skill-btn {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+    padding: 4px 12px;
+    border: 1px solid #ddd;
+    border-radius: 16px;
+    font-size: 0.82em;
+    cursor: pointer;
+    background: white;
+    color: #555;
+
+    input[type="checkbox"] {
+      display: none;
+    }
+
+    &.is-selected {
+      background: #e8f5e9;
+      border-color: #4caf50;
+      color: #2e7d32;
+      font-weight: 600;
+    }
+
+    &:hover:not(.is-selected) {
+      background: #f0f4ff;
+      border-color: #90caf9;
+    }
+  }
+
+  /* 時間帯スロット */
+  .e-slot-days {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+  }
+
+  .e-slot-day {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+  }
+
+  .e-slot-day-header {
+    display: flex;
+    align-items: center;
+  }
+
+  .e-day-toggle {
+    padding: 2px 10px;
+    background: #f5f5f5;
+    border: 1px solid #ddd;
+    border-radius: 4px;
+    font-size: 0.78em;
+    cursor: pointer;
+    color: #555;
+
+    &.is-all {
+      background: #1976d2;
+      border-color: #1976d2;
+      color: white;
+    }
+
+    &:hover:not(.is-all) {
+      background: #e3f2fd;
+    }
+  }
+
+  .e-slot-row {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 4px;
+  }
+
+  .e-slot-btn {
+    padding: 3px 8px;
+    background: #f5f5f5;
+    border: 1px solid #e0e0e0;
+    border-radius: 4px;
+    font-size: 0.75em;
+    cursor: pointer;
+    color: #555;
+    white-space: nowrap;
+
+    &.is-selected {
+      background: #e3f2fd;
+      border-color: #90caf9;
+      color: #1565c0;
+      font-weight: 600;
+    }
+
+    &:hover:not(.is-selected) {
+      background: #e8f5e9;
+      border-color: #a5d6a7;
+    }
+  }
+
+  /* アクション */
+  .e-actions {
+    display: flex;
+    justify-content: flex-end;
+    gap: 8px;
+    margin-top: 4px;
+    padding-top: 12px;
+    border-top: 1px solid #f0f0f0;
+  }
+
+  .e-btn {
+    padding: 7px 18px;
+    border: none;
+    border-radius: 6px;
+    font-size: 0.9em;
+    cursor: pointer;
+    font-weight: 500;
+  }
+
+  .e-btn-cancel {
+    background: #f5f5f5;
+    color: #555;
+
+    &:hover {
+      background: #e0e0e0;
+    }
+  }
+
+  .e-btn-save {
+    background: #1976d2;
+    color: white;
+
+    &:hover:not(:disabled) {
+      background: #1565c0;
+    }
+
+    &:disabled {
+      opacity: 0.5;
+      cursor: not-allowed;
+    }
+  }
+` as React.FC<React.HTMLAttributes<HTMLDivElement>>;

--- a/shift-puzzle-bubly/shift-puzzle-libs/src/ui/MemberDetail/MemberDetailView.tsx
+++ b/shift-puzzle-bubly/shift-puzzle-libs/src/ui/MemberDetail/MemberDetailView.tsx
@@ -1,0 +1,341 @@
+'use client';
+import React from 'react';
+import styled from 'styled-components';
+import type {
+  MemberState,
+  TimeSlotState,
+  SkillDefinitionState,
+  AssignmentState,
+  RoleState,
+} from '@bublys-org/shift-puzzle-model';
+
+export interface MemberDetailViewProps {
+  member: MemberState;
+  skillDefinitions?: ReadonlyArray<SkillDefinitionState>;
+  timeSlots?: ReadonlyArray<TimeSlotState>;
+  /** このシフト案内での配置一覧 */
+  assignments?: ReadonlyArray<AssignmentState>;
+  roles?: ReadonlyArray<RoleState>;
+  isPocketed?: boolean;
+  onAddToPocket?: () => void;
+}
+
+/** F-4-1: メンバー詳細バブル（スキル・参加可能時間・現在の配置状況） */
+export const MemberDetailView: React.FC<MemberDetailViewProps> = ({
+  member,
+  skillDefinitions = [],
+  timeSlots = [],
+  assignments = [],
+  roles = [],
+  isPocketed = false,
+  onAddToPocket,
+}) => {
+  const skillLabels = member.skills
+    .map((skillId) => skillDefinitions.find((d) => d.id === skillId)?.label ?? skillId)
+    .filter(Boolean);
+
+  const availableSlots = timeSlots.filter((s) => member.availableSlotIds.includes(s.id));
+  const totalCount = timeSlots.length;
+  const availableCount = availableSlots.length;
+
+  const myAssignments = assignments.filter((a) => a.memberId === member.id);
+
+  const formatTime = (minutes: number) => {
+    const h = Math.floor(minutes / 60);
+    const m = minutes % 60;
+    return `${h}:${String(m).padStart(2, '0')}`;
+  };
+
+  const getRoleName = (roleId: string) =>
+    roles.find((r) => r.id === roleId)?.name ?? roleId;
+
+  const getSlotLabel = (slotId: string) => {
+    const slot = timeSlots.find((s) => s.id === slotId);
+    if (!slot) return slotId;
+    return `${formatTime(slot.startMinute)}〜${formatTime(slot.startMinute + slot.durationMinutes)}`;
+  };
+
+  return (
+    <StyledWrapper>
+      {/* ヘッダー */}
+      <div className="e-header">
+        <div className="e-name">{member.name}</div>
+        {onAddToPocket && (
+          <button
+            className={`e-pocket-btn ${isPocketed ? 'is-pocketed' : ''}`}
+            onClick={onAddToPocket}
+            disabled={isPocketed}
+            title={isPocketed ? 'ポケット済み' : 'ポケットに追加'}
+          >
+            {isPocketed ? '📌 ポケット済み' : '📌 ポケットに追加'}
+          </button>
+        )}
+      </div>
+
+      {/* F-1-4: タグ */}
+      {member.tags.length > 0 && (
+        <div className="e-section">
+          <div className="e-section-title">タグ</div>
+          <div className="e-tags">
+            {member.tags.map((tag) => (
+              <span key={tag} className="e-tag">{tag}</span>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {/* F-1-2: スキル */}
+      <div className="e-section">
+        <div className="e-section-title">スキル</div>
+        {skillLabels.length > 0 ? (
+          <div className="e-skills">
+            {skillLabels.map((label) => (
+              <span key={label} className="e-skill-badge">✓ {label}</span>
+            ))}
+          </div>
+        ) : (
+          <div className="e-empty-note">スキル未登録</div>
+        )}
+      </div>
+
+      {/* F-1-3: 参加可能時間帯 */}
+      {totalCount > 0 && (
+        <div className="e-section">
+          <div className="e-section-title">
+            参加可能時間帯
+            <span className="e-count-badge">{availableCount}/{totalCount}</span>
+          </div>
+          <div className="e-avail-bar-wrap">
+            <div
+              className="e-avail-bar"
+              style={{ width: `${(availableCount / totalCount) * 100}%` }}
+            />
+          </div>
+          {availableSlots.length > 0 && (
+            <div className="e-slot-list">
+              {availableSlots.map((slot) => (
+                <span key={slot.id} className="e-slot-chip">
+                  {formatTime(slot.startMinute)}〜{formatTime(slot.startMinute + slot.durationMinutes)}
+                </span>
+              ))}
+            </div>
+          )}
+        </div>
+      )}
+
+      {/* 現在の配置状況 */}
+      <div className="e-section">
+        <div className="e-section-title">
+          現在の配置
+          <span className="e-count-badge">{myAssignments.length}件</span>
+        </div>
+        {myAssignments.length > 0 ? (
+          <div className="e-assignment-list">
+            {myAssignments.map((a) => (
+              <div key={a.id} className="e-assignment-item">
+                <span
+                  className="e-role-dot"
+                  style={{ background: roles.find((r) => r.id === a.roleId)?.color ?? '#999' }}
+                />
+                <span className="e-role-name">{getRoleName(a.roleId)}</span>
+                <span className="e-slot-time">{getSlotLabel(a.timeSlotId)}</span>
+              </div>
+            ))}
+          </div>
+        ) : (
+          <div className="e-empty-note">このシフト案では未配置</div>
+        )}
+      </div>
+
+      {/* メモ */}
+      {member.memo && (
+        <div className="e-section">
+          <div className="e-section-title">メモ</div>
+          <div className="e-memo">{member.memo}</div>
+        </div>
+      )}
+    </StyledWrapper>
+  );
+};
+
+const StyledWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  overflow-y: auto;
+  background: #fafafa;
+  gap: 0;
+
+  .e-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 12px 14px;
+    background: white;
+    border-bottom: 1px solid #eee;
+    flex-shrink: 0;
+    gap: 8px;
+  }
+
+  .e-name {
+    font-size: 1.05em;
+    font-weight: 700;
+    color: #222;
+  }
+
+  .e-pocket-btn {
+    padding: 5px 12px;
+    background: #f3f4f6;
+    border: 1px solid #d1d5db;
+    border-radius: 6px;
+    font-size: 0.8em;
+    cursor: pointer;
+    white-space: nowrap;
+    transition: all 0.15s;
+
+    &:hover:not(:disabled) {
+      background: #e0f2fe;
+      border-color: #0284c7;
+      color: #0284c7;
+    }
+
+    &.is-pocketed {
+      background: #eff6ff;
+      border-color: #93c5fd;
+      color: #1d4ed8;
+      cursor: default;
+    }
+  }
+
+  .e-section {
+    padding: 10px 14px;
+    border-bottom: 1px solid #f0f0f0;
+    background: white;
+  }
+
+  .e-section-title {
+    font-size: 0.75em;
+    font-weight: 600;
+    color: #888;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    margin-bottom: 6px;
+    display: flex;
+    align-items: center;
+    gap: 6px;
+  }
+
+  .e-count-badge {
+    background: #f0f0f0;
+    color: #555;
+    padding: 1px 7px;
+    border-radius: 10px;
+    font-size: 0.9em;
+    font-weight: 500;
+    text-transform: none;
+  }
+
+  .e-tags {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 4px;
+  }
+
+  .e-tag {
+    background: #e3f2fd;
+    color: #1565c0;
+    padding: 2px 9px;
+    border-radius: 12px;
+    font-size: 0.8em;
+    font-weight: 500;
+  }
+
+  .e-skills {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 4px;
+  }
+
+  .e-skill-badge {
+    background: #e8f5e9;
+    color: #2e7d32;
+    padding: 2px 9px;
+    border-radius: 4px;
+    font-size: 0.8em;
+    font-weight: 500;
+  }
+
+  .e-empty-note {
+    font-size: 0.82em;
+    color: #bbb;
+  }
+
+  .e-avail-bar-wrap {
+    height: 6px;
+    background: #e0e0e0;
+    border-radius: 3px;
+    overflow: hidden;
+    margin-bottom: 8px;
+  }
+
+  .e-avail-bar {
+    height: 100%;
+    background: #4caf50;
+    border-radius: 3px;
+    transition: width 0.3s;
+  }
+
+  .e-slot-list {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 4px;
+  }
+
+  .e-slot-chip {
+    background: #f5f5f5;
+    border: 1px solid #e0e0e0;
+    color: #555;
+    padding: 2px 8px;
+    border-radius: 4px;
+    font-size: 0.76em;
+  }
+
+  .e-assignment-list {
+    display: flex;
+    flex-direction: column;
+    gap: 5px;
+  }
+
+  .e-assignment-item {
+    display: flex;
+    align-items: center;
+    gap: 7px;
+    font-size: 0.85em;
+  }
+
+  .e-role-dot {
+    width: 8px;
+    height: 8px;
+    border-radius: 50%;
+    flex-shrink: 0;
+  }
+
+  .e-role-name {
+    font-weight: 500;
+    color: #333;
+    flex: 1;
+  }
+
+  .e-slot-time {
+    color: #888;
+    font-size: 0.9em;
+    white-space: nowrap;
+  }
+
+  .e-memo {
+    font-size: 0.85em;
+    color: #666;
+    line-height: 1.5;
+    white-space: pre-wrap;
+  }
+` as React.FC<React.HTMLAttributes<HTMLDivElement>>;

--- a/shift-puzzle-bubly/shift-puzzle-libs/src/ui/ReasonPanel/ReasonInputPanel.tsx
+++ b/shift-puzzle-bubly/shift-puzzle-libs/src/ui/ReasonPanel/ReasonInputPanel.tsx
@@ -1,0 +1,282 @@
+'use client';
+import React, { useState } from 'react';
+import styled from 'styled-components';
+import type { AssignmentReasonState, ReasonCategory } from '@bublys-org/shift-puzzle-model';
+
+export interface ReasonInputPanelProps {
+  memberName?: string;
+  roleName?: string;
+  initialCategory?: ReasonCategory;
+  initialText?: string;
+  initialCreatedBy?: string;
+  onSave: (reason: AssignmentReasonState) => void;
+  onCancel?: () => void;
+}
+
+const CATEGORY_LABELS: Record<ReasonCategory, string> = {
+  skill_match:   'スキル適合',
+  training:      '育成目的',
+  compatibility: '相性考慮',
+  availability:  '空き時間調整',
+  other:         'その他',
+};
+
+/** F-3-1: 配置理由入力パネル（記録者フィールド付き、モーダルなし） */
+export const ReasonInputPanel: React.FC<ReasonInputPanelProps> = ({
+  memberName,
+  roleName,
+  initialCategory = 'skill_match',
+  initialText = '',
+  initialCreatedBy = '',
+  onSave,
+  onCancel,
+}) => {
+  const [category, setCategory] = useState<ReasonCategory>(initialCategory);
+  const [text, setText] = useState(initialText);
+  const [createdBy, setCreatedBy] = useState(initialCreatedBy);
+
+  const handleSave = () => {
+    onSave({
+      category,
+      text,
+      createdBy,
+      createdAt: new Date().toISOString(),
+    });
+  };
+
+  return (
+    <StyledPanel>
+      <div className="e-title">配置理由を記録</div>
+
+      {(memberName || roleName) && (
+        <div className="e-info">
+          {memberName && <span className="e-chip">{memberName}</span>}
+          {roleName && (
+            <>
+              <span className="e-arrow">→</span>
+              <span className="e-chip e-role">{roleName}</span>
+            </>
+          )}
+        </div>
+      )}
+
+      <div className="e-field">
+        <label className="e-field-label">カテゴリ</label>
+        <div className="e-category-list">
+          {(Object.entries(CATEGORY_LABELS) as [ReasonCategory, string][]).map(([key, label]) => (
+            <label
+              key={key}
+              className={`e-category-btn ${category === key ? 'is-selected' : ''}`}
+            >
+              <input
+                type="radio"
+                name="reason-panel-category"
+                value={key}
+                checked={category === key}
+                onChange={() => setCategory(key)}
+              />
+              {label}
+            </label>
+          ))}
+        </div>
+      </div>
+
+      <div className="e-field">
+        <label className="e-field-label">詳細メモ（任意）</label>
+        <textarea
+          className="e-textarea"
+          rows={3}
+          placeholder="配置の背景・理由を記入..."
+          value={text}
+          onChange={(e: React.ChangeEvent<HTMLTextAreaElement>) => setText(e.target.value)}
+        />
+      </div>
+
+      <div className="e-footer">
+        <div className="e-recorder">
+          <label className="e-field-label">記録者</label>
+          <input
+            className="e-recorder-input"
+            type="text"
+            placeholder="名前を入力"
+            value={createdBy}
+            onChange={(e: React.ChangeEvent<HTMLInputElement>) => setCreatedBy(e.target.value)}
+          />
+        </div>
+        <div className="e-actions">
+          {onCancel && (
+            <button className="e-btn e-btn-cancel" onClick={onCancel}>
+              キャンセル
+            </button>
+          )}
+          <button className="e-btn e-btn-save" onClick={handleSave}>
+            保存
+          </button>
+        </div>
+      </div>
+    </StyledPanel>
+  );
+};
+
+const StyledPanel = styled.div`
+  background: white;
+  border-radius: 8px;
+  padding: 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+
+  .e-title {
+    font-size: 0.95em;
+    font-weight: 600;
+    color: #333;
+  }
+
+  .e-info {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    flex-wrap: wrap;
+
+    .e-chip {
+      background: #e3f2fd;
+      color: #1565c0;
+      padding: 2px 8px;
+      border-radius: 12px;
+      font-size: 0.85em;
+      font-weight: 500;
+    }
+
+    .e-chip.e-role {
+      background: #f3e5f5;
+      color: #6a1b9a;
+    }
+
+    .e-arrow {
+      color: #888;
+      font-size: 0.9em;
+    }
+  }
+
+  .e-field {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+  }
+
+  .e-field-label {
+    font-size: 0.8em;
+    color: #666;
+    font-weight: 500;
+  }
+
+  .e-category-list {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 6px;
+  }
+
+  .e-category-btn {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+    padding: 4px 10px;
+    border: 1px solid #ddd;
+    border-radius: 16px;
+    font-size: 0.82em;
+    cursor: pointer;
+    background: white;
+
+    input[type="radio"] {
+      display: none;
+    }
+
+    &.is-selected {
+      background: #1976d2;
+      border-color: #1976d2;
+      color: white;
+    }
+
+    &:hover:not(.is-selected) {
+      background: #f0f4ff;
+      border-color: #90caf9;
+    }
+  }
+
+  .e-textarea {
+    padding: 8px;
+    border: 1px solid #ddd;
+    border-radius: 4px;
+    font-size: 0.9em;
+    resize: vertical;
+    font-family: inherit;
+    min-height: 72px;
+
+    &:focus {
+      outline: none;
+      border-color: #1976d2;
+    }
+  }
+
+  .e-footer {
+    display: flex;
+    align-items: flex-end;
+    justify-content: space-between;
+    gap: 8px;
+    margin-top: 4px;
+  }
+
+  .e-recorder {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    flex: 1;
+  }
+
+  .e-recorder-input {
+    padding: 6px 8px;
+    border: 1px solid #ddd;
+    border-radius: 4px;
+    font-size: 0.9em;
+    font-family: inherit;
+    max-width: 140px;
+
+    &:focus {
+      outline: none;
+      border-color: #1976d2;
+    }
+  }
+
+  .e-actions {
+    display: flex;
+    gap: 8px;
+  }
+
+  .e-btn {
+    padding: 7px 16px;
+    border: none;
+    border-radius: 4px;
+    font-size: 0.9em;
+    cursor: pointer;
+    font-weight: 500;
+    white-space: nowrap;
+  }
+
+  .e-btn-cancel {
+    background: #f5f5f5;
+    color: #555;
+
+    &:hover {
+      background: #e0e0e0;
+    }
+  }
+
+  .e-btn-save {
+    background: #1976d2;
+    color: white;
+
+    &:hover {
+      background: #1565c0;
+    }
+  }
+` as React.FC<React.HTMLAttributes<HTMLDivElement>>;

--- a/shift-puzzle-bubly/shift-puzzle-libs/src/ui/ReasonPanel/ReasonList.tsx
+++ b/shift-puzzle-bubly/shift-puzzle-libs/src/ui/ReasonPanel/ReasonList.tsx
@@ -1,0 +1,336 @@
+'use client';
+import React, { useMemo, useState } from 'react';
+import styled from 'styled-components';
+import type {
+  AssignmentState,
+  MemberState,
+  RoleState,
+  TimeSlotState,
+  ReasonCategory,
+} from '@bublys-org/shift-puzzle-model';
+import { AssignmentReason } from '@bublys-org/shift-puzzle-model';
+
+export interface ReasonListProps {
+  assignments: AssignmentState[];
+  memberMap: Map<string, MemberState>;
+  roleMap: Map<string, RoleState>;
+  timeSlotMap: Map<string, TimeSlotState>;
+}
+
+const CATEGORY_LABELS: Record<ReasonCategory, string> = {
+  skill_match:   'スキル適合',
+  training:      '育成目的',
+  compatibility: '相性考慮',
+  availability:  '空き時間調整',
+  other:         'その他',
+};
+
+const CATEGORY_COLORS: Record<ReasonCategory, { bg: string; text: string }> = {
+  skill_match:   { bg: '#e8f5e9', text: '#2e7d32' },
+  training:      { bg: '#fff3e0', text: '#e65100' },
+  compatibility: { bg: '#fce4ec', text: '#880e4f' },
+  availability:  { bg: '#e3f2fd', text: '#1565c0' },
+  other:         { bg: '#f5f5f5', text: '#616161' },
+};
+
+function formatMinutes(minutes: number): string {
+  const h = Math.floor(minutes / 60);
+  const m = minutes % 60;
+  return `${String(h).padStart(2, '0')}:${String(m).padStart(2, '0')}`;
+}
+
+/** F-3-3: 配置理由一覧ビュー（引き継ぎドキュメント代替） */
+export const ReasonList: React.FC<ReasonListProps> = ({
+  assignments,
+  memberMap,
+  roleMap,
+  timeSlotMap,
+}) => {
+  const [filterCategory, setFilterCategory] = useState<ReasonCategory | 'all'>('all');
+  const [searchText, setSearchText] = useState('');
+
+  const filtered = useMemo(() => {
+    return assignments.filter((a) => {
+      if (filterCategory !== 'all' && a.reason.category !== filterCategory) return false;
+      if (searchText) {
+        const q = searchText.toLowerCase();
+        const memberName = memberMap.get(a.memberId)?.name ?? '';
+        const roleName = roleMap.get(a.roleId)?.name ?? '';
+        if (
+          !memberName.toLowerCase().includes(q) &&
+          !roleName.toLowerCase().includes(q) &&
+          !a.reason.text.toLowerCase().includes(q) &&
+          !(a.reason.createdBy ?? '').toLowerCase().includes(q)
+        ) return false;
+      }
+      return true;
+    });
+  }, [assignments, filterCategory, searchText, memberMap, roleMap]);
+
+  const categoryCounts = useMemo(() => {
+    const counts: Partial<Record<ReasonCategory, number>> = {};
+    for (const a of assignments) {
+      counts[a.reason.category] = (counts[a.reason.category] ?? 0) + 1;
+    }
+    return counts;
+  }, [assignments]);
+
+  return (
+    <StyledContainer>
+      <div className="e-toolbar">
+        <input
+          className="e-search"
+          type="text"
+          placeholder="スタッフ名・役割・メモで検索..."
+          value={searchText}
+          onChange={(e: React.ChangeEvent<HTMLInputElement>) => setSearchText(e.target.value)}
+        />
+        <div className="e-category-filters">
+          <button
+            className={`e-filter-btn ${filterCategory === 'all' ? 'is-active' : ''}`}
+            onClick={() => setFilterCategory('all')}
+          >
+            すべて ({assignments.length})
+          </button>
+          {(Object.entries(CATEGORY_LABELS) as [ReasonCategory, string][]).map(([key, label]) => {
+            const count = categoryCounts[key] ?? 0;
+            return (
+              <button
+                key={key}
+                className={`e-filter-btn ${filterCategory === key ? 'is-active' : ''}`}
+                onClick={() => setFilterCategory(key)}
+                style={
+                  filterCategory === key
+                    ? {}
+                    : { backgroundColor: CATEGORY_COLORS[key].bg, color: CATEGORY_COLORS[key].text, borderColor: 'transparent' }
+                }
+              >
+                {label} ({count})
+              </button>
+            );
+          })}
+        </div>
+      </div>
+
+      {filtered.length === 0 ? (
+        <div className="e-empty">
+          {searchText || filterCategory !== 'all'
+            ? '条件に合う配置理由が見つかりません'
+            : '配置がまだありません'}
+        </div>
+      ) : (
+        <div className="e-list">
+          {filtered.map((assignment) => {
+            const member = memberMap.get(assignment.memberId);
+            const role = roleMap.get(assignment.roleId);
+            const slot = timeSlotMap.get(assignment.timeSlotId);
+            const reason = new AssignmentReason(assignment.reason);
+            const colors = CATEGORY_COLORS[reason.category];
+
+            const timeStr = slot
+              ? `${formatMinutes(slot.startMinute)}〜${formatMinutes(slot.startMinute + slot.durationMinutes)}`
+              : '時間帯不明';
+
+            return (
+              <div key={assignment.id} className="e-card">
+                <div className="e-card-header">
+                  <div className="e-names">
+                    <span className="e-member-name">{member?.name ?? '（不明）'}</span>
+                    <span className="e-arrow">→</span>
+                    <span
+                      className="e-role-name"
+                      style={{ color: role?.color ?? '#555' }}
+                    >
+                      {role?.name ?? '（不明）'}
+                    </span>
+                    <span className="e-time-badge">{timeStr}</span>
+                  </div>
+                  <span
+                    className="e-category-badge"
+                    style={{ background: colors.bg, color: colors.text }}
+                  >
+                    {reason.categoryLabel}
+                  </span>
+                </div>
+
+                {reason.text ? (
+                  <div className="e-reason-text">{reason.text}</div>
+                ) : (
+                  <div className="e-reason-text e-no-text">（詳細メモなし）</div>
+                )}
+
+                <div className="e-meta">
+                  {reason.createdBy && <span>記録: {reason.createdBy}</span>}
+                  {assignment.locked && <span className="e-locked">🔒 確定済み</span>}
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      )}
+    </StyledContainer>
+  );
+};
+
+const StyledContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  overflow: hidden;
+  background: #fafafa;
+
+  .e-toolbar {
+    padding: 12px;
+    background: white;
+    border-bottom: 1px solid #eee;
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    flex-shrink: 0;
+  }
+
+  .e-search {
+    padding: 7px 10px;
+    border: 1px solid #ddd;
+    border-radius: 6px;
+    font-size: 0.9em;
+    width: 100%;
+    box-sizing: border-box;
+    font-family: inherit;
+
+    &:focus {
+      outline: none;
+      border-color: #1976d2;
+    }
+  }
+
+  .e-category-filters {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 4px;
+  }
+
+  .e-filter-btn {
+    padding: 3px 10px;
+    border: 1px solid #ddd;
+    border-radius: 12px;
+    background: white;
+    font-size: 0.78em;
+    cursor: pointer;
+    color: #666;
+    transition: background 0.1s;
+
+    &.is-active {
+      background: #1976d2 !important;
+      border-color: #1976d2 !important;
+      color: white !important;
+    }
+
+    &:hover:not(.is-active) {
+      opacity: 0.8;
+    }
+  }
+
+  .e-list {
+    flex: 1;
+    overflow-y: auto;
+    padding: 10px;
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+  }
+
+  .e-empty {
+    flex: 1;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    color: #999;
+    font-size: 0.9em;
+  }
+
+  .e-card {
+    background: white;
+    border: 1px solid #e0e0e0;
+    border-radius: 8px;
+    padding: 12px;
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+
+    &:hover {
+      border-color: #bdbdbd;
+      box-shadow: 0 1px 4px rgba(0, 0, 0, 0.08);
+    }
+  }
+
+  .e-card-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 8px;
+    flex-wrap: wrap;
+  }
+
+  .e-names {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    font-size: 0.9em;
+    flex-wrap: wrap;
+  }
+
+  .e-member-name {
+    font-weight: 600;
+    color: #222;
+  }
+
+  .e-arrow {
+    color: #bbb;
+  }
+
+  .e-role-name {
+    font-weight: 500;
+  }
+
+  .e-time-badge {
+    background: #f5f5f5;
+    padding: 1px 6px;
+    border-radius: 4px;
+    font-size: 0.82em;
+    color: #666;
+  }
+
+  .e-category-badge {
+    padding: 2px 8px;
+    border-radius: 4px;
+    font-size: 0.78em;
+    font-weight: 600;
+    white-space: nowrap;
+    flex-shrink: 0;
+  }
+
+  .e-reason-text {
+    font-size: 0.85em;
+    color: #444;
+    line-height: 1.5;
+    white-space: pre-wrap;
+    word-break: break-word;
+  }
+
+  .e-no-text {
+    color: #bbb;
+    font-style: italic;
+  }
+
+  .e-meta {
+    display: flex;
+    gap: 10px;
+    font-size: 0.76em;
+    color: #aaa;
+  }
+
+  .e-locked {
+    color: #666;
+  }
+` as React.FC<React.HTMLAttributes<HTMLDivElement>>;

--- a/shift-puzzle-bubly/shift-puzzle-libs/src/ui/ReasonPanel/ReasonPopover.tsx
+++ b/shift-puzzle-bubly/shift-puzzle-libs/src/ui/ReasonPanel/ReasonPopover.tsx
@@ -1,0 +1,162 @@
+'use client';
+import React from 'react';
+import styled from 'styled-components';
+import type { AssignmentState } from '@bublys-org/shift-puzzle-model';
+import { AssignmentReason } from '@bublys-org/shift-puzzle-model';
+
+export interface ReasonPopoverProps {
+  assignment: AssignmentState;
+  memberName: string;
+  roleName: string;
+  /** ビューポート基準のX座標（px） */
+  top: number;
+  /** ビューポート基準のY座標（px） */
+  left: number;
+}
+
+const CATEGORY_COLORS: Record<string, { bg: string; text: string }> = {
+  skill_match:   { bg: '#e8f5e9', text: '#2e7d32' },
+  training:      { bg: '#fff3e0', text: '#e65100' },
+  compatibility: { bg: '#fce4ec', text: '#880e4f' },
+  availability:  { bg: '#e3f2fd', text: '#1565c0' },
+  other:         { bg: '#f5f5f5', text: '#616161' },
+};
+
+/** F-3-2: 配置ブロックのホバーポップオーバー（position:fixed で親のoverflow:hiddenを突き抜ける） */
+export const ReasonPopover: React.FC<ReasonPopoverProps> = ({
+  assignment,
+  memberName,
+  roleName,
+  top,
+  left,
+}) => {
+  const reason = new AssignmentReason(assignment.reason);
+  const colors = CATEGORY_COLORS[reason.category] ?? CATEGORY_COLORS.other;
+
+  const formattedDate = (() => {
+    try {
+      return new Date(reason.createdAt).toLocaleString('ja-JP', {
+        month: '2-digit',
+        day: '2-digit',
+        hour: '2-digit',
+        minute: '2-digit',
+      });
+    } catch {
+      return '';
+    }
+  })();
+
+  return (
+    <StyledPopover style={{ top, left }}>
+      <div className="e-header">
+        <span className="e-chip">{memberName || '?'}</span>
+        <span className="e-arrow">→</span>
+        <span className="e-chip e-role">{roleName || '?'}</span>
+      </div>
+
+      <span
+        className="e-category-badge"
+        style={{ background: colors.bg, color: colors.text }}
+      >
+        {reason.categoryLabel}
+      </span>
+
+      {reason.text ? (
+        <div className="e-text">{reason.text}</div>
+      ) : (
+        <div className="e-text e-no-text">（詳細メモなし）</div>
+      )}
+
+      {(reason.createdBy || formattedDate) && (
+        <div className="e-meta">
+          {reason.createdBy && <span>記録: {reason.createdBy}</span>}
+          {formattedDate && <span>{formattedDate}</span>}
+        </div>
+      )}
+
+      {assignment.locked && (
+        <div className="e-locked-badge">🔒 確定済み</div>
+      )}
+    </StyledPopover>
+  );
+};
+
+// position:fixed はビューポート基準で表示されるため、
+// 祖先要素の overflow:hidden の影響を受けない
+const StyledPopover = styled.div`
+  position: fixed;
+  z-index: 9999;
+  background: white;
+  border: 1px solid #e0e0e0;
+  border-radius: 8px;
+  padding: 10px 12px;
+  min-width: 180px;
+  max-width: 280px;
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.18);
+  pointer-events: none;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  font-size: 0.85em;
+
+  .e-header {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    flex-wrap: wrap;
+
+    .e-chip {
+      background: #e3f2fd;
+      color: #1565c0;
+      padding: 1px 8px;
+      border-radius: 12px;
+      font-size: 0.88em;
+      font-weight: 500;
+    }
+
+    .e-chip.e-role {
+      background: #f3e5f5;
+      color: #6a1b9a;
+    }
+
+    .e-arrow {
+      color: #bbb;
+      font-size: 0.85em;
+    }
+  }
+
+  .e-category-badge {
+    display: inline-block;
+    padding: 2px 8px;
+    border-radius: 4px;
+    font-size: 0.8em;
+    font-weight: 600;
+    align-self: flex-start;
+  }
+
+  .e-text {
+    font-size: 0.85em;
+    color: #333;
+    line-height: 1.5;
+    word-break: break-word;
+    white-space: pre-wrap;
+  }
+
+  .e-no-text {
+    color: #bbb;
+    font-style: italic;
+  }
+
+  .e-meta {
+    display: flex;
+    gap: 8px;
+    font-size: 0.76em;
+    color: #aaa;
+    flex-wrap: wrap;
+  }
+
+  .e-locked-badge {
+    font-size: 0.78em;
+    color: #777;
+  }
+` as React.FC<React.HTMLAttributes<HTMLDivElement>>;

--- a/shift-puzzle-bubly/shift-puzzle-libs/src/ui/RoleFulfillment/RoleFulfillmentView.tsx
+++ b/shift-puzzle-bubly/shift-puzzle-libs/src/ui/RoleFulfillment/RoleFulfillmentView.tsx
@@ -1,0 +1,367 @@
+'use client';
+import React, { useMemo } from 'react';
+import styled from 'styled-components';
+import type {
+  RoleState,
+  TimeSlotState,
+  MemberState,
+  AssignmentState,
+  SkillDefinitionState,
+} from '@bublys-org/shift-puzzle-model';
+
+export interface RoleFulfillmentViewProps {
+  role: RoleState;
+  /** このシフト案内での配置一覧 */
+  assignments?: ReadonlyArray<AssignmentState>;
+  timeSlots?: ReadonlyArray<TimeSlotState>;
+  members?: ReadonlyArray<MemberState>;
+  skillDefinitions?: ReadonlyArray<SkillDefinitionState>;
+}
+
+/** F-4-2: 役割充足状況バブル（配置人数/必要人数・スキル充足率） */
+export const RoleFulfillmentView: React.FC<RoleFulfillmentViewProps> = ({
+  role,
+  assignments = [],
+  timeSlots = [],
+  members = [],
+  skillDefinitions = [],
+}) => {
+  const roleAssignments = assignments.filter((a) => a.roleId === role.id);
+
+  const formatTime = (minutes: number) => {
+    const h = Math.floor(minutes / 60);
+    const m = minutes % 60;
+    return `${h}:${String(m).padStart(2, '0')}`;
+  };
+
+  const getMemberName = (memberId: string) =>
+    members.find((m) => m.id === memberId)?.name ?? memberId;
+
+  // 時間帯ごとの充足状況
+  const slotFulfillment = useMemo(() => {
+    return timeSlots.map((slot) => {
+      const count = roleAssignments.filter((a) => a.timeSlotId === slot.id).length;
+      const assignedMembers = roleAssignments
+        .filter((a) => a.timeSlotId === slot.id)
+        .map((a) => getMemberName(a.memberId));
+      const isFulfilled = count >= role.minRequired;
+      const isOverFilled = role.maxRequired !== null && count > role.maxRequired;
+      return { slot, count, assignedMembers, isFulfilled, isOverFilled };
+    });
+  }, [timeSlots, roleAssignments, role, members]);
+
+  // 全体充足率（充足スロット数 / 全スロット数）
+  const fulfilledCount = slotFulfillment.filter((s) => s.isFulfilled).length;
+  const totalSlots = timeSlots.length;
+  const fulfillRate = totalSlots > 0 ? (fulfilledCount / totalSlots) * 100 : 0;
+
+  const requiredSkillLabels = role.requiredSkillIds.map(
+    (id) => skillDefinitions.find((d) => d.id === id)?.label ?? id
+  );
+
+  return (
+    <StyledWrapper>
+      {/* ヘッダー */}
+      <div className="e-header">
+        <div className="e-role-dot" style={{ background: role.color }} />
+        <div className="e-name">{role.name}</div>
+      </div>
+
+      {/* 概要 */}
+      {role.description && (
+        <div className="e-section">
+          <div className="e-section-title">説明</div>
+          <div className="e-description">{role.description}</div>
+        </div>
+      )}
+
+      {/* 必要人数 */}
+      <div className="e-section">
+        <div className="e-section-title">必要人数</div>
+        <div className="e-requirement">
+          <span className="e-req-min">{role.minRequired}名以上</span>
+          {role.maxRequired !== null && (
+            <span className="e-req-max">{role.maxRequired}名以下</span>
+          )}
+        </div>
+      </div>
+
+      {/* 必須スキル */}
+      <div className="e-section">
+        <div className="e-section-title">必須スキル</div>
+        {requiredSkillLabels.length > 0 ? (
+          <div className="e-skills">
+            {requiredSkillLabels.map((label) => (
+              <span key={label} className="e-skill-badge">✓ {label}</span>
+            ))}
+          </div>
+        ) : (
+          <div className="e-empty-note">スキル要件なし</div>
+        )}
+      </div>
+
+      {/* 充足状況サマリー */}
+      {totalSlots > 0 && (
+        <div className="e-section">
+          <div className="e-section-title">
+            充足状況
+            <span className={`e-fulfill-badge ${fulfillRate === 100 ? 'is-full' : fulfillRate > 0 ? 'is-partial' : 'is-empty'}`}>
+              {fulfilledCount}/{totalSlots} スロット充足
+            </span>
+          </div>
+          <div className="e-fulfill-bar-wrap">
+            <div
+              className={`e-fulfill-bar ${fulfillRate === 100 ? 'is-full' : ''}`}
+              style={{ width: `${fulfillRate}%` }}
+            />
+          </div>
+        </div>
+      )}
+
+      {/* 時間帯別充足 */}
+      {timeSlots.length > 0 && (
+        <div className="e-section">
+          <div className="e-section-title">時間帯別配置</div>
+          <div className="e-slot-table">
+            {slotFulfillment.map(({ slot, count, assignedMembers, isFulfilled, isOverFilled }) => (
+              <div
+                key={slot.id}
+                className={`e-slot-row ${isFulfilled ? 'is-fulfilled' : 'is-short'} ${isOverFilled ? 'is-over' : ''}`}
+              >
+                <div className="e-slot-time">
+                  {formatTime(slot.startMinute)}〜{formatTime(slot.startMinute + slot.durationMinutes)}
+                </div>
+                <div className="e-slot-count">
+                  <span className={`e-count-num ${isFulfilled ? 'ok' : 'ng'}`}>{count}</span>
+                  <span className="e-count-slash">/</span>
+                  <span className="e-count-req">{role.minRequired}</span>
+                </div>
+                {assignedMembers.length > 0 && (
+                  <div className="e-slot-members">
+                    {assignedMembers.map((name, i) => (
+                      <span key={i} className="e-member-chip">{name}</span>
+                    ))}
+                  </div>
+                )}
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+    </StyledWrapper>
+  );
+};
+
+const StyledWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  overflow-y: auto;
+  background: #fafafa;
+
+  .e-header {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    padding: 12px 14px;
+    background: white;
+    border-bottom: 1px solid #eee;
+    flex-shrink: 0;
+  }
+
+  .e-role-dot {
+    width: 12px;
+    height: 12px;
+    border-radius: 50%;
+    flex-shrink: 0;
+  }
+
+  .e-name {
+    font-size: 1.05em;
+    font-weight: 700;
+    color: #222;
+  }
+
+  .e-section {
+    padding: 10px 14px;
+    border-bottom: 1px solid #f0f0f0;
+    background: white;
+  }
+
+  .e-section-title {
+    font-size: 0.75em;
+    font-weight: 600;
+    color: #888;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    margin-bottom: 6px;
+    display: flex;
+    align-items: center;
+    gap: 6px;
+  }
+
+  .e-description {
+    font-size: 0.88em;
+    color: #555;
+    line-height: 1.5;
+  }
+
+  .e-requirement {
+    display: flex;
+    gap: 8px;
+  }
+
+  .e-req-min {
+    background: #e8f5e9;
+    color: #2e7d32;
+    padding: 2px 10px;
+    border-radius: 4px;
+    font-size: 0.85em;
+    font-weight: 600;
+  }
+
+  .e-req-max {
+    background: #fff3e0;
+    color: #e65100;
+    padding: 2px 10px;
+    border-radius: 4px;
+    font-size: 0.85em;
+    font-weight: 600;
+  }
+
+  .e-skills {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 4px;
+  }
+
+  .e-skill-badge {
+    background: #e8f5e9;
+    color: #2e7d32;
+    padding: 2px 9px;
+    border-radius: 4px;
+    font-size: 0.8em;
+    font-weight: 500;
+  }
+
+  .e-empty-note {
+    font-size: 0.82em;
+    color: #bbb;
+  }
+
+  .e-fulfill-badge {
+    padding: 1px 8px;
+    border-radius: 10px;
+    font-size: 0.9em;
+    font-weight: 500;
+    text-transform: none;
+
+    &.is-full {
+      background: #e8f5e9;
+      color: #2e7d32;
+    }
+    &.is-partial {
+      background: #fff3e0;
+      color: #e65100;
+    }
+    &.is-empty {
+      background: #fce4e4;
+      color: #c62828;
+    }
+  }
+
+  .e-fulfill-bar-wrap {
+    height: 6px;
+    background: #e0e0e0;
+    border-radius: 3px;
+    overflow: hidden;
+  }
+
+  .e-fulfill-bar {
+    height: 100%;
+    background: #ff9800;
+    border-radius: 3px;
+    transition: width 0.3s;
+
+    &.is-full {
+      background: #4caf50;
+    }
+  }
+
+  .e-slot-table {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+  }
+
+  .e-slot-row {
+    display: flex;
+    flex-direction: column;
+    gap: 3px;
+    padding: 6px 8px;
+    border-radius: 5px;
+    border: 1px solid #e0e0e0;
+    background: #fafafa;
+
+    &.is-fulfilled {
+      border-color: #a5d6a7;
+      background: #f1f8f1;
+    }
+
+    &.is-short {
+      border-color: #ffcc80;
+      background: #fff8f0;
+    }
+
+    &.is-over {
+      border-color: #ef9a9a;
+      background: #fff5f5;
+    }
+  }
+
+  .e-slot-time {
+    font-size: 0.8em;
+    color: #666;
+    font-weight: 500;
+  }
+
+  .e-slot-count {
+    display: flex;
+    align-items: baseline;
+    gap: 2px;
+    font-size: 0.9em;
+  }
+
+  .e-count-num {
+    font-weight: 700;
+    font-size: 1.1em;
+
+    &.ok { color: #2e7d32; }
+    &.ng { color: #e65100; }
+  }
+
+  .e-count-slash {
+    color: #bbb;
+    font-size: 0.9em;
+  }
+
+  .e-count-req {
+    color: #888;
+    font-size: 0.9em;
+  }
+
+  .e-slot-members {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 3px;
+  }
+
+  .e-member-chip {
+    background: white;
+    border: 1px solid #ddd;
+    color: #555;
+    padding: 1px 7px;
+    border-radius: 10px;
+    font-size: 0.76em;
+  }
+` as React.FC<React.HTMLAttributes<HTMLDivElement>>;

--- a/shift-puzzle-bubly/shift-puzzle-libs/src/ui/Summary/ShiftPlanSummaryView.tsx
+++ b/shift-puzzle-bubly/shift-puzzle-libs/src/ui/Summary/ShiftPlanSummaryView.tsx
@@ -1,0 +1,562 @@
+'use client';
+import React, { useMemo } from 'react';
+import styled from 'styled-components';
+import type {
+  MemberState,
+  RoleState,
+  TimeSlotState,
+  AssignmentState,
+} from '@bublys-org/shift-puzzle-model';
+
+// ========== 型定義 ==========
+
+/** メンバー拘束時間サマリー（F-7-1） */
+export interface MemberWorkloadSummary {
+  member: MemberState;
+  totalMinutes: number;
+  isUnassigned: boolean;
+  isOverloaded: boolean;
+}
+
+/** 役割充足状況サマリー（F-7-2） */
+export interface RoleFulfillmentSummary {
+  role: RoleState;
+  /** 充足スロット数 */
+  fulfilledSlots: number;
+  /** 全スロット数（minRequired > 0 のもの） */
+  totalSlots: number;
+  /** 不足合計人数（全スロット分の合算） */
+  totalShortfall: number;
+  /** 充足率 (0〜100) */
+  fulfillmentRate: number;
+  isFullyFulfilled: boolean;
+}
+
+/** アラート（F-7-3） */
+export interface SummaryAlert {
+  type: 'unassigned_member' | 'understaffed_role';
+  label: string;
+  detail: string;
+}
+
+export interface ShiftPlanSummaryViewProps {
+  members: ReadonlyArray<MemberState>;
+  roles: ReadonlyArray<RoleState>;
+  timeSlots: ReadonlyArray<TimeSlotState>;
+  assignments: ReadonlyArray<AssignmentState>;
+}
+
+// ========== ヘルパー ==========
+
+function formatMinutes(minutes: number): string {
+  const h = Math.floor(minutes / 60);
+  const m = minutes % 60;
+  if (m === 0) return `${h}時間`;
+  return `${h}時間${m}分`;
+}
+
+// ========== コンポーネント ==========
+
+/** F-7-1〜F-7-3: シフト案評価サマリービュー */
+export const ShiftPlanSummaryView: React.FC<ShiftPlanSummaryViewProps> = ({
+  members,
+  roles,
+  timeSlots,
+  assignments,
+}) => {
+  // タイムスロットをMapに変換
+  const timeSlotMap = useMemo(
+    () => new Map(timeSlots.map((ts) => [ts.id, ts])),
+    [timeSlots]
+  );
+
+  // F-7-1: メンバーごとの総拘束時間
+  const memberWorkloads = useMemo((): MemberWorkloadSummary[] => {
+    const assignedMinutes = new Map<string, number>();
+    for (const assignment of assignments) {
+      const slot = timeSlotMap.get(assignment.timeSlotId);
+      const duration = slot?.durationMinutes ?? 0;
+      assignedMinutes.set(
+        assignment.memberId,
+        (assignedMinutes.get(assignment.memberId) ?? 0) + duration
+      );
+    }
+
+    // 平均拘束時間（配置済みメンバーのみ）
+    const assignedValues = [...assignedMinutes.values()].filter((v) => v > 0);
+    const avgMinutes =
+      assignedValues.length > 0
+        ? assignedValues.reduce((s, v) => s + v, 0) / assignedValues.length
+        : 0;
+
+    return members.map((member) => {
+      const totalMinutes = assignedMinutes.get(member.id) ?? 0;
+      return {
+        member,
+        totalMinutes,
+        isUnassigned: totalMinutes === 0,
+        isOverloaded: avgMinutes > 0 && totalMinutes > avgMinutes * 1.8,
+      };
+    });
+  }, [members, assignments, timeSlotMap]);
+
+  const maxWorkloadMinutes = useMemo(
+    () => Math.max(...memberWorkloads.map((w) => w.totalMinutes), 1),
+    [memberWorkloads]
+  );
+
+  // F-7-2: 役割ごとの充足率
+  const roleFulfillments = useMemo((): RoleFulfillmentSummary[] => {
+    // timeSlotId × roleId での配置人数集計
+    const countMap = new Map<string, number>();
+    for (const assignment of assignments) {
+      const key = `${assignment.timeSlotId}:${assignment.roleId}`;
+      countMap.set(key, (countMap.get(key) ?? 0) + 1);
+    }
+
+    return roles.map((role) => {
+      const relevantSlots = timeSlots.filter(() => role.minRequired > 0);
+      let fulfilledSlots = 0;
+      let totalShortfall = 0;
+
+      for (const slot of relevantSlots) {
+        const assigned = countMap.get(`${slot.id}:${role.id}`) ?? 0;
+        if (assigned >= role.minRequired) {
+          fulfilledSlots++;
+        } else {
+          totalShortfall += role.minRequired - assigned;
+        }
+      }
+
+      const totalSlots = relevantSlots.length;
+      const fulfillmentRate =
+        totalSlots > 0 ? (fulfilledSlots / totalSlots) * 100 : 100;
+
+      return {
+        role,
+        fulfilledSlots,
+        totalSlots,
+        totalShortfall,
+        fulfillmentRate,
+        isFullyFulfilled: fulfilledSlots === totalSlots,
+      };
+    });
+  }, [roles, timeSlots, assignments]);
+
+  // F-7-3: アラート生成
+  const alerts = useMemo((): SummaryAlert[] => {
+    const result: SummaryAlert[] = [];
+
+    // 未配置メンバー
+    for (const w of memberWorkloads) {
+      if (w.isUnassigned) {
+        result.push({
+          type: 'unassigned_member',
+          label: w.member.name,
+          detail: '配置なし',
+        });
+      }
+    }
+
+    // 充足不足役割
+    for (const f of roleFulfillments) {
+      if (!f.isFullyFulfilled && f.totalShortfall > 0) {
+        result.push({
+          type: 'understaffed_role',
+          label: f.role.name,
+          detail: `計${f.totalShortfall}人不足（${f.fulfilledSlots}/${f.totalSlots}スロット充足）`,
+        });
+      }
+    }
+
+    return result;
+  }, [memberWorkloads, roleFulfillments]);
+
+  // 全体スコア
+  const overallScore = useMemo(() => {
+    if (roleFulfillments.length === 0) return 100;
+    const fulfilledCount = roleFulfillments.filter((f) => f.isFullyFulfilled).length;
+    return Math.round((fulfilledCount / roleFulfillments.length) * 100);
+  }, [roleFulfillments]);
+
+  return (
+    <StyledWrapper>
+      {/* ヘッダー */}
+      <div className="e-header">
+        <div className="e-header-title">評価サマリー</div>
+        <div className={`e-score-badge ${overallScore === 100 ? 'is-perfect' : overallScore >= 60 ? 'is-good' : 'is-poor'}`}>
+          充足スコア {overallScore}%
+        </div>
+      </div>
+
+      {/* F-7-3: アラート */}
+      {alerts.length > 0 && (
+        <section className="e-section">
+          <div className="e-section-title">
+            ⚠ アラート
+            <span className="e-badge e-badge--warn">{alerts.length}件</span>
+          </div>
+          <div className="e-alert-list">
+            {alerts.map((alert, i) => (
+              <div
+                key={i}
+                className={`e-alert-item ${alert.type === 'unassigned_member' ? 'is-member' : 'is-role'}`}
+              >
+                <span className="e-alert-icon">
+                  {alert.type === 'unassigned_member' ? '👤' : '📋'}
+                </span>
+                <span className="e-alert-label">{alert.label}</span>
+                <span className="e-alert-detail">{alert.detail}</span>
+              </div>
+            ))}
+          </div>
+        </section>
+      )}
+
+      {/* F-7-2: 役割充足率 */}
+      <section className="e-section">
+        <div className="e-section-title">役割充足状況</div>
+        <div className="e-role-list">
+          {roleFulfillments.map(({ role, fulfilledSlots, totalSlots, fulfillmentRate, isFullyFulfilled, totalShortfall }) => (
+            <div key={role.id} className="e-role-row">
+              <div className="e-role-row-header">
+                <div className="e-role-dot" style={{ background: role.color }} />
+                <span className="e-role-name">{role.name}</span>
+                <span className={`e-role-status ${isFullyFulfilled ? 'is-ok' : 'is-ng'}`}>
+                  {isFullyFulfilled ? '✓' : `⚠ ${totalShortfall}人不足`}
+                </span>
+                <span className="e-role-rate">{Math.round(fulfillmentRate)}%</span>
+              </div>
+              <div className="e-progress-wrap">
+                <div
+                  className={`e-progress-bar ${isFullyFulfilled ? 'is-full' : fulfillmentRate > 0 ? 'is-partial' : 'is-empty'}`}
+                  style={{ width: `${fulfillmentRate}%` }}
+                />
+              </div>
+              <div className="e-role-slots">
+                {fulfilledSlots}/{totalSlots}スロット充足
+              </div>
+            </div>
+          ))}
+          {roleFulfillments.length === 0 && (
+            <div className="e-empty">役割が登録されていません</div>
+          )}
+        </div>
+      </section>
+
+      {/* F-7-1: メンバー拘束時間 */}
+      <section className="e-section">
+        <div className="e-section-title">メンバー拘束時間</div>
+        <div className="e-member-list">
+          {memberWorkloads.map(({ member, totalMinutes, isUnassigned, isOverloaded }) => (
+            <div
+              key={member.id}
+              className={`e-member-row ${isUnassigned ? 'is-unassigned' : ''} ${isOverloaded ? 'is-overloaded' : ''}`}
+            >
+              <span className="e-member-name">{member.name}</span>
+              <div className="e-member-bar-wrap">
+                <div
+                  className={`e-member-bar ${isOverloaded ? 'is-over' : ''}`}
+                  style={{ width: `${(totalMinutes / maxWorkloadMinutes) * 100}%` }}
+                />
+              </div>
+              <span className="e-member-time">
+                {isUnassigned ? (
+                  <span className="e-unassigned-label">未配置</span>
+                ) : (
+                  <>
+                    {formatMinutes(totalMinutes)}
+                    {isOverloaded && <span className="e-overload-label">過負荷</span>}
+                  </>
+                )}
+              </span>
+            </div>
+          ))}
+          {memberWorkloads.length === 0 && (
+            <div className="e-empty">メンバーが登録されていません</div>
+          )}
+        </div>
+      </section>
+    </StyledWrapper>
+  );
+};
+
+// ========== スタイル ==========
+
+const StyledWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  overflow-y: auto;
+  background: #fafafa;
+
+  .e-header {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    padding: 12px 14px;
+    background: white;
+    border-bottom: 1px solid #eee;
+    flex-shrink: 0;
+  }
+
+  .e-header-title {
+    font-size: 1.05em;
+    font-weight: 700;
+    color: #222;
+  }
+
+  .e-score-badge {
+    margin-left: auto;
+    padding: 3px 12px;
+    border-radius: 12px;
+    font-size: 0.85em;
+    font-weight: 600;
+
+    &.is-perfect {
+      background: #e8f5e9;
+      color: #2e7d32;
+    }
+    &.is-good {
+      background: #fff3e0;
+      color: #e65100;
+    }
+    &.is-poor {
+      background: #fce4e4;
+      color: #c62828;
+    }
+  }
+
+  .e-section {
+    background: white;
+    border-bottom: 1px solid #f0f0f0;
+    padding: 10px 14px;
+  }
+
+  .e-section-title {
+    font-size: 0.75em;
+    font-weight: 600;
+    color: #888;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    margin-bottom: 8px;
+    display: flex;
+    align-items: center;
+    gap: 6px;
+  }
+
+  .e-badge {
+    padding: 1px 7px;
+    border-radius: 10px;
+    font-size: 0.9em;
+    font-weight: 500;
+    text-transform: none;
+
+    &.e-badge--warn {
+      background: #fce4e4;
+      color: #c62828;
+    }
+  }
+
+  /* F-7-3: アラートリスト */
+  .e-alert-list {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+  }
+
+  .e-alert-item {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    padding: 6px 9px;
+    border-radius: 5px;
+    font-size: 0.85em;
+
+    &.is-member {
+      background: #fff8e1;
+      border: 1px solid #ffe082;
+    }
+    &.is-role {
+      background: #fce4e4;
+      border: 1px solid #ef9a9a;
+    }
+  }
+
+  .e-alert-icon {
+    font-size: 1em;
+  }
+
+  .e-alert-label {
+    font-weight: 600;
+    color: #333;
+  }
+
+  .e-alert-detail {
+    color: #666;
+    margin-left: auto;
+    font-size: 0.9em;
+  }
+
+  /* F-7-2: 役割充足率 */
+  .e-role-list {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+  }
+
+  .e-role-row {
+    display: flex;
+    flex-direction: column;
+    gap: 3px;
+  }
+
+  .e-role-row-header {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    font-size: 0.88em;
+  }
+
+  .e-role-dot {
+    width: 10px;
+    height: 10px;
+    border-radius: 50%;
+    flex-shrink: 0;
+  }
+
+  .e-role-name {
+    font-weight: 600;
+    color: #333;
+  }
+
+  .e-role-status {
+    margin-left: auto;
+    font-size: 0.85em;
+
+    &.is-ok {
+      color: #2e7d32;
+    }
+    &.is-ng {
+      color: #c62828;
+      font-weight: 600;
+    }
+  }
+
+  .e-role-rate {
+    font-size: 0.85em;
+    color: #666;
+    min-width: 36px;
+    text-align: right;
+  }
+
+  .e-progress-wrap {
+    height: 6px;
+    background: #e0e0e0;
+    border-radius: 3px;
+    overflow: hidden;
+  }
+
+  .e-progress-bar {
+    height: 100%;
+    border-radius: 3px;
+    transition: width 0.3s;
+
+    &.is-full {
+      background: #4caf50;
+    }
+    &.is-partial {
+      background: #ff9800;
+    }
+    &.is-empty {
+      background: #ef5350;
+      width: 0% !important;
+    }
+  }
+
+  .e-role-slots {
+    font-size: 0.76em;
+    color: #aaa;
+  }
+
+  /* F-7-1: メンバー拘束時間 */
+  .e-member-list {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+  }
+
+  .e-member-row {
+    display: grid;
+    grid-template-columns: 100px 1fr 90px;
+    align-items: center;
+    gap: 6px;
+    font-size: 0.85em;
+
+    &.is-unassigned .e-member-name {
+      color: #bbb;
+    }
+
+    &.is-overloaded .e-member-name {
+      color: #c62828;
+      font-weight: 600;
+    }
+  }
+
+  .e-member-name {
+    color: #333;
+    font-weight: 500;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .e-member-bar-wrap {
+    height: 8px;
+    background: #f0f0f0;
+    border-radius: 4px;
+    overflow: hidden;
+  }
+
+  .e-member-bar {
+    height: 100%;
+    background: #42a5f5;
+    border-radius: 4px;
+    transition: width 0.3s;
+    min-width: 2px;
+
+    &.is-over {
+      background: #ef5350;
+    }
+  }
+
+  .e-member-time {
+    text-align: right;
+    color: #555;
+    display: flex;
+    align-items: center;
+    justify-content: flex-end;
+    gap: 4px;
+  }
+
+  .e-unassigned-label {
+    color: #bbb;
+    font-size: 0.9em;
+  }
+
+  .e-overload-label {
+    background: #fce4e4;
+    color: #c62828;
+    padding: 1px 5px;
+    border-radius: 3px;
+    font-size: 0.8em;
+    font-weight: 600;
+  }
+
+  .e-empty {
+    font-size: 0.85em;
+    color: #bbb;
+    padding: 8px 0;
+    text-align: center;
+  }
+` as React.FC<React.HTMLAttributes<HTMLDivElement>>;

--- a/shift-puzzle-bubly/shift-puzzle-libs/src/ui/index.ts
+++ b/shift-puzzle-bubly/shift-puzzle-libs/src/ui/index.ts
@@ -10,8 +10,14 @@ export { ReasonInputPanel } from './ReasonPanel/ReasonInputPanel.js';
 export { ReasonPopover } from './ReasonPanel/ReasonPopover.js';
 export { ReasonList } from './ReasonPanel/ReasonList.js';
 
+// F-1-1〜F-1-4: メンバー管理
+export { MemberCard } from './MemberCard/MemberCard.js';
+export { MemberForm } from './MemberCard/MemberForm.js';
+
 export type { GanttChartViewProps } from './GanttChart/GanttChartView.js';
 export type { ReasonInputDialogProps } from './GanttChart/ReasonInputDialog.js';
 export type { ReasonInputPanelProps } from './ReasonPanel/ReasonInputPanel.js';
 export type { ReasonPopoverProps } from './ReasonPanel/ReasonPopover.js';
 export type { ReasonListProps } from './ReasonPanel/ReasonList.js';
+export type { MemberCardProps } from './MemberCard/MemberCard.js';
+export type { MemberFormProps } from './MemberCard/MemberForm.js';

--- a/shift-puzzle-bubly/shift-puzzle-libs/src/ui/index.ts
+++ b/shift-puzzle-bubly/shift-puzzle-libs/src/ui/index.ts
@@ -14,6 +14,12 @@ export { ReasonList } from './ReasonPanel/ReasonList.js';
 export { MemberCard } from './MemberCard/MemberCard.js';
 export { MemberForm } from './MemberCard/MemberForm.js';
 
+// F-4-1: メンバー詳細
+export { MemberDetailView } from './MemberDetail/MemberDetailView.js';
+
+// F-4-2: 役割充足状況
+export { RoleFulfillmentView } from './RoleFulfillment/RoleFulfillmentView.js';
+
 export type { GanttChartViewProps } from './GanttChart/GanttChartView.js';
 export type { ReasonInputDialogProps } from './GanttChart/ReasonInputDialog.js';
 export type { ReasonInputPanelProps } from './ReasonPanel/ReasonInputPanel.js';
@@ -21,3 +27,5 @@ export type { ReasonPopoverProps } from './ReasonPanel/ReasonPopover.js';
 export type { ReasonListProps } from './ReasonPanel/ReasonList.js';
 export type { MemberCardProps } from './MemberCard/MemberCard.js';
 export type { MemberFormProps } from './MemberCard/MemberForm.js';
+export type { MemberDetailViewProps } from './MemberDetail/MemberDetailView.js';
+export type { RoleFulfillmentViewProps } from './RoleFulfillment/RoleFulfillmentView.js';

--- a/shift-puzzle-bubly/shift-puzzle-libs/src/ui/index.ts
+++ b/shift-puzzle-bubly/shift-puzzle-libs/src/ui/index.ts
@@ -5,5 +5,13 @@ export { MemberRow } from './GanttChart/MemberRow.js';
 export { ConflictHighlight } from './GanttChart/ConflictHighlight.js';
 export { ReasonInputDialog } from './GanttChart/ReasonInputDialog.js';
 
+// F-3-1〜F-3-3: 配置理由パネル
+export { ReasonInputPanel } from './ReasonPanel/ReasonInputPanel.js';
+export { ReasonPopover } from './ReasonPanel/ReasonPopover.js';
+export { ReasonList } from './ReasonPanel/ReasonList.js';
+
 export type { GanttChartViewProps } from './GanttChart/GanttChartView.js';
 export type { ReasonInputDialogProps } from './GanttChart/ReasonInputDialog.js';
+export type { ReasonInputPanelProps } from './ReasonPanel/ReasonInputPanel.js';
+export type { ReasonPopoverProps } from './ReasonPanel/ReasonPopover.js';
+export type { ReasonListProps } from './ReasonPanel/ReasonList.js';

--- a/shift-puzzle-bubly/shift-puzzle-libs/src/ui/index.ts
+++ b/shift-puzzle-bubly/shift-puzzle-libs/src/ui/index.ts
@@ -1,0 +1,9 @@
+export { GanttChartView } from './GanttChart/GanttChartView.js';
+export { AssignmentBlock } from './GanttChart/AssignmentBlock.js';
+export { TimeAxis } from './GanttChart/TimeAxis.js';
+export { MemberRow } from './GanttChart/MemberRow.js';
+export { ConflictHighlight } from './GanttChart/ConflictHighlight.js';
+export { ReasonInputDialog } from './GanttChart/ReasonInputDialog.js';
+
+export type { GanttChartViewProps } from './GanttChart/GanttChartView.js';
+export type { ReasonInputDialogProps } from './GanttChart/ReasonInputDialog.js';

--- a/shift-puzzle-bubly/shift-puzzle-libs/src/ui/index.ts
+++ b/shift-puzzle-bubly/shift-puzzle-libs/src/ui/index.ts
@@ -20,6 +20,10 @@ export { MemberDetailView } from './MemberDetail/MemberDetailView.js';
 // F-4-2: 役割充足状況
 export { RoleFulfillmentView } from './RoleFulfillment/RoleFulfillmentView.js';
 
+// F-7-1〜F-7-3: 評価サマリー
+export { ShiftPlanSummaryView } from './Summary/ShiftPlanSummaryView.js';
+export type { ShiftPlanSummaryViewProps, MemberWorkloadSummary, RoleFulfillmentSummary, SummaryAlert } from './Summary/ShiftPlanSummaryView.js';
+
 export type { GanttChartViewProps } from './GanttChart/GanttChartView.js';
 export type { ReasonInputDialogProps } from './GanttChart/ReasonInputDialog.js';
 export type { ReasonInputPanelProps } from './ReasonPanel/ReasonInputPanel.js';

--- a/shift-puzzle-bubly/shift-puzzle-libs/tsconfig.lib.json
+++ b/shift-puzzle-bubly/shift-puzzle-libs/tsconfig.lib.json
@@ -1,0 +1,24 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "baseUrl": ".",
+    "rootDir": "src",
+    "outDir": "dist",
+    "tsBuildInfoFile": "dist/tsconfig.lib.tsbuildinfo",
+    "emitDeclarationOnly": false,
+    "forceConsistentCasingInFileNames": true,
+    "types": ["node"],
+    "jsx": "react-jsx",
+    "lib": ["dom", "dom.iterable", "esnext"]
+  },
+  "include": ["src/**/*.ts", "src/**/*.tsx"],
+  "references": [
+    { "path": "../shift-puzzle-model/tsconfig.lib.json" }
+  ],
+  "exclude": [
+    "jest.config.ts",
+    "jest.config.cts",
+    "src/**/*.spec.ts",
+    "src/**/*.test.ts"
+  ]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -80,6 +80,12 @@
     },
     {
       "path": "./sekaisen-igo-bubly/sekaisen-igo-app"
+    },
+    {
+      "path": "./shift-puzzle-bubly/shift-puzzle-model"
+    },
+    {
+      "path": "./shift-puzzle-bubly/shift-puzzle-libs"
     }
   ]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -85,7 +85,7 @@
       "path": "./shift-puzzle-bubly/shift-puzzle-model"
     },
     {
-      "path": "./shift-puzzle-bubly/shift-puzzle-libs"
+      "path": "./shift-puzzle-bubly/shift-puzzle-app"
     }
   ]
 }


### PR DESCRIPTION
## Summary

- **バグ修正**: メンバー管理バブルが開かない問題を修正
  - `BublyApp.tsx`: メニュークリック時のopenerを `'root'`（存在しない仮想ID）から実在バブルIDに変更
  - `bubbles-listener.ts`: opener bubbleがstoreに存在しない場合の安全な早期リターンを追加（TypeError防止）
- **役割D&D配置**: ガントチャートのメンバービューで役割リストからドラッグ&ドロップ配置に対応
  - `RoleListFeature`: `readOnly` プロパティを追加（編集UI非表示・役割カードをドラッグ可能）
  - `GanttChartView`: `text/role-id` ドラッグタイプを受け付け、メンバー行へドロップで配置作成
- **origin-side展開**: 配置ブロッククリック時にクリック位置からバブルが展開されるよう変更
- **readOnlyモード**: ガントチャートのメンバービューセルクリックで役割一覧を `?readOnly=true` で開く

## Test plan

- [ ] サイドバー「メンバー管理」をクリックしてバブルが正常に開くことを確認
- [ ] ガントチャートをメンバービューに切り替え、セルクリックで役割一覧バブルが開き「配置用」バッジが表示されること
- [ ] 役割リストから役割カードをガントチャートのメンバー行にD&Dして配置が作成されること
- [ ] 配置ブロックをクリックするとクリックしたブロックの位置からメンバー詳細バブルが展開されること
- [ ] 通常の役割一覧（EventDetail等から開いた場合）は編集UIが表示されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)