### PR TITLE
feat(bublys-ui): 無限キャンバス実装・LinkBubble座標修正・Surface境界除去

### DIFF
--- a/apps/bublys-os/app/bubble-ui/BubblesUI/feature/BubblesUI.tsx
+++ b/apps/bublys-os/app/bubble-ui/BubblesUI/feature/BubblesUI.tsx
@@ -1,4 +1,4 @@
-import { FC, useEffect, useCallback, useState, useMemo } from "react";
+import { FC, useEffect, useCallback, useState, useMemo, useRef } from "react";
 import { useAppSelector, useAppDispatch, selectWindowSize, setWindowSize, addPocketItem, selectPocketItems, removePocketItem } from "@bublys-org/state-management";
 import { useShellManager } from "@bublys-org/object-shell";
 
@@ -52,6 +52,10 @@ export const BubblesUI: FC<BubblesUI> = ({ additionalButton }) => {
   const [isControlPanelOpen, setIsControlPanelOpen] = useState(false);
   const [isPocketOpen, setIsPocketOpen] = useState(false);
   const pocketItems = useAppSelector(selectPocketItems);
+
+  // 無限キャンバス用 zoom/pan refs（ref なので変更しても再レンダリングしない）
+  const canvasZoomRef = useRef(1);
+  const canvasPanRef = useRef({ x: 0, y: 0 });
 
    // ページサイズ管理
   const pageSize = useAppSelector(selectWindowSize);
@@ -107,9 +111,10 @@ export const BubblesUI: FC<BubblesUI> = ({ additionalButton }) => {
   }, [dispatch]);
 
   const popChildMax = useCallback((b: Bubble, openerBubbleId:string): string => {
-    // 利用可能なスペース（グローバル座標系）
-    const availableWidth = pageSize.width - globalCoordinateSystem.offset.x - surfaceLeftTop.x;
-    const availableHeight = pageSize.height - globalCoordinateSystem.offset.y - surfaceLeftTop.y;
+    // 利用可能なスペース（screen座標系 → canvas座標系へ変換）
+    const canvasZoom = canvasZoomRef.current;
+    const availableWidth = (pageSize.width - globalCoordinateSystem.offset.x - surfaceLeftTop.x) / canvasZoom;
+    const availableHeight = (pageSize.height - globalCoordinateSystem.offset.y - surfaceLeftTop.y) / canvasZoom;
 
 
     // サイズと位置を設定
@@ -165,12 +170,15 @@ export const BubblesUI: FC<BubblesUI> = ({ additionalButton }) => {
   }, [dispatch]);
 
   // BubblesContextの値をメモ化（不要な再レンダリング防止）
+  // canvasZoomRef / canvasPanRef はrefなので依存配列に含めない（refは常に同一オブジェクト）
   const bubblesContextValue = useMemo(() => ({
     pageSize,
     surfaceLeftTop,
     coordinateSystem: globalCoordinateSystem,
     openBubble: popChildOrJoinSibling,
-  }), [pageSize, surfaceLeftTop, globalCoordinateSystem, popChildOrJoinSibling]);
+    canvasZoomRef,
+    canvasPanRef,
+  }), [pageSize, surfaceLeftTop, globalCoordinateSystem, popChildOrJoinSibling]); // eslint-disable-line react-hooks/exhaustive-deps
 
   // Pocketのドロップハンドラー
   const handlePocketDrop = (url: string, type: DragDataType, label?: string, objectId?: string) => {
@@ -218,6 +226,8 @@ export const BubblesUI: FC<BubblesUI> = ({ additionalButton }) => {
                   onBubbleLayerDown={layerDown}
                   onBubbleLayerUp={layerUp}
                   onCoordinateSystemReady={handleCoordinateSystemReady}
+                  canvasZoomRef={canvasZoomRef}
+                  canvasPanRef={canvasPanRef}
                 />
               </Box>
             </PositionDebuggerProvider>

--- a/apps/bublys-os/app/bubble-ui/BubblesUI/ui/BubblesLayeredView.tsx
+++ b/apps/bublys-os/app/bubble-ui/BubblesUI/ui/BubblesLayeredView.tsx
@@ -1,4 +1,4 @@
-import React, { FC, useRef, useLayoutEffect, memo, useMemo } from "react";
+import React, { FC, useRef, useLayoutEffect, useEffect, useCallback, memo, useMemo, useState } from "react";
 import styled from "styled-components";
 import {
   Bubble,
@@ -119,7 +119,7 @@ const ConnectedLinkBubbleView: FC<ConnectedLinkBubbleViewProps> = memo(function 
 });
 
 type BubblesLayeredViewProps = {
-  bubbleLayers: string[][];  // IDの配列に変更
+  bubbleLayers: string[][];
   vanishingPoint?: Point2;
   onBubbleClick?: (name: string) => void;
   onBubbleClose?: (bubble: Bubble) => void;
@@ -128,6 +128,10 @@ type BubblesLayeredViewProps = {
   onBubbleLayerDown?: (bubble: Bubble) => void;
   onBubbleLayerUp?: (bubble: Bubble) => void;
   onCoordinateSystemReady?: (coordinateSystem: CoordinateSystem) => void;
+  /** キャンバスズーム用ref（BubblesUIから受け取り、ドラッグ計算に使用） */
+  canvasZoomRef?: React.MutableRefObject<number>;
+  /** キャンバスパン用ref（BubblesUIから受け取り） */
+  canvasPanRef?: React.MutableRefObject<Point2>;
 };
 
 export const BubblesLayeredView: FC<BubblesLayeredViewProps> = ({
@@ -140,10 +144,134 @@ export const BubblesLayeredView: FC<BubblesLayeredViewProps> = ({
   onBubbleLayerDown,
   onBubbleLayerUp,
   onCoordinateSystemReady,
+  canvasZoomRef: externalZoomRef,
+  canvasPanRef: externalPanRef,
 }) => {
   const containerRef = useRef<HTMLDivElement>(null);
+  const canvasRef = useRef<HTMLDivElement>(null);
 
-  // コンテナの位置を取得してCoordinateSystemを設定（サイズ・位置変更時も更新）
+  // 外部refが渡されない場合のローカルfallback
+  const localZoomRef = useRef(1);
+  const localPanRef = useRef<Point2>({ x: 0, y: 0 });
+  const zoomRef = externalZoomRef ?? localZoomRef;
+  const panRef = externalPanRef ?? localPanRef;
+
+  // Space キーによるパンモードの状態（カーソル表示用のみ）
+  const [isPanMode, setIsPanMode] = useState(false);
+  const isSpaceDownRef = useRef(false);
+
+  // キャンバスのCSS transformを直接DOM更新（Reactの再レンダリングを避けてパフォーマンス向上）
+  const applyCanvasTransform = useCallback(() => {
+    if (!canvasRef.current) return;
+    const { x, y } = panRef.current;
+    const zoom = zoomRef.current;
+    canvasRef.current.style.transform = `translate(${x}px, ${y}px) scale(${zoom})`;
+  }, [panRef, zoomRef]);
+
+  // ── ホイールイベント（zoom / trackpad pan）──────────────────────────────
+  useEffect(() => {
+    const container = containerRef.current;
+    if (!container) return;
+
+    const handleWheel = (e: WheelEvent) => {
+      // バブルのコンテンツ内スクロールはキャンバス操作に変換しない
+      const target = e.target as HTMLElement;
+      if (target.closest('.e-bubble-content')) return;
+
+      e.preventDefault();
+
+      if (e.ctrlKey) {
+        // ピンチジェスチャー / Ctrl+スクロール → ズーム
+        const zoomFactor = Math.exp(-e.deltaY * 0.005);
+        const oldZoom = zoomRef.current;
+        const newZoom = Math.max(0.1, Math.min(8, oldZoom * zoomFactor));
+
+        // カーソル位置を中心にズーム
+        const rect = container.getBoundingClientRect();
+        const cursorX = e.clientX - rect.left;
+        const cursorY = e.clientY - rect.top;
+        const oldPan = panRef.current;
+
+        zoomRef.current = newZoom;
+        panRef.current = {
+          x: cursorX - ((cursorX - oldPan.x) / oldZoom) * newZoom,
+          y: cursorY - ((cursorY - oldPan.y) / oldZoom) * newZoom,
+        };
+      } else {
+        // 二本指スクロール → パン
+        panRef.current = {
+          x: panRef.current.x - e.deltaX,
+          y: panRef.current.y - e.deltaY,
+        };
+      }
+
+      applyCanvasTransform();
+    };
+
+    container.addEventListener('wheel', handleWheel, { passive: false });
+    return () => container.removeEventListener('wheel', handleWheel);
+  }, [zoomRef, panRef, applyCanvasTransform]);
+
+  // ── Space キー（パンモード切替）──────────────────────────────────────
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (
+        e.code === 'Space' &&
+        !e.repeat &&
+        !(e.target instanceof HTMLInputElement) &&
+        !(e.target instanceof HTMLTextAreaElement)
+      ) {
+        isSpaceDownRef.current = true;
+        setIsPanMode(true);
+        e.preventDefault();
+      }
+    };
+    const handleKeyUp = (e: KeyboardEvent) => {
+      if (e.code === 'Space') {
+        isSpaceDownRef.current = false;
+        setIsPanMode(false);
+      }
+    };
+    document.addEventListener('keydown', handleKeyDown);
+    document.addEventListener('keyup', handleKeyUp);
+    return () => {
+      document.removeEventListener('keydown', handleKeyDown);
+      document.removeEventListener('keyup', handleKeyUp);
+    };
+  }, []);
+
+  // ── マウスドラッグによるパン（中ボタン or Space+左ボタン）──────────────
+  const handleMouseDown = useCallback((e: React.MouseEvent<HTMLDivElement>) => {
+    const isMiddle = e.button === 1;
+    const isSpaceDrag = e.button === 0 && isSpaceDownRef.current;
+    if (!isMiddle && !isSpaceDrag) return;
+
+    e.preventDefault();
+    e.stopPropagation();
+
+    const startMouseX = e.clientX;
+    const startMouseY = e.clientY;
+    const startPanX = panRef.current.x;
+    const startPanY = panRef.current.y;
+
+    const handleMove = (e: MouseEvent) => {
+      panRef.current = {
+        x: startPanX + (e.clientX - startMouseX),
+        y: startPanY + (e.clientY - startMouseY),
+      };
+      applyCanvasTransform();
+    };
+
+    const handleUp = () => {
+      document.removeEventListener('mousemove', handleMove);
+      document.removeEventListener('mouseup', handleUp);
+    };
+
+    document.addEventListener('mousemove', handleMove);
+    document.addEventListener('mouseup', handleUp);
+  }, [panRef, applyCanvasTransform]);
+
+  // ── CoordinateSystem の更新（コンテナ位置変更時）──────────────────────
   useLayoutEffect(() => {
     let lastOffset = { x: 0, y: 0 };
     let lastVanishingPoint = { x: 0, y: 0 };
@@ -153,7 +281,6 @@ export const BubblesLayeredView: FC<BubblesLayeredViewProps> = ({
         const rect = containerRef.current.getBoundingClientRect();
         const currentVanishingPoint = vanishingPoint || { x: 0, y: 0 };
 
-        // 座標またはvanishingPointが変更された場合のみ更新（無限ループ防止）
         if (
           rect.left === lastOffset.x &&
           rect.top === lastOffset.y &&
@@ -167,18 +294,16 @@ export const BubblesLayeredView: FC<BubblesLayeredViewProps> = ({
         lastVanishingPoint = currentVanishingPoint;
 
         const coordinateSystem = new CoordinateSystem(
-          0,  // layerIndex
-          { x: rect.left, y: rect.top },  // offset
-          currentVanishingPoint  // vanishingPoint
+          0,
+          { x: rect.left, y: rect.top },
+          currentVanishingPoint
         );
         onCoordinateSystemReady?.(coordinateSystem);
       }
     };
 
-    // 初期設定
     updateCoordinateSystem();
 
-    // ResizeObserverでサイズ変更を監視
     const resizeObserver = new ResizeObserver(() => {
       updateCoordinateSystem();
     });
@@ -187,8 +312,6 @@ export const BubblesLayeredView: FC<BubblesLayeredViewProps> = ({
       resizeObserver.observe(containerRef.current);
     }
 
-    // windowのresizeイベントで位置変更も検出（サイドバー幅変更など）
-    // requestAnimationFrameでスロットリング
     let rafId: number | null = null;
     const handleResize = () => {
       if (rafId !== null) return;
@@ -209,23 +332,17 @@ export const BubblesLayeredView: FC<BubblesLayeredViewProps> = ({
     };
   }, [onCoordinateSystemReady, vanishingPoint]);
 
-  // IDベースの関係性のみ取得（パフォーマンス最適化）
+  // ── Redux からのデータ取得 ─────────────────────────────────────────────
   const relationIds = useAppSelector(selectValidBubbleRelationIds);
   const surfaceLeftTop = useAppSelector(selectSurfaceLeftTop);
   const coordinateSystem = useAppSelector(selectGlobalCoordinateSystem);
   const isLayerAnimating = useAppSelector(selectIsLayerAnimating);
 
-  // PositionDebuggerからaddRectsを取得
   const { addRects } = usePositionDebugger();
 
-  const undergroundVanishingPoint: Point2 = vanishingPoint || {
-    x: 20,
-    y: 10,
-  };
-
+  const undergroundVanishingPoint: Point2 = vanishingPoint || { x: 20, y: 10 };
   const baseZIndex = 100;
 
-  // bubbleIdToZIndexを計算（LinkBubbleView用）
   const bubbleIdToZIndex: Record<string, number> = useMemo(() => {
     const result: Record<string, number> = {};
     bubbleLayers.forEach((layer, layerIndex) => {
@@ -237,12 +354,10 @@ export const BubblesLayeredView: FC<BubblesLayeredViewProps> = ({
     return result;
   }, [bubbleLayers]);
 
-  // リンクバブルが接続されているopenee IDのSet（左角丸を無効化するため）
   const openeeIds = useMemo(() => {
     return new Set(relationIds.map(r => r.openeeId));
   }, [relationIds]);
 
-  // 各バブルをConnectedBubbleViewでレンダリング
   const renderedBubbles = bubbleLayers
     .map((layer, layerIndex) =>
       layer.map((bubbleId) => {
@@ -271,102 +386,91 @@ export const BubblesLayeredView: FC<BubblesLayeredViewProps> = ({
     )
     .flat();
 
+  // styled-components v5 は ref を直接受け取れないため、
+  // plain div を外側に置いて containerRef を持たせる
   return (
-    <div ref={containerRef} style={{ width: '100%', height: '100%', position: 'relative' }}>
-      <StyledBubblesLayeredView
-        surface={{ leftTop: surfaceLeftTop }}
-        underground={{ vanishingPoint: undergroundVanishingPoint }}
-        surfaceZIndex={baseZIndex - 2}
+    <div
+      ref={containerRef}
+      style={{ width: '100%', height: '100%' }}
+    >
+      <StyledViewport
+        isPanMode={isPanMode}
+        onMouseDown={handleMouseDown}
       >
-        {renderedBubbles}
-        <div className="e-underground-curtain"></div>
-        <div className="e-debug-visualizations">
-          <div className="e-surface-border"></div>
-          <div className="e-underground-border"></div>
-          <div className="e-vanishing-point"></div>
+        {/* キャンバス層：CSS transform で pan/zoom を実現 */}
+        <div
+          ref={canvasRef}
+          style={{
+            position: 'absolute',
+            top: 0,
+            left: 0,
+            width: '100%',
+            height: '100%',
+            transformOrigin: '0 0',
+            // 初期 transform（applyCanvasTransform で直接更新される）
+            transform: 'translate(0px, 0px) scale(1)',
+          }}
+        >
+          <StyledCanvas>
+            {renderedBubbles}
+
+            {/* アニメーション中はLinkBubbleを非表示にする（位置ズレ防止） */}
+            {!isLayerAnimating &&
+              relationIds.map(({ openerId, openeeId }) => {
+                const linkZIndex = bubbleIdToZIndex[openeeId] - 1;
+                return (
+                  <ConnectedLinkBubbleView
+                    key={`${openerId}_${openeeId}`}
+                    openerId={openerId}
+                    openeeId={openeeId}
+                    coordinateSystem={coordinateSystem}
+                    linkZIndex={linkZIndex}
+                  />
+                );
+              })
+            }
+          </StyledCanvas>
         </div>
-
-        {/* アニメーション中はLinkBubbleを非表示にする（位置ズレ防止） */}
-        {!isLayerAnimating &&
-          relationIds.map(({ openerId, openeeId }) => {
-            const linkZIndex = bubbleIdToZIndex[openeeId] - 1;
-
-            return(
-              <ConnectedLinkBubbleView
-                key={`${openerId}_${openeeId}`}
-                openerId={openerId}
-                openeeId={openeeId}
-                coordinateSystem={coordinateSystem}
-                linkZIndex={linkZIndex}
-              />
-            );
-          })
-        }
-
-      </StyledBubblesLayeredView>
+      </StyledViewport>
     </div>
   );
 };
 
-type StyledBubblesLayeredViewProps = {
-  surface: { leftTop: Point2 };
-  underground: { vanishingPoint?: Point2 };
-  surfaceZIndex?: number;
-  children?: React.ReactNode;
-};
+// ── Styled Components ──────────────────────────────────────────────────────
 
-const StyledBubblesLayeredView = styled.div<StyledBubblesLayeredViewProps>`
+/**
+ * 画面に見えるビューポート。クリッピングと背景を担当。
+ * overflow: hidden でキャンバス外のバブルを非表示にする。
+ */
+const StyledViewport = styled.div<React.HTMLAttributes<HTMLDivElement> & { isPanMode: boolean }>`
   width: 100%;
   height: 100%;
   position: relative;
   overflow: hidden;
-  z-index: 0;
+  cursor: ${({ isPanMode }) => isPanMode ? 'grab' : 'default'};
 
-  // 上品な藍色のグラデーション背景
+  // 上品な藍色のグラデーション背景（固定。キャンバスパンに追従しない）
   background: linear-gradient(
     145deg,
     hsl(220, 35%, 18%) 0%,
     hsl(225, 40%, 22%) 40%,
     hsl(230, 35%, 20%) 100%
   );
+`;
 
-  > .e-underground-curtain {
-    position: absolute;
-    top: 0;
-    left: 0;
-    z-index: ${({ surfaceZIndex }) => surfaceZIndex || 0};
-    width: 100%;
-    height: 100%;
-    pointer-events: none;
-  }
+type StyledCanvasProps = {
+  children?: React.ReactNode;
+};
 
-  > .e-debug-visualizations {
-    .e-surface-border {
-      position: absolute;
-      top: ${({ surface }) => surface.leftTop.y}px;
-      left: ${({ surface }) => surface.leftTop.x}px;
-      width: calc(100% - ${({ surface }) => surface.leftTop.x}px);
-      height: calc(100% - ${({ surface }) => surface.leftTop.y}px);
-      border-radius: 24px;
-      background: rgba(255, 255, 255, 0.08);
-      border: 1px solid rgba(255, 255, 255, 0.2);
-      backdrop-filter: blur(1px);
-      box-shadow:
-        0 4px 30px rgba(0, 0, 0, 0.05),
-        inset 0 0 20px rgba(255, 255, 255, 0.05);
-      pointer-events: none;
-      // layerIndex 0,1 はぼかしの上に、layerIndex 2以降はぼかしの下に
-      z-index: ${({ surfaceZIndex }) => surfaceZIndex || 0};
-    }
-    .e-vanishing-point {
-      position: absolute;
-      top: ${({ underground }) => underground.vanishingPoint?.y || 0}px;
-      left: ${({ underground }) => underground.vanishingPoint?.x || 0}px;
-      width: 8px;
-      height: 8px;
-      background: blue;
-      border-radius: 50%;
-      pointer-events: none;
-    }
-  }
+/**
+ * キャンバス本体。バブルを配置する空間。
+ * overflow: visible でキャンバス外への配置を許容（ビューポートがクリップする）。
+ */
+const StyledCanvas = styled.div<StyledCanvasProps>`
+  width: 100%;
+  height: 100%;
+  position: relative;
+  overflow: visible;
+  z-index: 0;
+  background: transparent;
 `;

--- a/bublys-libs/bubbles-ui/src/lib/bubble-routing/BubbleRouting.ts
+++ b/bublys-libs/bubbles-ui/src/lib/bubble-routing/BubbleRouting.ts
@@ -1,4 +1,4 @@
-import { FC, createContext } from "react";
+import { FC, createContext, MutableRefObject } from "react";
 import { Bubble, BubbleOptions, BubbleParams } from "../Bubble.domain.js";
 import { Size2, CoordinateSystem } from "@bublys-org/bubbles-ui-util";
 import { OpeningPosition } from "../state/bubbles-slice.js";
@@ -92,6 +92,10 @@ export type BubblesContextType = {
   surfaceLeftTop: { x: number; y: number };
   coordinateSystem: CoordinateSystem;
   openBubble: (name: string, openerBubbleId: string, openingPosition?: OpeningPosition) => string;
+  /** キャンバスズームの現在値への同期的アクセス用ref。ドラッグ計算・座標変換に使用。 */
+  canvasZoomRef: MutableRefObject<number>;
+  /** キャンバスパンの現在値への同期的アクセス用ref。LinkBubble座標変換に使用。 */
+  canvasPanRef: MutableRefObject<{ x: number; y: number }>;
 };
 
 export const BubblesContext = createContext<BubblesContextType>({
@@ -102,6 +106,8 @@ export const BubblesContext = createContext<BubblesContextType>({
     console.warn("openBubble not implemented");
     return "void_id";
   },
+  canvasZoomRef: { current: 1 },
+  canvasPanRef: { current: { x: 0, y: 0 } },
 });
 
 // ルートマッチングユーティリティ

--- a/bublys-libs/bubbles-ui/src/lib/bubly/BublyApp.tsx
+++ b/bublys-libs/bubbles-ui/src/lib/bubly/BublyApp.tsx
@@ -1,5 +1,5 @@
 'use client';
-import { FC, useState, useEffect, useCallback, useMemo } from 'react';
+import { FC, useState, useEffect, useCallback, useMemo, useRef } from 'react';
 import { Box, IconButton, List, ListItemButton, ListItemIcon, Tooltip, Typography } from '@mui/material';
 import Inventory2Icon from '@mui/icons-material/Inventory2';
 import {
@@ -154,12 +154,18 @@ export const BublyApp: FC<BublyAppProps> = ({
     dispatch(setGlobalCoordinateSystem(cs.toData()));
   }, [dispatch]);
 
+  // BublyApp は独自のキャンバス操作を持たないが、BubblesContextType の要件を満たすために ref を提供
+  const canvasZoomRef = useRef(1);
+  const canvasPanRef = useRef({ x: 0, y: 0 });
+
   const bubblesContextValue = useMemo(() => ({
     pageSize,
     surfaceLeftTop,
     coordinateSystem: globalCoordinateSystem,
     openBubble: popChildOrJoinSibling,
-  }), [pageSize, surfaceLeftTop, globalCoordinateSystem, popChildOrJoinSibling]);
+    canvasZoomRef,
+    canvasPanRef,
+  }), [pageSize, surfaceLeftTop, globalCoordinateSystem, popChildOrJoinSibling]); // eslint-disable-line react-hooks/exhaustive-deps
 
   // Pocket
   const [isPocketOpen, setIsPocketOpen] = useState(false);

--- a/bublys-libs/bubbles-ui/src/lib/ui/BubbleView.tsx
+++ b/bublys-libs/bubbles-ui/src/lib/ui/BubbleView.tsx
@@ -155,7 +155,7 @@ const BubbleViewInner: FC<BubbleProps> = ({
   );
 
   const dispatch = useAppDispatch();
-  const { coordinateSystem, pageSize, surfaceLeftTop } = useContext(BubblesContext);
+  const { coordinateSystem, pageSize, surfaceLeftTop, canvasZoomRef } = useContext(BubblesContext);
   const bubbleRefs = useBubbleRefsOptional();
 
   // ドラッグハンドラ用に最新値を保持
@@ -205,12 +205,15 @@ const BubbleViewInner: FC<BubbleProps> = ({
       y: e.clientY - dragStartMouseRef.current.y,
     };
 
-    // CoordinateSystemを使ってスクリーン座標→ローカル座標の変換を行う
-    const coordSystem = CoordinateSystem.fromLayerIndex(layerIndex || 0)
-      .withVanishingPoint(vanishingPointRef.current || { x: 0, y: 0 });
-
-    // スクリーン座標でのマウス移動量をローカル座標系での移動量に変換
-    const localDelta = coordSystem.transformScreenDeltaToLocal(screenDelta);
+    // screen座標 → canvas座標 → layer local座標 の2段階変換
+    // canvasZoom: キャンバス全体のズーム倍率（無限キャンバス用）
+    // layerScale: レイヤーの奥行きによるスケール
+    const canvasZoom = canvasZoomRef?.current ?? 1;
+    const layerScale = CoordinateSystem.fromLayerIndex(layerIndex || 0).scale;
+    const localDelta = {
+      x: screenDelta.x / (canvasZoom * layerScale),
+      y: screenDelta.y / (canvasZoom * layerScale),
+    };
     const newPos = {
       x: dragStartPosRef.current.x + localDelta.x,
       y: dragStartPosRef.current.y + localDelta.y,
@@ -229,7 +232,12 @@ const BubbleViewInner: FC<BubbleProps> = ({
 
     // transform-originも更新（vanishingPointとの相対位置を維持）
     // これがないと、Redux更新後にtransform-originが再計算されて位置がズレる
-    const newTransformOrigin = coordSystem.calculateTransformOrigin(screenPos);
+    // calculateTransformOrigin の実装: vanishingPoint - elementCanvasPosition
+    const vp = vanishingPointRef.current || { x: 0, y: 0 };
+    const newTransformOrigin = {
+      x: vp.x - screenPos.x,
+      y: vp.y - screenPos.y,
+    };
     ref.current.style.transformOrigin = `${newTransformOrigin.x}px ${newTransformOrigin.y}px`;
   };
 
@@ -243,11 +251,12 @@ const BubbleViewInner: FC<BubbleProps> = ({
       dispatch(updateBubble(resizedBubble.toJSON()));
       onResize?.(resizedBubble);
     } else {
-      // 最大化
+      // 最大化（screen座標をcanvas座標に変換）
       if (!pageSize) return;
       const globalCoordinateSystem = coordinateSystem;
-      const availableWidth = pageSize.width - globalCoordinateSystem.offset.x - surfaceLeftTop.x;
-      const availableHeight = pageSize.height - globalCoordinateSystem.offset.y - surfaceLeftTop.y;
+      const canvasZoom = canvasZoomRef?.current ?? 1;
+      const availableWidth = (pageSize.width - globalCoordinateSystem.offset.x - surfaceLeftTop.x) / canvasZoom;
+      const availableHeight = (pageSize.height - globalCoordinateSystem.offset.y - surfaceLeftTop.y) / canvasZoom;
       const newPosition = { x: 0, y: 0 };
 
       const resizedBubble = bubble.resizeTo({ width: availableWidth, height: availableHeight }).moveTo(newPosition);
@@ -456,8 +465,6 @@ const StyledBubble = styled.div<StyledBubbleProp>`
   transform: scale(
     ${({ layerIndex }) => CoordinateSystem.fromLayerIndex(layerIndex ?? 0).scale}
   );
-
-  max-height: 90vh;//FIXME:突貫対応
 
   // 泡っぽいグラデーション背景
   background: linear-gradient(

--- a/bublys-libs/bubbles-ui/src/lib/ui/LinkBubbleView.tsx
+++ b/bublys-libs/bubbles-ui/src/lib/ui/LinkBubbleView.tsx
@@ -1,14 +1,37 @@
-import { FC } from "react";
+import { FC, useContext } from "react";
 import { Bubble } from "../Bubble.domain.js";
-import { CoordinateSystem } from "@bublys-org/bubbles-ui-util";
+import { CoordinateSystem, SmartRect } from "@bublys-org/bubbles-ui-util";
 import { getOriginRect } from "../utils/get-origin-rect.js";
 import { useBubbleRefsOptional } from "../context/BubbleRefsContext.js";
+import { BubblesContext } from "../bubble-routing/BubbleRouting.js";
 
 type LinkBubbleViewProps = {
   opener: Bubble;
   openee: Bubble;
   coordinateSystem: CoordinateSystem;
   linkZIndex: number;
+};
+
+/**
+ * screen-within-container 座標（getBoundingClientRect - containerOffset）を
+ * canvas 座標（CSS transform の逆変換）に変換する。
+ *
+ * 変換式: canvasX = (localX - panX) / zoom
+ *
+ * getBoundingClientRect は CSS transform を含む screen 座標を返すため、
+ * canvas の transform（translate + scale）の逆変換が必要。
+ */
+const toCanvasRect = (rect: SmartRect, panX: number, panY: number, zoom: number): SmartRect => {
+  return new SmartRect(
+    new DOMRect(
+      (rect.x - panX) / zoom,
+      (rect.y - panY) / zoom,
+      rect.width / zoom,
+      rect.height / zoom,
+    ),
+    rect.parentSize,
+    rect.coordinateSystem,
+  );
 };
 
 export const LinkBubbleView: FC<LinkBubbleViewProps> = ({
@@ -18,25 +41,32 @@ export const LinkBubbleView: FC<LinkBubbleViewProps> = ({
   linkZIndex,
 }) => {
   const bubbleRefs = useBubbleRefsOptional();
+  const { canvasZoomRef, canvasPanRef } = useContext(BubblesContext);
 
   // キャッシュ付きでorigin rectを取得（強制リフローを最小化）
-  // useMemoは不要 - getOriginRectCachedが内部でキャッシュしている
   const originRect = bubbleRefs?.getOriginRectCached(openee.url)
     // フォールバック: 従来のgetOriginRectを使う
     ?? getOriginRect(opener.id, openee.url);
 
   const baseOpenerRect = originRect || opener.renderedRect;
-  const openerRect = baseOpenerRect
+
+  // toLocal で「screen-within-container」座標に変換し、さらに canvas 逆変換を適用
+  const canvasZoom = canvasZoomRef?.current ?? 1;
+  const canvasPan = canvasPanRef?.current ?? { x: 0, y: 0 };
+
+  const rawOpenerRect = baseOpenerRect
     ? baseOpenerRect.toLocal(coordinateSystem)
     : undefined;
 
-  const openeeRect = openee.renderedRect
+  const rawOpeneeRect = openee.renderedRect
     ? openee.renderedRect.toLocal(coordinateSystem)
     : undefined;
 
-  if (!openerRect || !openeeRect) return null;
+  if (!rawOpenerRect || !rawOpeneeRect) return null;
 
-
+  // canvas 座標系へ逆変換
+  const openerRect = toCanvasRect(rawOpenerRect, canvasPan.x, canvasPan.y, canvasZoom);
+  const openeeRect = toCanvasRect(rawOpeneeRect, canvasPan.x, canvasPan.y, canvasZoom);
 
   //A 〜 B
   //|    |
@@ -67,9 +97,12 @@ export const LinkBubbleView: FC<LinkBubbleViewProps> = ({
         width: "100%",
         height: "100%",
         pointerEvents: "none",
+        // SVGのoverflow:visibleを有効にするため、親divもvisibleにする
+        overflow: "visible",
       }}
     >
-      <svg width="100%" height="100%">
+      {/* overflow: visible でキャンバス境界外のパスもクリップしない */}
+      <svg width="100%" height="100%" style={{ overflow: "visible" }}>
         <defs>
           <marker
             id="arrowhead"


### PR DESCRIPTION
- 無限キャンバス: キャンバス div に CSS transform (translate + scale) を適用し、 ホイールズーム（カーソル中心）・二本指パン・中ボタンドラッグ・Space+ドラッグを実装
- BubblesContext に canvasZoomRef / canvasPanRef を追加し、 バブルドラッグ計算・LinkBubble座標変換を canvas 座標系に対応
- LinkBubble ずれ修正: getBoundingClientRect の screen 座標を (localX - panX) / zoom で canvas 座標に逆変換
- LinkBubble クリップ修正: SVG に overflow: visible を設定し ビューポート外への線描画を許可
- Surface 境界除去: e-surface-border・e-underground-curtain を削除、 max-height: 90vh 制約を除去