### PR TITLE
Feat/bubble always right scroll

### DIFF
--- a/apps/bublys-os/app/bubble-ui/BubblesUI/ui/BubblesLayeredView.tsx
+++ b/apps/bublys-os/app/bubble-ui/BubblesUI/ui/BubblesLayeredView.tsx
@@ -1,7 +1,4 @@
 import React, { FC, useRef, useLayoutEffect, memo, useMemo } from "react";
-
-const CANVAS_WIDTH = 20000;
-const CANVAS_HEIGHT = 5000;
 import styled from "styled-components";
 import {
   Bubble,
@@ -16,8 +13,9 @@ import {
   selectSurfaceLeftTop,
   selectIsLayerAnimating,
   makeSelectBubbleById,
+  selectBubblesMaxExtent,
 } from "@bublys-org/bubbles-ui";
-import { useAppSelector } from "@bublys-org/state-management";
+import { useAppSelector, selectWindowSize } from "@bublys-org/state-management";
 import { BubbleContent } from "./BubbleContent";
 import { usePositionDebugger } from "@bublys-org/bubbles-ui/debug";
 
@@ -229,6 +227,12 @@ export const BubblesLayeredView: FC<BubblesLayeredViewProps> = ({
   const coordinateSystem = useAppSelector(selectGlobalCoordinateSystem);
   const isLayerAnimating = useAppSelector(selectIsLayerAnimating);
 
+  // キャンバスサイズ: バブルの配置範囲とビューポートサイズの大きい方に広がる
+  const pageSize = useAppSelector(selectWindowSize);
+  const bubblesExtent = useAppSelector(selectBubblesMaxExtent);
+  const canvasWidth = Math.max(pageSize.width, bubblesExtent.width);
+  const canvasHeight = Math.max(pageSize.height, bubblesExtent.height);
+
   // PositionDebuggerからaddRectsを取得
   const { addRects } = usePositionDebugger();
 
@@ -287,7 +291,7 @@ export const BubblesLayeredView: FC<BubblesLayeredViewProps> = ({
 
   return (
     <div ref={scrollContainerRef} style={{ width: '100%', height: '100%', overflow: 'auto' }}>
-      <div ref={containerRef} style={{ position: 'relative', width: `${CANVAS_WIDTH}px`, height: `${CANVAS_HEIGHT}px` }}>
+      <div ref={containerRef} style={{ position: 'relative', width: `${canvasWidth}px`, height: `${canvasHeight}px` }}>
         <StyledBubblesLayeredView
           surface={{ leftTop: surfaceLeftTop }}
           underground={{ vanishingPoint: undergroundVanishingPoint }}

--- a/apps/bublys-os/app/bubble-ui/BubblesUI/ui/BubblesLayeredView.tsx
+++ b/apps/bublys-os/app/bubble-ui/BubblesUI/ui/BubblesLayeredView.tsx
@@ -1,4 +1,7 @@
 import React, { FC, useRef, useLayoutEffect, memo, useMemo } from "react";
+
+const CANVAS_WIDTH = 20000;
+const CANVAS_HEIGHT = 5000;
 import styled from "styled-components";
 import {
   Bubble,
@@ -141,6 +144,9 @@ export const BubblesLayeredView: FC<BubblesLayeredViewProps> = ({
   onBubbleLayerUp,
   onCoordinateSystemReady,
 }) => {
+  // scrollContainerRef: ビューポートサイズのスクロール可能な外側コンテナ
+  const scrollContainerRef = useRef<HTMLDivElement>(null);
+  // containerRef: 大きなキャンバス（内側div）。スクロールで動くのでgetBoundingClientRect()がoffsetを正確に反映する
   const containerRef = useRef<HTMLDivElement>(null);
 
   // コンテナの位置を取得してCoordinateSystemを設定（サイズ・位置変更時も更新）
@@ -167,9 +173,9 @@ export const BubblesLayeredView: FC<BubblesLayeredViewProps> = ({
         lastVanishingPoint = currentVanishingPoint;
 
         const coordinateSystem = new CoordinateSystem(
-          0,  // layerIndex
-          { x: rect.left, y: rect.top },  // offset
-          currentVanishingPoint  // vanishingPoint
+          0,
+          { x: rect.left, y: rect.top },
+          currentVanishingPoint
         );
         onCoordinateSystemReady?.(coordinateSystem);
       }
@@ -178,13 +184,20 @@ export const BubblesLayeredView: FC<BubblesLayeredViewProps> = ({
     // 初期設定
     updateCoordinateSystem();
 
-    // ResizeObserverでサイズ変更を監視
+    // スクロール時にキャンバスdivのviewport位置が変わるのでoffsetを更新
+    const scrollContainer = scrollContainerRef.current;
+    const handleScroll = () => {
+      updateCoordinateSystem();
+    };
+    scrollContainer?.addEventListener('scroll', handleScroll);
+
+    // サイドバー幅変更などによるレイアウト変化を検知
     const resizeObserver = new ResizeObserver(() => {
       updateCoordinateSystem();
     });
 
-    if (containerRef.current) {
-      resizeObserver.observe(containerRef.current);
+    if (scrollContainerRef.current) {
+      resizeObserver.observe(scrollContainerRef.current);
     }
 
     // windowのresizeイベントで位置変更も検出（サイドバー幅変更など）
@@ -203,6 +216,7 @@ export const BubblesLayeredView: FC<BubblesLayeredViewProps> = ({
     return () => {
       resizeObserver.disconnect();
       window.removeEventListener('resize', handleResize);
+      scrollContainer?.removeEventListener('scroll', handleScroll);
       if (rafId !== null) {
         cancelAnimationFrame(rafId);
       }
@@ -272,38 +286,40 @@ export const BubblesLayeredView: FC<BubblesLayeredViewProps> = ({
     .flat();
 
   return (
-    <div ref={containerRef} style={{ width: '100%', height: '100%', position: 'relative' }}>
-      <StyledBubblesLayeredView
-        surface={{ leftTop: surfaceLeftTop }}
-        underground={{ vanishingPoint: undergroundVanishingPoint }}
-        surfaceZIndex={baseZIndex - 2}
-      >
-        {renderedBubbles}
-        <div className="e-underground-curtain"></div>
-        <div className="e-debug-visualizations">
-          <div className="e-surface-border"></div>
-          <div className="e-underground-border"></div>
-          <div className="e-vanishing-point"></div>
-        </div>
+    <div ref={scrollContainerRef} style={{ width: '100%', height: '100%', overflow: 'auto' }}>
+      <div ref={containerRef} style={{ position: 'relative', width: `${CANVAS_WIDTH}px`, height: `${CANVAS_HEIGHT}px` }}>
+        <StyledBubblesLayeredView
+          surface={{ leftTop: surfaceLeftTop }}
+          underground={{ vanishingPoint: undergroundVanishingPoint }}
+          surfaceZIndex={baseZIndex - 2}
+        >
+          {renderedBubbles}
+          <div className="e-underground-curtain"></div>
+          <div className="e-debug-visualizations">
+            <div className="e-surface-border"></div>
+            <div className="e-underground-border"></div>
+            <div className="e-vanishing-point"></div>
+          </div>
 
-        {/* アニメーション中はLinkBubbleを非表示にする（位置ズレ防止） */}
-        {!isLayerAnimating &&
-          relationIds.map(({ openerId, openeeId }) => {
-            const linkZIndex = bubbleIdToZIndex[openeeId] - 1;
+          {/* アニメーション中はLinkBubbleを非表示にする（位置ズレ防止） */}
+          {!isLayerAnimating &&
+            relationIds.map(({ openerId, openeeId }) => {
+              const linkZIndex = bubbleIdToZIndex[openeeId] - 1;
 
-            return(
-              <ConnectedLinkBubbleView
-                key={`${openerId}_${openeeId}`}
-                openerId={openerId}
-                openeeId={openeeId}
-                coordinateSystem={coordinateSystem}
-                linkZIndex={linkZIndex}
-              />
-            );
-          })
-        }
+              return(
+                <ConnectedLinkBubbleView
+                  key={`${openerId}_${openeeId}`}
+                  openerId={openerId}
+                  openeeId={openeeId}
+                  coordinateSystem={coordinateSystem}
+                  linkZIndex={linkZIndex}
+                />
+              );
+            })
+          }
 
-      </StyledBubblesLayeredView>
+        </StyledBubblesLayeredView>
+      </div>
     </div>
   );
 };
@@ -319,7 +335,7 @@ const StyledBubblesLayeredView = styled.div<StyledBubblesLayeredViewProps>`
   width: 100%;
   height: 100%;
   position: relative;
-  overflow: hidden;
+  overflow: visible;
   z-index: 0;
 
   // 上品な藍色のグラデーション背景

--- a/bublys-libs/bubbles-ui-util/src/lib/SmartRect.ts
+++ b/bublys-libs/bubbles-ui-util/src/lib/SmartRect.ts
@@ -152,53 +152,14 @@ export class SmartRect implements DOMRectReadOnly {
 
   /**
    * 兄弟要素を配置する位置を計算（同じレイヤー）
-   * 優先順位: 右隣 → 下 → 左 → 上
+   * 常に右隣に配置する（画面端に関わらず）
    *
-   * @param openingSize 配置する要素のサイズ
+   * @param openingSize 配置する要素のサイズ（現在は未使用）
    * @returns 配置すべきグローバル座標
    */
   calcPositionForSibling(openingSize: Size2): Point2 {
-    // 現在のrectをグローバル座標に変換
     const globalRect = this.toGlobal();
-
-    // 各方向の利用可能なスペースとその方向の隣接領域を取得
-    const directions: Array<{ direction: Direction; neighbor: SmartRect; space: number }> = [
-      {
-        direction: 'right',
-        neighbor: globalRect.getNeighbor('right'),
-        space: globalRect.rightSpace - openingSize.width,
-      },
-      {
-        direction: 'bottom',
-        neighbor: globalRect.getNeighbor('bottom'),
-        space: globalRect.bottomSpace - openingSize.height,
-      },
-      {
-        direction: 'left',
-        neighbor: globalRect.getNeighbor('left'),
-        space: globalRect.leftSpace - openingSize.width,
-      },
-      {
-        direction: 'top',
-        neighbor: globalRect.getNeighbor('top'),
-        space: globalRect.topSpace - openingSize.height,
-      },
-    ];
-
-    // スペースが十分にある方向を優先順位順に探す
-    for (const { neighbor, space } of directions) {
-      if (space >= 0) {
-        // 十分なスペースがあるので、その方向の隣接領域の左上に配置
-        return neighbor.position;
-      }
-    }
-
-    // どの方向にも十分なスペースがない場合は、最もスペースが広い方向を選択
-    const bestDirection = directions.reduce((best, current) =>
-      current.space > best.space ? current : best
-    );
-
-    return bestDirection.neighbor.position;
+    return globalRect.getNeighbor('right').position;
   }
 
   /**

--- a/bublys-libs/bubbles-ui/src/lib/state/bubbles-slice.ts
+++ b/bublys-libs/bubbles-ui/src/lib/state/bubbles-slice.ts
@@ -419,6 +419,39 @@ export const makeSelectBubbleLayerIndex = (bubbleId: string): LayerIndexSelector
   return layerIndexSelectorCache.get(bubbleId)!;
 };
 
+/** バブルのサイズが未知の場合のフォールバック値 */
+const FALLBACK_BUBBLE_WIDTH = 400;
+const FALLBACK_BUBBLE_HEIGHT = 300;
+/** キャンバス端に確保する余白 */
+const CANVAS_PADDING = 200;
+
+/**
+ * 全バブルの配置から必要なキャンバスの最小サイズを計算する
+ * バブルが右方向に展開していくたびにキャンバスが広がるよう使用する
+ */
+export const selectBubblesMaxExtent = createSelector(
+  [selectBubblesJson, selectSurfaceLeftTop],
+  (bubblesJson, surfaceLeftTop): { width: number; height: number } => {
+    let maxRight = 0;
+    let maxBottom = 0;
+
+    for (const bubbleJson of Object.values(bubblesJson)) {
+      const x = (bubbleJson.position?.x ?? 0) + surfaceLeftTop.x;
+      const y = (bubbleJson.position?.y ?? 0) + surfaceLeftTop.y;
+      const width = bubbleJson.renderedRect?.width ?? bubbleJson.size?.width ?? FALLBACK_BUBBLE_WIDTH;
+      const height = bubbleJson.renderedRect?.height ?? bubbleJson.size?.height ?? FALLBACK_BUBBLE_HEIGHT;
+
+      maxRight = Math.max(maxRight, x + width);
+      maxBottom = Math.max(maxBottom, y + height);
+    }
+
+    return {
+      width: maxRight + CANVAS_PADDING,
+      height: maxBottom + CANVAS_PADDING,
+    };
+  }
+);
+
 export default bubblesSlice.reducer;
 
 // rootReducerにbubblesSliceを動的に注入する関数

--- a/bublys-libs/bubbles-ui/src/lib/ui/BubbleView.tsx
+++ b/bublys-libs/bubbles-ui/src/lib/ui/BubbleView.tsx
@@ -212,8 +212,8 @@ const BubbleViewInner: FC<BubbleProps> = ({
     // スクリーン座標でのマウス移動量をローカル座標系での移動量に変換
     const localDelta = coordSystem.transformScreenDeltaToLocal(screenDelta);
     const newPos = {
-      x: dragStartPosRef.current.x + localDelta.x,
-      y: dragStartPosRef.current.y + localDelta.y,
+      x: Math.max(-surfaceLeftTopRef.current.x, dragStartPosRef.current.x + localDelta.x),
+      y: Math.max(-surfaceLeftTopRef.current.y, dragStartPosRef.current.y + localDelta.y),
     };
 
     // ドラッグ中はDOM直接操作（Redux更新を避けてパフォーマンス向上）


### PR DESCRIPTION
- SmartRect.calcPositionForSibling
  - 画面端チェックを廃止し常に右隣へ配置
- BubblesLayeredView
  - 外側div (overflow:auto) でネイティブスクロールを提供
  - canvasWidth/Height = max(ビューポートサイズ, バブル最大範囲)
  - バブルが開かれるたびにキャンバスが右方向へ追従して広がる
  
- selectBubblesMaxExtent セレクターを追加: 全バブルのposition+サイズから必要な最小キャンバスサイズを計算
  - renderedRect → size → フォールバック(400x300) の優先順でサイズを参照
  - 端に400pxのパディングを追加

- BubbleView
   - キャンバスの上端と左端に制限を設ける
   - 現状は上端と左端へ動的拡張機能は設けない方針