### PR TITLE
feat: バブルフォーカス管理とヘッダー外側表示 (issue #59)

### DIFF
--- a/bublys-libs/bubbles-ui-util/src/lib/CoordinateSystem.ts
+++ b/bublys-libs/bubbles-ui-util/src/lib/CoordinateSystem.ts
@@ -14,7 +14,7 @@ export type CoordinateSystemData = {
  * スケール計算の定数
  * レイヤーごとのスケール減少率
  */
-const SCALE_DECAY_RATE = 0.1;
+const SCALE_DECAY_RATE = 0;
 
 /**
  * スケール計算を開始するレイヤーインデックス

--- a/bublys-libs/bubbles-ui-util/src/lib/CoordinateSystem.ts
+++ b/bublys-libs/bubbles-ui-util/src/lib/CoordinateSystem.ts
@@ -14,7 +14,7 @@ export type CoordinateSystemData = {
  * スケール計算の定数
  * レイヤーごとのスケール減少率
  */
-const SCALE_DECAY_RATE = 0;
+const SCALE_DECAY_RATE = 0.1;
 
 /**
  * スケール計算を開始するレイヤーインデックス

--- a/bublys-libs/bubbles-ui/src/lib/BubblesProcess.domain.test.ts
+++ b/bublys-libs/bubbles-ui/src/lib/BubblesProcess.domain.test.ts
@@ -1,0 +1,63 @@
+import { BubblesProcess, BubblesProcessState } from './BubblesProcess.domain.js';
+
+const makeProcess = (layers: string[][], focusedBubbleId?: string): BubblesProcess => {
+  return BubblesProcess.fromJSON({ layers, focusedBubbleId });
+};
+
+describe('BubblesProcess - focus', () => {
+  it('focus() sets focusedId', () => {
+    const process = makeProcess([['A', 'B'], ['C']]);
+    const focused = process.focus('A');
+
+    expect(focused.focusedId).toBe('A');
+  });
+
+  it('focus() returns a new instance (immutable)', () => {
+    const process = makeProcess([['A', 'B']]);
+    const focused = process.focus('A');
+
+    expect(focused).not.toBe(process);
+    expect(process.focusedId).toBeUndefined();
+  });
+
+  it('focus() replaces previous focused id', () => {
+    const process = makeProcess([['A', 'B']]).focus('A');
+    const refocused = process.focus('B');
+
+    expect(refocused.focusedId).toBe('B');
+  });
+
+  it('blur() clears focusedId', () => {
+    const process = makeProcess([['A', 'B']]).focus('A');
+    const blurred = process.blur();
+
+    expect(blurred.focusedId).toBeUndefined();
+  });
+
+  it('blur() on already-unfocused process is safe', () => {
+    const process = makeProcess([['A']]);
+    expect(() => process.blur()).not.toThrow();
+    expect(process.blur().focusedId).toBeUndefined();
+  });
+
+  it('toJSON() persists focusedBubbleId', () => {
+    const process = makeProcess([['A', 'B']]).focus('B');
+    const json = process.toJSON();
+
+    expect(json.focusedBubbleId).toBe('B');
+  });
+
+  it('fromJSON() restores focusedBubbleId', () => {
+    const state: BubblesProcessState = { layers: [['A', 'B']], focusedBubbleId: 'A' };
+    const process = BubblesProcess.fromJSON(state);
+
+    expect(process.focusedId).toBe('A');
+  });
+
+  it('layer operations preserve focusedBubbleId', () => {
+    const process = makeProcess([['A', 'B'], ['C']]).focus('A');
+    const afterLayerDown = process.layerDown('B');
+
+    expect(afterLayerDown.focusedId).toBe('A');
+  });
+});

--- a/bublys-libs/bubbles-ui/src/lib/BubblesProcess.domain.ts
+++ b/bublys-libs/bubbles-ui/src/lib/BubblesProcess.domain.ts
@@ -6,6 +6,9 @@ export interface BubblesProcessState {
   // e.g.
   // [["A"], ["B", "C"], ["D"]]
   focusedBubbleId?: string;
+  // z-order stack: ordered from most recently focused to least recently focused.
+  // Used to compute z-indices that preserve focus history ordering.
+  zOrderStack?: string[];
 }
 
 
@@ -15,13 +18,21 @@ export class BubblesProcess {
   constructor(props: BubblesProcessState) {
     const layers = props.layers;
     //空のレイヤーがあったら削除する
-    this.state = { layers: layers.filter(layer => layer.length > 0), focusedBubbleId: props.focusedBubbleId };
+    this.state = {
+      layers: layers.filter(layer => layer.length > 0),
+      focusedBubbleId: props.focusedBubbleId,
+      zOrderStack: props.zOrderStack ?? [],
+    };
   }
 
   /** Create from JSON with ID layers */
   static fromJSON(state: BubblesProcessState): BubblesProcess {
     // layers is string[][]
-    return new BubblesProcess({ layers: state.layers.map(layer => [...layer]), focusedBubbleId: state.focusedBubbleId });
+    return new BubblesProcess({
+      layers: state.layers.map(layer => [...layer]),
+      focusedBubbleId: state.focusedBubbleId,
+      zOrderStack: state.zOrderStack ? [...state.zOrderStack] : [],
+    });
   }
 
   /** Expose layers of IDs */
@@ -39,9 +50,17 @@ export class BubblesProcess {
     return this.state.focusedBubbleId;
   }
 
+  get zOrderStack(): string[] {
+    return [...(this.state.zOrderStack ?? [])];
+  }
+
   /** Serialize to JSON */
   toJSON(): BubblesProcessState {
-    return { layers: this.layers.map(layer => [...layer]), focusedBubbleId: this.state.focusedBubbleId };
+    return {
+      layers: this.layers.map(layer => [...layer]),
+      focusedBubbleId: this.state.focusedBubbleId,
+      zOrderStack: [...(this.state.zOrderStack ?? [])],
+    };
   }
 
   /** Immer producer helper */
@@ -57,6 +76,9 @@ export class BubblesProcess {
       for (let i = draft.layers.length - 1; i >= 0; --i) {
         draft.layers[i] = draft.layers[i].filter(bId => bId !== id);
         if (draft.layers[i].length === 0) draft.layers.splice(i, 1);
+      }
+      if (draft.zOrderStack) {
+        draft.zOrderStack = draft.zOrderStack.filter(x => x !== id);
       }
     });
   }
@@ -111,7 +133,9 @@ export class BubblesProcess {
   }
 
   focus(id: string): BubblesProcess {
-    return new BubblesProcess({ ...this.state, focusedBubbleId: id });
+    const prevStack = this.state.zOrderStack ?? [];
+    const zOrderStack = [id, ...prevStack.filter(x => x !== id)];
+    return new BubblesProcess({ ...this.state, focusedBubbleId: id, zOrderStack });
   }
 
   blur(): BubblesProcess {

--- a/bublys-libs/bubbles-ui/src/lib/BubblesProcess.domain.ts
+++ b/bublys-libs/bubbles-ui/src/lib/BubblesProcess.domain.ts
@@ -5,6 +5,7 @@ export interface BubblesProcessState {
   layers: string[][];
   // e.g.
   // [["A"], ["B", "C"], ["D"]]
+  focusedBubbleId?: string;
 }
 
 
@@ -14,13 +15,13 @@ export class BubblesProcess {
   constructor(props: BubblesProcessState) {
     const layers = props.layers;
     //空のレイヤーがあったら削除する
-    this.state = { layers: layers.filter(layer => layer.length > 0) };
+    this.state = { layers: layers.filter(layer => layer.length > 0), focusedBubbleId: props.focusedBubbleId };
   }
 
   /** Create from JSON with ID layers */
   static fromJSON(state: BubblesProcessState): BubblesProcess {
     // layers is string[][]
-    return new BubblesProcess({ layers: state.layers.map(layer => [...layer]) });
+    return new BubblesProcess({ layers: state.layers.map(layer => [...layer]), focusedBubbleId: state.focusedBubbleId });
   }
 
   /** Expose layers of IDs */
@@ -34,9 +35,13 @@ export class BubblesProcess {
     return this.layers[0];
   }
 
+  get focusedId(): string | undefined {
+    return this.state.focusedBubbleId;
+  }
+
   /** Serialize to JSON */
   toJSON(): BubblesProcessState {
-    return { layers: this.layers.map(layer => [...layer]) };
+    return { layers: this.layers.map(layer => [...layer]), focusedBubbleId: this.state.focusedBubbleId };
   }
 
   /** Immer producer helper */
@@ -103,5 +108,13 @@ export class BubblesProcess {
         draft.layers[0].push(id);
       }
     });
+  }
+
+  focus(id: string): BubblesProcess {
+    return new BubblesProcess({ ...this.state, focusedBubbleId: id });
+  }
+
+  blur(): BubblesProcess {
+    return new BubblesProcess({ ...this.state, focusedBubbleId: undefined });
   }
 }

--- a/bublys-libs/bubbles-ui/src/lib/state/bubbles-focus.test.ts
+++ b/bublys-libs/bubbles-ui/src/lib/state/bubbles-focus.test.ts
@@ -1,0 +1,74 @@
+import bubblesReducer, {
+  focusBubble,
+  blurBubble,
+  makeSelectFocusedBubbleId,
+  ROOT_UNIVERSE_ID,
+  BubbleStateSlice,
+} from './bubbles-slice.js';
+
+const emptyState = (): BubbleStateSlice => ({
+  universes: {
+    [ROOT_UNIVERSE_ID]: {
+      bubbles: {},
+      process: { layers: [] },
+      bubbleRelations: [],
+      globalCoordinateSystem: { origin: { x: 0, y: 0 }, scale: 1 },
+      surfaceLeftTop: { x: 0, y: 0 },
+    },
+  },
+  renderCount: 0,
+  animatingBubbleIds: [],
+});
+
+describe('focusBubble action', () => {
+  it('sets focusedBubbleId in the process', () => {
+    const state = emptyState();
+    const next = bubblesReducer(state, focusBubble('bubble-1'));
+
+    expect(next.universes[ROOT_UNIVERSE_ID].process.focusedBubbleId).toBe('bubble-1');
+  });
+
+  it('replaces previous focusedBubbleId', () => {
+    const state = emptyState();
+    const first = bubblesReducer(state, focusBubble('bubble-1'));
+    const second = bubblesReducer(first, focusBubble('bubble-2'));
+
+    expect(second.universes[ROOT_UNIVERSE_ID].process.focusedBubbleId).toBe('bubble-2');
+  });
+});
+
+describe('blurBubble action', () => {
+  it('clears focusedBubbleId', () => {
+    const state = emptyState();
+    const focused = bubblesReducer(state, focusBubble('bubble-1'));
+    const blurred = bubblesReducer(focused, blurBubble());
+
+    expect(blurred.universes[ROOT_UNIVERSE_ID].process.focusedBubbleId).toBeUndefined();
+  });
+});
+
+describe('makeSelectFocusedBubbleId', () => {
+  const selector = makeSelectFocusedBubbleId(ROOT_UNIVERSE_ID);
+
+  it('returns undefined when no bubble is focused', () => {
+    const state = { bubbleState: emptyState() };
+    expect(selector(state)).toBeUndefined();
+  });
+
+  it('returns the focused bubble id after focusBubble', () => {
+    const raw = emptyState();
+    const next = bubblesReducer(raw, focusBubble('bubble-1'));
+    const state = { bubbleState: next };
+
+    expect(selector(state)).toBe('bubble-1');
+  });
+
+  it('returns undefined after blurBubble', () => {
+    const raw = emptyState();
+    const focused = bubblesReducer(raw, focusBubble('bubble-1'));
+    const blurred = bubblesReducer(focused, blurBubble());
+    const state = { bubbleState: blurred };
+
+    expect(selector(state)).toBeUndefined();
+  });
+});

--- a/bublys-libs/bubbles-ui/src/lib/state/bubbles-slice.ts
+++ b/bublys-libs/bubbles-ui/src/lib/state/bubbles-slice.ts
@@ -694,6 +694,11 @@ export const makeSelectFocusedBubbleId = memoizeByUniverse(
     universeOf(state, uid).process.focusedBubbleId,
 );
 
+export const makeSelectZOrderStack = memoizeByUniverse(
+  (uid) => (state: { bubbleState: BubbleStateSlice }): string[] =>
+    universeOf(state, uid).process.zOrderStack ?? [],
+);
+
 export const makeSelectBubbleLayers = memoizeByUniverse((uid) =>
   createSelector([makeSelectProcessJson(uid)], (processJson): string[][] =>
     BubblesProcess.fromJSON(processJson).layers,

--- a/bublys-libs/bubbles-ui/src/lib/state/bubbles-slice.ts
+++ b/bublys-libs/bubbles-ui/src/lib/state/bubbles-slice.ts
@@ -235,6 +235,22 @@ export const bubblesSlice = createSlice({
       state.animatingBubbleIds = [];
     },
 
+    focusBubble: {
+      reducer: (state, action: PayloadAction<string, string, UniverseMeta>) => {
+        const u = draftUniverse(state, action.meta.universeId);
+        u.process = BubblesProcess.fromJSON(u.process).focus(action.payload).toJSON();
+      },
+      prepare: prepStr,
+    },
+
+    blurBubble: {
+      reducer: (state, action: PayloadAction<null, string, UniverseMeta>) => {
+        const u = draftUniverse(state, action.meta.universeId);
+        u.process = BubblesProcess.fromJSON(u.process).blur().toJSON();
+      },
+      prepare: (universeId?: string) => ({ payload: null, meta: { universeId: universeId ?? ROOT_UNIVERSE_ID } }),
+    },
+
     // Entity-only actions
     addBubble: {
       reducer: (state, action: PayloadAction<BubbleJson, string, UniverseMeta>) => {
@@ -359,6 +375,8 @@ export const {
   replaceBubbleArrangement,
   finishBubbleAnimation,
   clearAllAnimations,
+  focusBubble,
+  blurBubble,
 } = bubblesSlice.actions;
 
 // ============================================================================
@@ -670,6 +688,11 @@ export const makeSelectBubbleLayerIndex = (bubbleId: string): LayerIndexSelector
 // universe スコープのセレクタファクトリ（ネストした universe のレンダリング用）
 // 上の root 用 selectX は make...(ROOT) と等価。
 // ============================================================================
+
+export const makeSelectFocusedBubbleId = memoizeByUniverse(
+  (uid) => (state: { bubbleState: BubbleStateSlice }): string | undefined =>
+    universeOf(state, uid).process.focusedBubbleId,
+);
 
 export const makeSelectBubbleLayers = memoizeByUniverse((uid) =>
   createSelector([makeSelectProcessJson(uid)], (processJson): string[][] =>

--- a/bublys-libs/bubbles-ui/src/lib/ui/BubbleView.tsx
+++ b/bublys-libs/bubbles-ui/src/lib/ui/BubbleView.tsx
@@ -6,7 +6,7 @@ import { useMyRectObserver } from "../hooks/useMyRect.js";
 import { useBubbleDrag } from "../hooks/useBubbleDrag.js";
 import { useBubbleResize } from "../hooks/useBubbleResize.js";
 import { useAppDispatch } from "@bublys-org/state-management";
-import { renderBubble, updateBubble, finishBubbleAnimation } from "../state/bubbles-slice.js";
+import { renderBubble, updateBubble, finishBubbleAnimation, focusBubble } from "../state/bubbles-slice.js";
 import { BubblesContext } from "../bubble-routing/BubbleRouting.js";
 import { useBubbleRefsOptional } from "../context/BubbleRefsContext.js";
 import { measureViewport } from "../utils/measure-viewport.js";
@@ -139,6 +139,7 @@ type BubbleProps = {
 
   layerIndex?: number;
   zIndex?: number;
+  isFocused?: boolean; // Reduxのフォーカス状態（クリックで最前面）
   contentBackground?: string; // コンテンツ背景色（デフォルト: white）
   hasLeftLink?: boolean; // 左側にリンクバブルが接続されているか（左角丸を無効化）
 
@@ -159,6 +160,7 @@ const BubbleViewInner: FC<BubbleProps> = ({
   children,
   layerIndex,
   zIndex,
+  isFocused = false,
   contentBackground = "white",
   hasLeftLink = false,
   position,
@@ -196,7 +198,7 @@ const BubbleViewInner: FC<BubbleProps> = ({
   const { onDragStart } = useBubbleDrag({ bubble, ref, layerIndex, vanishingPoint });
   const { onResizeStart } = useBubbleResize({ bubble, ref });
 
-  const [isFocused, setIsFocused] = useState(false);
+  const [isDragFocused, setIsDragFocused] = useState(false);
 
   const isMaximized = bubble.isMaximized;
 
@@ -235,14 +237,18 @@ const BubbleViewInner: FC<BubbleProps> = ({
     }
   };
 
+  const handleMouseDown = () => {
+    dispatch(focusBubble(bubble.id, universeId));
+  };
+
   const handleHeaderMouseDown = (e: React.MouseEvent<HTMLHeadingElement>) => {
-    setIsFocused(true); // ヘッダークリックで最前面に
+    setIsDragFocused(true);
     if (!onMove) return;
     onDragStart(e);
   };
 
   const handleMouseLeave = () => {
-    setIsFocused(false);
+    setIsDragFocused(false);
   };
 
   // DOM参照をContextに登録
@@ -262,11 +268,12 @@ const BubbleViewInner: FC<BubbleProps> = ({
       ref={ref}
       data-bubble-id={bubble.id}
       colorHue={bubble.colorHue}
-      zIndex={isFocused ? 100 : zIndex}
+      zIndex={isFocused ? 101 : isDragFocused ? 100 : zIndex}
       layerIndex={layerIndex}
       position={position}
       transformOrigin={vanishingPointRelative}
       onClick={onClick}
+      onMouseDown={handleMouseDown}
       onMouseLeave={handleMouseLeave}
       onTransitionEnd={() => {
         notifyRendered();

--- a/bublys-libs/bubbles-ui/src/lib/ui/BubbleView.tsx
+++ b/bublys-libs/bubbles-ui/src/lib/ui/BubbleView.tsx
@@ -481,7 +481,6 @@ const StyledBubble = styled.div<StyledBubbleProp>`
 
   max-height: 90vh;//FIXME:突貫対応
 
-  // 泡っぽいグラデーション背景
   background: linear-gradient(
     145deg,
     hsla(${({ colorHue }) => colorHue}, 60%, 70%, 0.6) 0%,
@@ -490,36 +489,15 @@ const StyledBubble = styled.div<StyledBubbleProp>`
     hsla(${({ colorHue }) => colorHue}, 55%, 65%, 0.55) 100%
   );
 
-  // 泡っぽいシャドウと光沢
   box-shadow:
     0 8px 32px hsla(${({ colorHue }) => colorHue}, 50%, 30%, 0.3),
-    0 2px 8px hsla(0, 0%, 0%, 0.1),
-    inset 0 2px 4px hsla(0, 0%, 100%, 0.4),
-    inset 0 -1px 2px hsla(${({ colorHue }) => colorHue}, 50%, 30%, 0.2);
+    0 2px 8px hsla(0, 0%, 0%, 0.1);
 
-  border: 1px solid hsla(0, 0%, 100%, 0.3);
+  border: 1px solid hsla(${({ colorHue }) => colorHue}, 60%, 65%, 0.45);
   border-radius: ${({ hasLeftLink }) => hasLeftLink ? '0 24px 24px 0' : '24px'};
 
   display: flex;
   flex-direction: column;
-
-  // ガラスのような光沢エフェクト（疑似要素）
-  &::before {
-    content: '';
-    position: absolute;
-    top: 0;
-    left: 0;
-    right: 0;
-    height: 50%;
-    background: linear-gradient(
-      to bottom,
-      hsla(0, 0%, 100%, 0.2) 0%,
-      hsla(0, 0%, 100%, 0.05) 50%,
-      transparent 100%
-    );
-    border-radius: ${({ hasLeftLink }) => hasLeftLink ? '0 24px 50% 50%' : '24px 24px 50% 50%'};
-    pointer-events: none;
-  }
 
   >.e-bubble-header {
     cursor: move;
@@ -532,8 +510,9 @@ const StyledBubble = styled.div<StyledBubbleProp>`
     z-index: 1;
     padding: 8px 12px;
     border-radius: 16px;
-    background: hsla(0, 0%, 10%, 0.55);
+    background: hsla(${({ colorHue }) => colorHue}, 45%, 20%, 0.7);
     backdrop-filter: blur(8px);
+    border: 1px solid hsla(${({ colorHue }) => colorHue}, 50%, 50%, 0.35);
     color: hsla(0, 0%, 100%, 0.9);
 
     opacity: ${({ headerVisible }) => headerVisible ? 1 : 0};
@@ -747,7 +726,7 @@ const StyledBubble = styled.div<StyledBubbleProp>`
       ${({ contentBackground }) => contentBackground || "hsla(0, 0%, 98%, 0.9)"} 100%
     );
     border-radius: 16px;
-    margin: 0 12px 12px;
+    margin: 12px;
     box-shadow:
       inset 0 2px 4px hsla(0, 0%, 0%, 0.05),
       0 1px 2px hsla(0, 0%, 100%, 0.5);

--- a/bublys-libs/bubbles-ui/src/lib/ui/BubbleView.tsx
+++ b/bublys-libs/bubbles-ui/src/lib/ui/BubbleView.tsx
@@ -1,4 +1,4 @@
-import { FC, useMemo, useState, useContext, useLayoutEffect, memo } from "react";
+import { FC, useMemo, useState, useContext, useLayoutEffect, useEffect, memo } from "react";
 import styled from "styled-components";
 import { Bubble } from "../Bubble.domain.js";
 import { Point2, Vec2, CoordinateSystem, SmartRect, Layer } from "@bublys-org/bubbles-ui-util";
@@ -6,7 +6,7 @@ import { useMyRectObserver } from "../hooks/useMyRect.js";
 import { useBubbleDrag } from "../hooks/useBubbleDrag.js";
 import { useBubbleResize } from "../hooks/useBubbleResize.js";
 import { useAppDispatch } from "@bublys-org/state-management";
-import { renderBubble, updateBubble, finishBubbleAnimation } from "../state/bubbles-slice.js";
+import { renderBubble, updateBubble, finishBubbleAnimation, focusBubble } from "../state/bubbles-slice.js";
 import { BubblesContext } from "../bubble-routing/BubbleRouting.js";
 import { useBubbleRefsOptional } from "../context/BubbleRefsContext.js";
 import { measureViewport } from "../utils/measure-viewport.js";
@@ -139,6 +139,7 @@ type BubbleProps = {
 
   layerIndex?: number;
   zIndex?: number;
+  isFocused?: boolean; // Reduxのフォーカス状態（クリックで最前面・ヘッダー表示）
   contentBackground?: string; // コンテンツ背景色（デフォルト: white）
   hasLeftLink?: boolean; // 左側にリンクバブルが接続されているか（左角丸を無効化）
 
@@ -154,11 +155,14 @@ type BubbleProps = {
   onDebugRects?: (rects: SmartRect[]) => void;
 };
 
+const HEADER_PROXIMITY_THRESHOLD = 40;
+
 const BubbleViewInner: FC<BubbleProps> = ({
   bubble,
   children,
   layerIndex,
   zIndex,
+  isFocused = false,
   contentBackground = "white",
   hasLeftLink = false,
   position,
@@ -196,8 +200,24 @@ const BubbleViewInner: FC<BubbleProps> = ({
   const { onDragStart } = useBubbleDrag({ bubble, ref, layerIndex, vanishingPoint });
   const { onResizeStart } = useBubbleResize({ bubble, ref });
 
-  const [isFocused, setIsFocused] = useState(false);
+  const [isDragFocused, setIsDragFocused] = useState(false);
+  const [isMouseNearTop, setIsMouseNearTop] = useState(false);
+  const [headerOffset, setHeaderOffset] = useState(0);
 
+  const isHeaderVisible = isFocused || isMouseNearTop;
+
+  const updateHeaderSafeZone = () => {
+    const bubbleRect = ref.current?.getBoundingClientRect();
+    if (!bubbleRect) return;
+    const headerEl = ref.current?.querySelector('.e-bubble-header');
+    const headerHeight = headerEl?.getBoundingClientRect().height ?? 48;
+    const headerTopInViewport = bubbleRect.top - 4 - headerHeight;
+    setHeaderOffset(Math.max(0, -headerTopInViewport));
+  };
+
+  useEffect(() => {
+    if (isFocused) updateHeaderSafeZone();
+  }, [isFocused]);
   const isMaximized = bubble.isMaximized;
 
   const handleToggleSize = (e: React.MouseEvent) => {
@@ -235,14 +255,26 @@ const BubbleViewInner: FC<BubbleProps> = ({
     }
   };
 
+  const handleMouseDown = () => {
+    dispatch(focusBubble(bubble.id, universeId));
+  };
+
+  const handleMouseMove = (e: React.MouseEvent<HTMLDivElement>) => {
+    const rect = ref.current?.getBoundingClientRect();
+    if (!rect) return;
+    setIsMouseNearTop(e.clientY - rect.top < HEADER_PROXIMITY_THRESHOLD);
+    updateHeaderSafeZone();
+  };
+
   const handleHeaderMouseDown = (e: React.MouseEvent<HTMLHeadingElement>) => {
-    setIsFocused(true); // ヘッダークリックで最前面に
+    setIsDragFocused(true);
     if (!onMove) return;
     onDragStart(e);
   };
 
   const handleMouseLeave = () => {
-    setIsFocused(false);
+    setIsDragFocused(false);
+    setIsMouseNearTop(false);
   };
 
   // DOM参照をContextに登録
@@ -262,11 +294,15 @@ const BubbleViewInner: FC<BubbleProps> = ({
       ref={ref}
       data-bubble-id={bubble.id}
       colorHue={bubble.colorHue}
-      zIndex={isFocused ? 100 : zIndex}
+      zIndex={isFocused ? 101 : isDragFocused ? 100 : zIndex}
       layerIndex={layerIndex}
       position={position}
       transformOrigin={vanishingPointRelative}
+      headerVisible={isHeaderVisible}
+      headerOffset={headerOffset}
       onClick={onClick}
+      onMouseDown={handleMouseDown}
+      onMouseMove={handleMouseMove}
       onMouseLeave={handleMouseLeave}
       onTransitionEnd={() => {
         notifyRendered();
@@ -384,6 +420,7 @@ export const BubbleView = memo(BubbleViewInner, (prevProps, nextProps) => {
   // BubbleContent内部は再レンダリングされない。
   if (prevProps.layerIndex !== nextProps.layerIndex ||
       prevProps.zIndex !== nextProps.zIndex ||
+      prevProps.isFocused !== nextProps.isFocused ||
       prevProps.contentBackground !== nextProps.contentBackground ||
       prevProps.hasLeftLink !== nextProps.hasLeftLink) {
     return false;
@@ -407,6 +444,8 @@ type StyledBubbleProp = React.HTMLAttributes<HTMLDivElement> & {
   contentBackground?: string; // コンテンツ背景色
   hasLeftLink?: boolean; // 左側にリンクバブルが接続されているか
   fillsContainer?: boolean; // 中身が自前のviewportを持つ窓型コンテンツ（スクロール抑止）
+  headerVisible?: boolean; // ヘッダー表示状態
+  headerOffset?: number; // バブル上端がビューポート外にかかる場合の押し下げ量(px)
 
   ref: React.RefObject<HTMLDivElement | null>;
 };
@@ -485,8 +524,23 @@ const StyledBubble = styled.div<StyledBubbleProp>`
   >.e-bubble-header {
     cursor: move;
     user-select: none;
-    position: relative;
-    padding: 12px 16px 8px;
+    position: absolute;
+    bottom: 100%;
+    margin-bottom: 4px;
+    left: 0;
+    right: 0;
+    z-index: 1;
+    padding: 8px 12px;
+    border-radius: 16px;
+    background: hsla(0, 0%, 10%, 0.55);
+    backdrop-filter: blur(8px);
+    color: hsla(0, 0%, 100%, 0.9);
+
+    opacity: ${({ headerVisible }) => headerVisible ? 1 : 0};
+    pointer-events: ${({ headerVisible }) => headerVisible ? 'auto' : 'none'};
+    transform: ${({ headerVisible, headerOffset = 0 }) =>
+      headerVisible ? `translateY(${headerOffset}px)` : `translateY(${headerOffset + 6}px)`};
+    transition: opacity 0.15s ease, transform 0.15s ease;
 
     .e-header-content {
       display: flex;
@@ -670,6 +724,13 @@ const StyledBubble = styled.div<StyledBubbleProp>`
       opacity: 1;
       visibility: visible;
     }
+  }
+
+  /* キーボードフォーカス時もヘッダーを表示（アクセシビリティ）。
+     transform は JS 管理（headerOffset 込み）なので上書きしない。 */
+  &:focus-within >.e-bubble-header {
+    opacity: 1;
+    pointer-events: auto;
   }
 
   >.e-bubble-content {

--- a/bublys-libs/bubbles-ui/src/lib/ui/BubbleView.tsx
+++ b/bublys-libs/bubbles-ui/src/lib/ui/BubbleView.tsx
@@ -1,4 +1,4 @@
-import { FC, useMemo, useContext, useLayoutEffect, memo } from "react";
+import { FC, useMemo, useContext, useLayoutEffect, useEffect, useState, memo } from "react";
 import styled from "styled-components";
 import { Bubble } from "../Bubble.domain.js";
 import { Point2, Vec2, CoordinateSystem, SmartRect, Layer } from "@bublys-org/bubbles-ui-util";
@@ -200,6 +200,24 @@ const BubbleViewInner: FC<BubbleProps> = ({
   const { onDragStart } = useBubbleDrag({ bubble, ref, layerIndex, vanishingPoint });
   const { onResizeStart } = useBubbleResize({ bubble, ref });
 
+  const [isMouseNearTop, setIsMouseNearTop] = useState(false);
+  const [headerOffset, setHeaderOffset] = useState(0);
+
+  const isHeaderVisible = isFocused || isMouseNearTop;
+
+  const updateHeaderSafeZone = () => {
+    const bubbleRect = ref.current?.getBoundingClientRect();
+    if (!bubbleRect) return;
+    const headerEl = ref.current?.querySelector('.e-bubble-header');
+    const headerHeight = headerEl?.getBoundingClientRect().height ?? 48;
+    const headerTopInViewport = bubbleRect.top - 4 - headerHeight;
+    setHeaderOffset(Math.max(0, -headerTopInViewport));
+  };
+
+  useEffect(() => {
+    if (isFocused) updateHeaderSafeZone();
+  }, [isFocused]);
+
   const isMaximized = bubble.isMaximized;
 
   const handleToggleSize = (e: React.MouseEvent) => {
@@ -241,6 +259,17 @@ const BubbleViewInner: FC<BubbleProps> = ({
     dispatch(focusBubble(bubble.id, universeId));
   };
 
+  const handleMouseMove = (e: React.MouseEvent<HTMLDivElement>) => {
+    const rect = ref.current?.getBoundingClientRect();
+    if (!rect) return;
+    setIsMouseNearTop(e.clientY - rect.top < HEADER_PROXIMITY_THRESHOLD);
+    updateHeaderSafeZone();
+  };
+
+  const handleMouseLeave = () => {
+    setIsMouseNearTop(false);
+  };
+
   const handleHeaderMouseDown = (e: React.MouseEvent<HTMLHeadingElement>) => {
     if (!onMove) return;
     onDragStart(e);
@@ -271,6 +300,8 @@ const BubbleViewInner: FC<BubbleProps> = ({
       headerOffset={headerOffset}
       onClick={onClick}
       onMouseDown={handleMouseDown}
+      onMouseMove={handleMouseMove}
+      onMouseLeave={handleMouseLeave}
       onTransitionEnd={() => {
         notifyRendered();
         dispatch(finishBubbleAnimation(bubble.id));

--- a/bublys-libs/bubbles-ui/src/lib/ui/BubbleView.tsx
+++ b/bublys-libs/bubbles-ui/src/lib/ui/BubbleView.tsx
@@ -261,7 +261,7 @@ const BubbleViewInner: FC<BubbleProps> = ({
       ref={ref}
       data-bubble-id={bubble.id}
       colorHue={bubble.colorHue}
-      zIndex={isFocused ? 101 : zIndex}
+      zIndex={zIndex}
       layerIndex={layerIndex}
       position={position}
       transformOrigin={vanishingPointRelative}
@@ -383,6 +383,7 @@ export const BubbleView = memo(BubbleViewInner, (prevProps, nextProps) => {
   // BubbleContent内部は再レンダリングされない。
   if (prevProps.layerIndex !== nextProps.layerIndex ||
       prevProps.zIndex !== nextProps.zIndex ||
+      prevProps.isFocused !== nextProps.isFocused ||
       prevProps.contentBackground !== nextProps.contentBackground ||
       prevProps.hasLeftLink !== nextProps.hasLeftLink) {
     return false;

--- a/bublys-libs/bubbles-ui/src/lib/ui/BubbleView.tsx
+++ b/bublys-libs/bubbles-ui/src/lib/ui/BubbleView.tsx
@@ -1,4 +1,4 @@
-import { FC, useMemo, useState, useContext, useLayoutEffect, memo } from "react";
+import { FC, useMemo, useContext, useLayoutEffect, memo } from "react";
 import styled from "styled-components";
 import { Bubble } from "../Bubble.domain.js";
 import { Point2, Vec2, CoordinateSystem, SmartRect, Layer } from "@bublys-org/bubbles-ui-util";
@@ -198,8 +198,6 @@ const BubbleViewInner: FC<BubbleProps> = ({
   const { onDragStart } = useBubbleDrag({ bubble, ref, layerIndex, vanishingPoint });
   const { onResizeStart } = useBubbleResize({ bubble, ref });
 
-  const [isDragFocused, setIsDragFocused] = useState(false);
-
   const isMaximized = bubble.isMaximized;
 
   const handleToggleSize = (e: React.MouseEvent) => {
@@ -242,13 +240,8 @@ const BubbleViewInner: FC<BubbleProps> = ({
   };
 
   const handleHeaderMouseDown = (e: React.MouseEvent<HTMLHeadingElement>) => {
-    setIsDragFocused(true);
     if (!onMove) return;
     onDragStart(e);
-  };
-
-  const handleMouseLeave = () => {
-    setIsDragFocused(false);
   };
 
   // DOM参照をContextに登録
@@ -268,13 +261,12 @@ const BubbleViewInner: FC<BubbleProps> = ({
       ref={ref}
       data-bubble-id={bubble.id}
       colorHue={bubble.colorHue}
-      zIndex={isFocused ? 101 : isDragFocused ? 100 : zIndex}
+      zIndex={isFocused ? 101 : zIndex}
       layerIndex={layerIndex}
       position={position}
       transformOrigin={vanishingPointRelative}
       onClick={onClick}
       onMouseDown={handleMouseDown}
-      onMouseLeave={handleMouseLeave}
       onTransitionEnd={() => {
         notifyRendered();
         dispatch(finishBubbleAnimation(bubble.id));

--- a/bublys-libs/bubbles-ui/src/lib/ui/BubbleView.tsx
+++ b/bublys-libs/bubbles-ui/src/lib/ui/BubbleView.tsx
@@ -504,7 +504,6 @@ const StyledBubble = styled.div<StyledBubbleProp>`
     user-select: none;
     position: absolute;
     bottom: 100%;
-    margin-bottom: 4px;
     left: 0;
     right: 0;
     z-index: 1;

--- a/bublys-libs/bubbles-ui/src/lib/ui/BubblesLayeredView.tsx
+++ b/bublys-libs/bubbles-ui/src/lib/ui/BubblesLayeredView.tsx
@@ -16,6 +16,7 @@ import {
   selectIsLayerAnimating,
   makeSelectBubbleByIdInUniverse,
   makeSelectFocusedBubbleId,
+  makeSelectZOrderStack,
   ROOT_UNIVERSE_ID,
 } from "../state/index.js";
 
@@ -68,9 +69,6 @@ const ConnectedBubbleView: FC<ConnectedBubbleViewProps> = memo(function Connecte
   // bubble.position は layer-local 座標。surface レイヤーで universe 座標へ写す
   const pos = surfaceLayer.place(bubble.position || { x: 0, y: 0 });
 
-  // フォーカスされたバブルは全レイヤーより前面に表示
-  const effectiveZIndex = isFocused ? 101 : zIndex;
-
   // fillsContainer な窓型バブル（universe / iframe / 等）は専用シェルで描く。
   // 透明な content と窓っぽいヘッダーで「親が透けて見える窓」として表現する。
   if (bubble.fillsContainer) {
@@ -79,7 +77,7 @@ const ConnectedBubbleView: FC<ConnectedBubbleViewProps> = memo(function Connecte
         bubble={bubble}
         position={pos}
         layerIndex={layerIndex}
-        zIndex={effectiveZIndex}
+        zIndex={zIndex}
         isFocused={isFocused}
         vanishingPoint={vanishingPoint}
         onClick={() => onBubbleClick?.(bubble.url)}
@@ -99,7 +97,7 @@ const ConnectedBubbleView: FC<ConnectedBubbleViewProps> = memo(function Connecte
       bubble={bubble}
       position={pos}
       layerIndex={layerIndex}
-      zIndex={effectiveZIndex}
+      zIndex={zIndex}
       isFocused={isFocused}
       vanishingPoint={vanishingPoint}
       contentBackground={bubble.contentBackground ?? "white"}
@@ -377,35 +375,60 @@ export const BubblesLayeredView: FC<BubblesLayeredViewProps> = ({
     [surfaceLeftTop, coordinateSystem],
   );
 
-  const renderedBubbles = bubbleLayers
-    .map((layer, layerIndex) =>
-      layer.map((bubbleId) => {
-        const zIndex = baseZIndex - layerIndex;
-        const hasLeftLink = openeeIds.has(bubbleId);
+  const focusedBubbleId = useAppSelector(makeSelectFocusedBubbleId(universeId));
+  const zOrderStack = useAppSelector(makeSelectZOrderStack(universeId));
 
-        return (
-          <ConnectedBubbleView
-            key={bubbleId}
-            universeId={universeId}
-            bubbleId={bubbleId}
-            layerIndex={layerIndex}
-            zIndex={zIndex}
-            vanishingPoint={undergroundVanishingPoint}
-            surfaceLayer={surfaceLayer}
-            hasLeftLink={hasLeftLink}
-            renderBubbleContent={renderBubbleContent}
-            onBubbleClick={onBubbleClick}
-            onBubbleClose={onBubbleClose}
-            onBubbleMove={onBubbleMove}
-            onBubbleResize={onBubbleResize}
-            onBubbleLayerDown={onBubbleLayerDown}
-            onBubbleLayerUp={onBubbleLayerUp}
-            onDebugRects={onDebugRects}
-          />
-        );
-      })
-    )
-    .flat();
+  // フォーカス履歴（zOrderStack）に基づいて DOM 順と z-index を決定する。
+  // スタック位置 0（最近フォーカス）が最も高い z-index を持ち、DOM でも最後に描画される。
+  // スタック外のバブルはレイヤーの自然な順序で描画・z-index が決まる。
+  const allBubbleEntries: Array<{ layerIndex: number; bubbleId: string }> = [];
+  bubbleLayers.forEach((layer, layerIndex) => {
+    layer.forEach((bubbleId) => {
+      allBubbleEntries.push({ layerIndex, bubbleId });
+    });
+  });
+
+  // スタック外のバブルを先に、スタック内のバブルを後に（スタック位置降順＝最近順に後ろへ）
+  const sortedBubbleEntries = [...allBubbleEntries].sort((a, b) => {
+    const ai = zOrderStack.indexOf(a.bubbleId);
+    const bi = zOrderStack.indexOf(b.bubbleId);
+    if (ai < 0 && bi < 0) return 0;
+    if (ai < 0) return -1;
+    if (bi < 0) return 1;
+    return bi - ai;
+  });
+
+  const renderedBubbles = sortedBubbleEntries.map(({ layerIndex, bubbleId }) => {
+    const naturalZIndex = baseZIndex - layerIndex;
+    const stackIndex = zOrderStack.indexOf(bubbleId);
+    // スタック内のバブルは baseZIndex+1 以上の z-index を付与（自然な層より必ず前面）。
+    // スタック位置 0（最近）が最大: baseZIndex + stackLength
+    const zIndex = stackIndex >= 0
+      ? baseZIndex + (zOrderStack.length - stackIndex)
+      : naturalZIndex;
+    const hasLeftLink = openeeIds.has(bubbleId);
+
+    return (
+      <ConnectedBubbleView
+        key={bubbleId}
+        universeId={universeId}
+        bubbleId={bubbleId}
+        layerIndex={layerIndex}
+        zIndex={zIndex}
+        vanishingPoint={undergroundVanishingPoint}
+        surfaceLayer={surfaceLayer}
+        hasLeftLink={hasLeftLink}
+        renderBubbleContent={renderBubbleContent}
+        onBubbleClick={onBubbleClick}
+        onBubbleClose={onBubbleClose}
+        onBubbleMove={onBubbleMove}
+        onBubbleResize={onBubbleResize}
+        onBubbleLayerDown={onBubbleLayerDown}
+        onBubbleLayerUp={onBubbleLayerUp}
+        onDebugRects={onDebugRects}
+      />
+    );
+  });
 
   const universeContextValue = useMemo(() => ({ universeId, universeRef }), [universeId]);
 

--- a/bublys-libs/bubbles-ui/src/lib/ui/BubblesLayeredView.tsx
+++ b/bublys-libs/bubbles-ui/src/lib/ui/BubblesLayeredView.tsx
@@ -69,9 +69,6 @@ const ConnectedBubbleView: FC<ConnectedBubbleViewProps> = memo(function Connecte
   // bubble.position は layer-local 座標。surface レイヤーで universe 座標へ写す
   const pos = surfaceLayer.place(bubble.position || { x: 0, y: 0 });
 
-  // フォーカスされたバブルは全レイヤーより前面に表示
-  const effectiveZIndex = isFocused ? 101 : zIndex;
-
   // fillsContainer な窓型バブル（universe / iframe / 等）は専用シェルで描く。
   // 透明な content と窓っぽいヘッダーで「親が透けて見える窓」として表現する。
   if (bubble.fillsContainer) {

--- a/bublys-libs/bubbles-ui/src/lib/ui/BubblesLayeredView.tsx
+++ b/bublys-libs/bubbles-ui/src/lib/ui/BubblesLayeredView.tsx
@@ -15,6 +15,7 @@ import {
   makeSelectUniverseDimensions,
   selectIsLayerAnimating,
   makeSelectBubbleByIdInUniverse,
+  makeSelectFocusedBubbleId,
   ROOT_UNIVERSE_ID,
 } from "../state/index.js";
 
@@ -58,11 +59,17 @@ const ConnectedBubbleView: FC<ConnectedBubbleViewProps> = memo(function Connecte
 })  {
   const selectBubble = useMemo(() => makeSelectBubbleByIdInUniverse(universeId, bubbleId), [universeId, bubbleId]);
   const bubble = useAppSelector(selectBubble);
+  const selectFocusedBubbleId = useMemo(() => makeSelectFocusedBubbleId(universeId), [universeId]);
+  const focusedBubbleId = useAppSelector(selectFocusedBubbleId);
+  const isFocused = focusedBubbleId === bubbleId;
 
   if (!bubble) return null;
 
   // bubble.position は layer-local 座標。surface レイヤーで universe 座標へ写す
   const pos = surfaceLayer.place(bubble.position || { x: 0, y: 0 });
+
+  // フォーカスされたバブルは全レイヤーより前面に表示
+  const effectiveZIndex = isFocused ? 101 : zIndex;
 
   // fillsContainer な窓型バブル（universe / iframe / 等）は専用シェルで描く。
   // 透明な content と窓っぽいヘッダーで「親が透けて見える窓」として表現する。
@@ -72,7 +79,8 @@ const ConnectedBubbleView: FC<ConnectedBubbleViewProps> = memo(function Connecte
         bubble={bubble}
         position={pos}
         layerIndex={layerIndex}
-        zIndex={zIndex}
+        zIndex={effectiveZIndex}
+        isFocused={isFocused}
         vanishingPoint={vanishingPoint}
         onClick={() => onBubbleClick?.(bubble.url)}
         onCloseClick={() => onBubbleClose?.(bubble)}
@@ -91,7 +99,8 @@ const ConnectedBubbleView: FC<ConnectedBubbleViewProps> = memo(function Connecte
       bubble={bubble}
       position={pos}
       layerIndex={layerIndex}
-      zIndex={zIndex}
+      zIndex={effectiveZIndex}
+      isFocused={isFocused}
       vanishingPoint={vanishingPoint}
       contentBackground={bubble.contentBackground ?? "white"}
       hasLeftLink={hasLeftLink}

--- a/bublys-libs/bubbles-ui/src/lib/ui/BubblesLayeredView.tsx
+++ b/bublys-libs/bubbles-ui/src/lib/ui/BubblesLayeredView.tsx
@@ -375,7 +375,6 @@ export const BubblesLayeredView: FC<BubblesLayeredViewProps> = ({
     [surfaceLeftTop, coordinateSystem],
   );
 
-  const focusedBubbleId = useAppSelector(makeSelectFocusedBubbleId(universeId));
   const zOrderStack = useAppSelector(makeSelectZOrderStack(universeId));
 
   // フォーカス履歴（zOrderStack）に基づいて DOM 順と z-index を決定する。

--- a/bublys-libs/bubbles-ui/src/lib/ui/UniverseBubbleView.tsx
+++ b/bublys-libs/bubbles-ui/src/lib/ui/UniverseBubbleView.tsx
@@ -1,5 +1,5 @@
 "use client";
-import { FC, useContext, useLayoutEffect, useMemo, useState, memo } from "react";
+import { FC, useContext, useLayoutEffect, useMemo, memo } from "react";
 import styled from "styled-components";
 import { Bubble } from "../Bubble.domain.js";
 import { Point2, Vec2, CoordinateSystem, SmartRect } from "@bublys-org/bubbles-ui-util";
@@ -107,8 +107,6 @@ const UniverseBubbleViewInner: FC<UniverseBubbleViewProps> = ({
   const { onDragStart } = useBubbleDrag({ bubble, ref, layerIndex, vanishingPoint });
   const { onResizeStart } = useBubbleResize({ bubble, ref });
 
-  const [isDragFocused, setIsDragFocused] = useState(false);
-
   const isMaximized = bubble.isMaximized;
 
   const handleToggleSize = (e: React.MouseEvent) => {
@@ -137,11 +135,8 @@ const UniverseBubbleViewInner: FC<UniverseBubbleViewProps> = ({
   };
 
   const handleHeaderMouseDown = (e: React.MouseEvent<HTMLElement>) => {
-    setIsDragFocused(true);
     onDragStart(e);
   };
-
-  const handleMouseLeave = () => setIsDragFocused(false);
 
   useLayoutEffect(() => {
     if (ref.current && bubbleRefs) {
@@ -160,13 +155,12 @@ const UniverseBubbleViewInner: FC<UniverseBubbleViewProps> = ({
       data-bubble-id={bubble.id}
       data-window-style="universe"
       $colorHue={bubble.colorHue}
-      $zIndex={isFocused ? 101 : isDragFocused ? 100 : zIndex}
+      $zIndex={isFocused ? 101 : zIndex}
       $layerIndex={layerIndex}
       $position={position}
       $transformOrigin={vanishingPointRelative}
       onClick={onClick}
       onMouseDown={handleMouseDown}
-      onMouseLeave={handleMouseLeave}
       onTransitionEnd={() => {
         notifyRendered();
         dispatch(finishBubbleAnimation(bubble.id));

--- a/bublys-libs/bubbles-ui/src/lib/ui/UniverseBubbleView.tsx
+++ b/bublys-libs/bubbles-ui/src/lib/ui/UniverseBubbleView.tsx
@@ -1,5 +1,5 @@
 "use client";
-import { FC, useContext, useLayoutEffect, useMemo, memo } from "react";
+import { FC, useContext, useLayoutEffect, useEffect, useState, useMemo, memo } from "react";
 import styled from "styled-components";
 import { Bubble } from "../Bubble.domain.js";
 import { Point2, Vec2, CoordinateSystem, SmartRect } from "@bublys-org/bubbles-ui-util";
@@ -109,6 +109,24 @@ const UniverseBubbleViewInner: FC<UniverseBubbleViewProps> = ({
   const { onDragStart } = useBubbleDrag({ bubble, ref, layerIndex, vanishingPoint });
   const { onResizeStart } = useBubbleResize({ bubble, ref });
 
+  const [isMouseNearTop, setIsMouseNearTop] = useState(false);
+  const [headerOffset, setHeaderOffset] = useState(0);
+
+  const isHeaderVisible = isFocused || isMouseNearTop;
+
+  const updateHeaderSafeZone = () => {
+    const bubbleRect = ref.current?.getBoundingClientRect();
+    if (!bubbleRect) return;
+    const headerEl = ref.current?.querySelector('.e-window-header');
+    const headerHeight = headerEl?.getBoundingClientRect().height ?? 40;
+    const headerTopInViewport = bubbleRect.top - headerHeight;
+    setHeaderOffset(Math.max(0, -headerTopInViewport));
+  };
+
+  useEffect(() => {
+    if (isFocused) updateHeaderSafeZone();
+  }, [isFocused]);
+
   const isMaximized = bubble.isMaximized;
 
   const handleToggleSize = (e: React.MouseEvent) => {
@@ -134,6 +152,17 @@ const UniverseBubbleViewInner: FC<UniverseBubbleViewProps> = ({
 
   const handleMouseDown = () => {
     dispatch(focusBubble(bubble.id, universeId));
+  };
+
+  const handleMouseMove = (e: React.MouseEvent<HTMLDivElement>) => {
+    const rect = ref.current?.getBoundingClientRect();
+    if (!rect) return;
+    setIsMouseNearTop(e.clientY - rect.top < HEADER_PROXIMITY_THRESHOLD);
+    updateHeaderSafeZone();
+  };
+
+  const handleMouseLeave = () => {
+    setIsMouseNearTop(false);
   };
 
   const handleHeaderMouseDown = (e: React.MouseEvent<HTMLElement>) => {
@@ -165,6 +194,8 @@ const UniverseBubbleViewInner: FC<UniverseBubbleViewProps> = ({
       $headerOffset={headerOffset}
       onClick={onClick}
       onMouseDown={handleMouseDown}
+      onMouseMove={handleMouseMove}
+      onMouseLeave={handleMouseLeave}
       onTransitionEnd={() => {
         notifyRendered();
         dispatch(finishBubbleAnimation(bubble.id));

--- a/bublys-libs/bubbles-ui/src/lib/ui/UniverseBubbleView.tsx
+++ b/bublys-libs/bubbles-ui/src/lib/ui/UniverseBubbleView.tsx
@@ -331,20 +331,15 @@ const StyledWindow = styled.div<StyledWindowProps>`
   display: flex;
   flex-direction: column;
 
-  /* シェル本体は backdropColor（バブリ宣言の「夜空」色）の半透明ガラスとして塗る。
-     色は color-mix で 55% に薄め、backdrop-filter blur と合わせて「色付きフロスト
-     ガラス越しに親 universe が透けて見える」感を出す。
-     指定が無ければ完全に透明で、外側 OS の夜空がそのまま透けて見える。 */
-  background: ${({ $backdropColor }) =>
+  background: ${({ $backdropColor, $colorHue }) =>
     $backdropColor
       ? `color-mix(in srgb, ${$backdropColor} 55%, transparent)`
-      : "transparent"};
-  border: none;
+      : `hsla(${$colorHue}, 50%, 60%, 0.45)`};
+  border: 1px solid hsla(${({ $colorHue }) => $colorHue}, 60%, 65%, 0.45);
   border-radius: 14px;
   box-shadow:
-    0 16px 48px hsla(0, 0%, 0%, 0.5),
-    0 2px 8px hsla(0, 0%, 0%, 0.25);
-  backdrop-filter: blur(10px) saturate(1.15);
+    0 8px 32px hsla(${({ $colorHue }) => $colorHue}, 50%, 30%, 0.3),
+    0 2px 8px hsla(0, 0%, 0%, 0.1);
 
   > .e-window-header {
     position: absolute;
@@ -360,8 +355,9 @@ const StyledWindow = styled.div<StyledWindowProps>`
     gap: 8px;
     padding: 6px 10px;
     border-radius: 14px;
-    background: hsla(0, 0%, 10%, 0.55);
+    background: hsla(${({ $colorHue }) => $colorHue}, 45%, 20%, 0.7);
     backdrop-filter: blur(8px);
+    border: 1px solid hsla(${({ $colorHue }) => $colorHue}, 50%, 50%, 0.35);
     color: hsla(0, 0%, 100%, 0.9);
     font-size: 0.8em;
 
@@ -439,6 +435,8 @@ const StyledWindow = styled.div<StyledWindowProps>`
     /* コンテンツ側（universe など）が自前で背景を塗るので、ここは透明。 */
     background: transparent;
     position: relative;
+    margin: 8px;
+    border-radius: 8px;
     /* StyledWindow 経由で none を継承しているが、奥が貫通可能であることを明示。 */
     pointer-events: none;
   }

--- a/bublys-libs/bubbles-ui/src/lib/ui/UniverseBubbleView.tsx
+++ b/bublys-libs/bubbles-ui/src/lib/ui/UniverseBubbleView.tsx
@@ -7,7 +7,7 @@ import { useMyRectObserver } from "../hooks/useMyRect.js";
 import { useBubbleDrag } from "../hooks/useBubbleDrag.js";
 import { useBubbleResize } from "../hooks/useBubbleResize.js";
 import { useAppDispatch } from "@bublys-org/state-management";
-import { renderBubble, updateBubble, finishBubbleAnimation } from "../state/bubbles-slice.js";
+import { renderBubble, updateBubble, finishBubbleAnimation, focusBubble } from "../state/bubbles-slice.js";
 import { BubblesContext } from "../bubble-routing/BubbleRouting.js";
 import { useBubbleRefsOptional } from "../context/BubbleRefsContext.js";
 import { measureViewport } from "../utils/measure-viewport.js";
@@ -58,6 +58,7 @@ type UniverseBubbleViewProps = {
   vanishingPoint?: Point2;
   layerIndex?: number;
   zIndex?: number;
+  isFocused?: boolean;
   /** ヘッダー右側に追加で挟みたいコントロール（例: ←→ 世界線ナビ） */
   headerExtras?: React.ReactNode;
   children?: React.ReactNode;
@@ -74,6 +75,7 @@ const UniverseBubbleViewInner: FC<UniverseBubbleViewProps> = ({
   children,
   layerIndex,
   zIndex,
+  isFocused = false,
   position = { x: 0, y: 0 },
   vanishingPoint = new Vec2({ x: 0, y: 0 }),
   headerExtras,
@@ -105,7 +107,7 @@ const UniverseBubbleViewInner: FC<UniverseBubbleViewProps> = ({
   const { onDragStart } = useBubbleDrag({ bubble, ref, layerIndex, vanishingPoint });
   const { onResizeStart } = useBubbleResize({ bubble, ref });
 
-  const [isFocused, setIsFocused] = useState(false);
+  const [isDragFocused, setIsDragFocused] = useState(false);
 
   const isMaximized = bubble.isMaximized;
 
@@ -130,12 +132,16 @@ const UniverseBubbleViewInner: FC<UniverseBubbleViewProps> = ({
     }
   };
 
+  const handleMouseDown = () => {
+    dispatch(focusBubble(bubble.id, universeId));
+  };
+
   const handleHeaderMouseDown = (e: React.MouseEvent<HTMLElement>) => {
-    setIsFocused(true);
+    setIsDragFocused(true);
     onDragStart(e);
   };
 
-  const handleMouseLeave = () => setIsFocused(false);
+  const handleMouseLeave = () => setIsDragFocused(false);
 
   useLayoutEffect(() => {
     if (ref.current && bubbleRefs) {
@@ -154,11 +160,12 @@ const UniverseBubbleViewInner: FC<UniverseBubbleViewProps> = ({
       data-bubble-id={bubble.id}
       data-window-style="universe"
       $colorHue={bubble.colorHue}
-      $zIndex={isFocused ? 100 : zIndex}
+      $zIndex={isFocused ? 101 : isDragFocused ? 100 : zIndex}
       $layerIndex={layerIndex}
       $position={position}
       $transformOrigin={vanishingPointRelative}
       onClick={onClick}
+      onMouseDown={handleMouseDown}
       onMouseLeave={handleMouseLeave}
       onTransitionEnd={() => {
         notifyRendered();

--- a/bublys-libs/bubbles-ui/src/lib/ui/UniverseBubbleView.tsx
+++ b/bublys-libs/bubbles-ui/src/lib/ui/UniverseBubbleView.tsx
@@ -435,10 +435,8 @@ const StyledWindow = styled.div<StyledWindowProps>`
     /* コンテンツ側（universe など）が自前で背景を塗るので、ここは透明。 */
     background: transparent;
     position: relative;
-    margin: 8px;
+    padding: 8px;
     border-radius: 8px;
-    /* StyledWindow 経由で none を継承しているが、奥が貫通可能であることを明示。 */
-    pointer-events: none;
   }
 
   /* 右下リサイズハンドル: StyledWindow が pointer-events: none なので explicit auto。 */

--- a/bublys-libs/bubbles-ui/src/lib/ui/UniverseBubbleView.tsx
+++ b/bublys-libs/bubbles-ui/src/lib/ui/UniverseBubbleView.tsx
@@ -155,7 +155,7 @@ const UniverseBubbleViewInner: FC<UniverseBubbleViewProps> = ({
       data-bubble-id={bubble.id}
       data-window-style="universe"
       $colorHue={bubble.colorHue}
-      $zIndex={isFocused ? 101 : zIndex}
+      $zIndex={zIndex}
       $layerIndex={layerIndex}
       $position={position}
       $transformOrigin={vanishingPointRelative}
@@ -249,6 +249,7 @@ export const UniverseBubbleView = memo(UniverseBubbleViewInner, (prev, next) => 
   }
   if (prev.position?.x !== next.position?.x || prev.position?.y !== next.position?.y) return false;
   if (prev.layerIndex !== next.layerIndex || prev.zIndex !== next.zIndex) return false;
+  if (prev.isFocused !== next.isFocused) return false;
   if (prev.headerExtras !== next.headerExtras) return false;
   return true;
 });

--- a/bublys-libs/bubbles-ui/src/lib/ui/UniverseBubbleView.tsx
+++ b/bublys-libs/bubbles-ui/src/lib/ui/UniverseBubbleView.tsx
@@ -1,5 +1,5 @@
 "use client";
-import { FC, useContext, useLayoutEffect, useMemo, useState, memo } from "react";
+import { FC, useContext, useLayoutEffect, useEffect, useMemo, useState, memo } from "react";
 import styled from "styled-components";
 import { Bubble } from "../Bubble.domain.js";
 import { Point2, Vec2, CoordinateSystem, SmartRect } from "@bublys-org/bubbles-ui-util";
@@ -7,7 +7,7 @@ import { useMyRectObserver } from "../hooks/useMyRect.js";
 import { useBubbleDrag } from "../hooks/useBubbleDrag.js";
 import { useBubbleResize } from "../hooks/useBubbleResize.js";
 import { useAppDispatch } from "@bublys-org/state-management";
-import { renderBubble, updateBubble, finishBubbleAnimation } from "../state/bubbles-slice.js";
+import { renderBubble, updateBubble, finishBubbleAnimation, focusBubble } from "../state/bubbles-slice.js";
 import { BubblesContext } from "../bubble-routing/BubbleRouting.js";
 import { useBubbleRefsOptional } from "../context/BubbleRefsContext.js";
 import { measureViewport } from "../utils/measure-viewport.js";
@@ -52,12 +52,15 @@ const LayerDownIcon: FC<{ size?: number }> = ({ size = 16 }) => (
   </svg>
 );
 
+const HEADER_PROXIMITY_THRESHOLD = 40;
+
 type UniverseBubbleViewProps = {
   bubble: Bubble;
   position?: Point2;
   vanishingPoint?: Point2;
   layerIndex?: number;
   zIndex?: number;
+  isFocused?: boolean;
   /** ヘッダー右側に追加で挟みたいコントロール（例: ←→ 世界線ナビ） */
   headerExtras?: React.ReactNode;
   children?: React.ReactNode;
@@ -74,6 +77,7 @@ const UniverseBubbleViewInner: FC<UniverseBubbleViewProps> = ({
   children,
   layerIndex,
   zIndex,
+  isFocused = false,
   position = { x: 0, y: 0 },
   vanishingPoint = new Vec2({ x: 0, y: 0 }),
   headerExtras,
@@ -105,8 +109,24 @@ const UniverseBubbleViewInner: FC<UniverseBubbleViewProps> = ({
   const { onDragStart } = useBubbleDrag({ bubble, ref, layerIndex, vanishingPoint });
   const { onResizeStart } = useBubbleResize({ bubble, ref });
 
-  const [isFocused, setIsFocused] = useState(false);
+  const [isDragFocused, setIsDragFocused] = useState(false);
+  const [isMouseNearTop, setIsMouseNearTop] = useState(false);
+  const [headerOffset, setHeaderOffset] = useState(0);
 
+  const isHeaderVisible = isFocused || isMouseNearTop;
+
+  const updateHeaderSafeZone = () => {
+    const bubbleRect = ref.current?.getBoundingClientRect();
+    if (!bubbleRect) return;
+    const headerEl = ref.current?.querySelector('.e-window-header');
+    const headerHeight = headerEl?.getBoundingClientRect().height ?? 40;
+    const headerTopInViewport = bubbleRect.top - 4 - headerHeight;
+    setHeaderOffset(Math.max(0, -headerTopInViewport));
+  };
+
+  useEffect(() => {
+    if (isFocused) updateHeaderSafeZone();
+  }, [isFocused]);
   const isMaximized = bubble.isMaximized;
 
   const handleToggleSize = (e: React.MouseEvent) => {
@@ -130,12 +150,26 @@ const UniverseBubbleViewInner: FC<UniverseBubbleViewProps> = ({
     }
   };
 
+  const handleMouseDown = () => {
+    dispatch(focusBubble(bubble.id, universeId));
+  };
+
+  const handleMouseMove = (e: React.MouseEvent<HTMLDivElement>) => {
+    const rect = ref.current?.getBoundingClientRect();
+    if (!rect) return;
+    setIsMouseNearTop(e.clientY - rect.top < HEADER_PROXIMITY_THRESHOLD);
+    updateHeaderSafeZone();
+  };
+
   const handleHeaderMouseDown = (e: React.MouseEvent<HTMLElement>) => {
-    setIsFocused(true);
+    setIsDragFocused(true);
     onDragStart(e);
   };
 
-  const handleMouseLeave = () => setIsFocused(false);
+  const handleMouseLeave = () => {
+    setIsDragFocused(false);
+    setIsMouseNearTop(false);
+  };
 
   useLayoutEffect(() => {
     if (ref.current && bubbleRefs) {
@@ -154,11 +188,15 @@ const UniverseBubbleViewInner: FC<UniverseBubbleViewProps> = ({
       data-bubble-id={bubble.id}
       data-window-style="universe"
       $colorHue={bubble.colorHue}
-      $zIndex={isFocused ? 100 : zIndex}
+      $zIndex={isFocused ? 101 : isDragFocused ? 100 : zIndex}
       $layerIndex={layerIndex}
       $position={position}
       $transformOrigin={vanishingPointRelative}
+      $headerVisible={isHeaderVisible}
+      $headerOffset={headerOffset}
       onClick={onClick}
+      onMouseDown={handleMouseDown}
+      onMouseMove={handleMouseMove}
       onMouseLeave={handleMouseLeave}
       onTransitionEnd={() => {
         notifyRendered();
@@ -248,6 +286,7 @@ export const UniverseBubbleView = memo(UniverseBubbleViewInner, (prev, next) => 
   }
   if (prev.position?.x !== next.position?.x || prev.position?.y !== next.position?.y) return false;
   if (prev.layerIndex !== next.layerIndex || prev.zIndex !== next.zIndex) return false;
+  if (prev.isFocused !== next.isFocused) return false;
   if (prev.headerExtras !== next.headerExtras) return false;
   return true;
 });
@@ -261,6 +300,8 @@ type StyledWindowProps = React.HTMLAttributes<HTMLDivElement> & {
   $width?: string;
   $height?: string;
   $backdropColor?: string;
+  $headerVisible?: boolean;
+  $headerOffset?: number;
   ref: React.RefObject<HTMLDivElement | null>;
 };
 
@@ -289,7 +330,6 @@ const StyledWindow = styled.div<StyledWindowProps>`
 
   display: flex;
   flex-direction: column;
-  overflow: hidden;
 
   /* シェル本体は backdropColor（バブリ宣言の「夜空」色）の半透明ガラスとして塗る。
      色は color-mix で 55% に薄め、backdrop-filter blur と合わせて「色付きフロスト
@@ -307,23 +347,29 @@ const StyledWindow = styled.div<StyledWindowProps>`
   backdrop-filter: blur(10px) saturate(1.15);
 
   > .e-window-header {
-    /* StyledWindow が none なので、操作を受けるヘッダーは explicit に auto。 */
-    pointer-events: auto;
+    position: absolute;
+    bottom: 100%;
+    margin-bottom: 4px;
+    left: 0;
+    right: 0;
+    z-index: 1;
     cursor: move;
     user-select: none;
-    flex: 0 0 auto;
     display: flex;
     align-items: center;
     gap: 8px;
     padding: 6px 10px;
-    background: linear-gradient(
-      180deg,
-      hsla(${({ $colorHue }) => $colorHue}, 35%, 30%, 0.65) 0%,
-      hsla(${({ $colorHue }) => $colorHue}, 30%, 22%, 0.45) 100%
-    );
-    border-bottom: 1px solid hsla(${({ $colorHue }) => $colorHue}, 40%, 70%, 0.25);
+    border-radius: 14px;
+    background: hsla(0, 0%, 10%, 0.55);
+    backdrop-filter: blur(8px);
     color: hsla(0, 0%, 100%, 0.9);
     font-size: 0.8em;
+
+    opacity: ${({ $headerVisible }) => $headerVisible ? 1 : 0};
+    pointer-events: ${({ $headerVisible }) => $headerVisible ? 'auto' : 'none'};
+    transform: ${({ $headerVisible, $headerOffset = 0 }) =>
+      $headerVisible ? `translateY(${$headerOffset}px)` : `translateY(${$headerOffset + 6}px)`};
+    transition: opacity 0.15s ease, transform 0.15s ease;
 
     .e-window-buttons-left,
     .e-window-buttons-right {
@@ -377,6 +423,13 @@ const StyledWindow = styled.div<StyledWindowProps>`
         background: hsla(270, 60%, 60%, 0.45);
       }
     }
+  }
+
+  /* キーボードフォーカス時もヘッダーを表示（アクセシビリティ）。
+     transform は JS 管理（$headerOffset 込み）なので上書きしない。 */
+  &:focus-within > .e-window-header {
+    opacity: 1;
+    pointer-events: auto;
   }
 
   > .e-window-content {

--- a/bublys-libs/bubbles-ui/src/lib/ui/UniverseBubbleView.tsx
+++ b/bublys-libs/bubbles-ui/src/lib/ui/UniverseBubbleView.tsx
@@ -256,6 +256,8 @@ const UniverseBubbleViewInner: FC<UniverseBubbleViewProps> = ({
         </div>
       </header>
 
+      <div className="e-header-hover-trigger" />
+
       <main className="e-window-content">{children}</main>
 
       {/* 右下リサイズハンドル — ユーザーがサイズを決められる状態への入り口 */}
@@ -434,6 +436,15 @@ const StyledWindow = styled.div<StyledWindowProps>`
     position: relative;
     padding: 8px;
     border-radius: 8px;
+  }
+
+  > .e-header-hover-trigger {
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    height: ${HEADER_PROXIMITY_THRESHOLD}px;
+    pointer-events: auto;
   }
 
   /* 右下リサイズハンドル: StyledWindow が pointer-events: none なので explicit auto。 */

--- a/bublys-libs/bubbles-ui/src/lib/ui/UniverseBubbleView.tsx
+++ b/bublys-libs/bubbles-ui/src/lib/ui/UniverseBubbleView.tsx
@@ -120,13 +120,14 @@ const UniverseBubbleViewInner: FC<UniverseBubbleViewProps> = ({
     if (!bubbleRect) return;
     const headerEl = ref.current?.querySelector('.e-window-header');
     const headerHeight = headerEl?.getBoundingClientRect().height ?? 40;
-    const headerTopInViewport = bubbleRect.top - 4 - headerHeight;
+    const headerTopInViewport = bubbleRect.top - headerHeight;
     setHeaderOffset(Math.max(0, -headerTopInViewport));
   };
 
   useEffect(() => {
     if (isFocused) updateHeaderSafeZone();
   }, [isFocused]);
+  
   const isMaximized = bubble.isMaximized;
 
   const handleToggleSize = (e: React.MouseEvent) => {
@@ -344,7 +345,6 @@ const StyledWindow = styled.div<StyledWindowProps>`
   > .e-window-header {
     position: absolute;
     bottom: 100%;
-    margin-bottom: 4px;
     left: 0;
     right: 0;
     z-index: 1;


### PR DESCRIPTION
## Summary

- **フォーカス管理 (issue #58 の基盤を統合)**: `zOrderStack` によるフォーカス履歴スタックで z-ordering を管理。最近フォーカスしたバブルが最前面に来て、それ以外の前後関係は変わらない
- **ヘッダーデフォルト非表示**: フォーカス時・マウスがバブル上端 40px 以内に近づいたとき・`:focus-within` でヘッダーを表示（opacity + pointer-events で切り替え）
- **ヘッダーをバブル外側上部に配置**: `bottom: 100%` でコンテンツと重ならないように変更、暗い半透明ピル形状 + `backdrop-filter: blur` でデザイン統一
- **ビューポートクランプ**: バブルが画面上端付近にある場合、ヘッダーの実測高さを元に `translateY` で押し下げ、常に操作可能に保つ
- **UniverseBubbleView のホバー修正**: `StyledWindow` が `pointer-events: none` のため上部でイベントが取れなかった問題を、透明なホバートリガーストリップ（上端 40px, `pointer-events: auto`）で解決
- `BubbleView` / `UniverseBubbleView` 両方に同一の挙動を適用

## Test plan

- [x] バブルをクリック → ヘッダーが上部に表示されることを確認
- [x] 複数バブルをクリック → 最後にクリックしたバブルが最前面、それ以外の前後関係は変わらないことを確認
- [x] バブル上端 40px 以内にマウスを移動 → ヘッダーが表示されることを確認
- [x] バブルを画面最上部にドラッグ → ヘッダーが画面外に消えず操作できることを確認
- [x] `UniverseBubbleView`（universe 型）でも上端ホバーでヘッダーが表示されることを確認
- [ ] 別のバブルをクリック → 前のバブルのフォーカスが外れてヘッダーが消えることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)