### PR TITLE
feat(bubble-ui): ヘッダーをデフォルト非表示にし、マウス接近・フォーカスで表示 (close #59)

### DIFF
--- a/bublys-libs/bubbles-ui/src/lib/BubblesProcess.domain.test.ts
+++ b/bublys-libs/bubbles-ui/src/lib/BubblesProcess.domain.test.ts
@@ -48,3 +48,26 @@ describe('BubblesProcess - focus', () => {
     expect(afterLayerDown.focusedId).toBe('A');
   });
 });
+
+describe('BubblesProcess - popChild', () => {
+  it('popChild() moves bubble to surface layer', () => {
+    const process = makeProcess([['A', 'B'], ['C']]);
+    const popped = process.popChild('C');
+
+    expect(popped.layers[0]).toContain('C');
+  });
+
+  it('popChild() sets focusedId to the popped bubble', () => {
+    const process = makeProcess([['A', 'B'], ['C']]);
+    const popped = process.popChild('C');
+
+    expect(popped.focusedId).toBe('C');
+  });
+
+  it('popChild() replaces previous focusedId', () => {
+    const process = makeProcess([['A', 'B'], ['C']]).focus('A');
+    const popped = process.popChild('C');
+
+    expect(popped.focusedId).toBe('C');
+  });
+});

--- a/bublys-libs/bubbles-ui/src/lib/BubblesProcess.domain.test.ts
+++ b/bublys-libs/bubbles-ui/src/lib/BubblesProcess.domain.test.ts
@@ -1,0 +1,50 @@
+import { BubblesProcess, BubblesProcessState } from './BubblesProcess.domain.js';
+
+const makeProcess = (layers: string[][], focusedBubbleId?: string): BubblesProcess => {
+  return BubblesProcess.fromJSON({ layers, focusedBubbleId });
+};
+
+describe('BubblesProcess - focus', () => {
+  it('focus() sets focusedId', () => {
+    const process = makeProcess([['A', 'B'], ['C']]);
+    const focused = process.focus('A');
+
+    expect(focused.focusedId).toBe('A');
+  });
+
+  it('focus() returns a new instance (immutable)', () => {
+    const process = makeProcess([['A', 'B']]);
+    const focused = process.focus('A');
+
+    expect(focused).not.toBe(process);
+    expect(process.focusedId).toBeUndefined();
+  });
+
+  it('focus() replaces previous focused id', () => {
+    const process = makeProcess([['A', 'B']]).focus('A');
+    const refocused = process.focus('B');
+
+    expect(refocused.focusedId).toBe('B');
+  });
+
+  it('toJSON() persists focusedBubbleId', () => {
+    const process = makeProcess([['A', 'B']]).focus('B');
+    const json = process.toJSON();
+
+    expect(json.focusedBubbleId).toBe('B');
+  });
+
+  it('fromJSON() restores focusedBubbleId', () => {
+    const state: BubblesProcessState = { layers: [['A', 'B']], focusedBubbleId: 'A' };
+    const process = BubblesProcess.fromJSON(state);
+
+    expect(process.focusedId).toBe('A');
+  });
+
+  it('layer operations preserve focusedBubbleId', () => {
+    const process = makeProcess([['A', 'B'], ['C']]).focus('A');
+    const afterLayerDown = process.layerDown('B');
+
+    expect(afterLayerDown.focusedId).toBe('A');
+  });
+});

--- a/bublys-libs/bubbles-ui/src/lib/BubblesProcess.domain.ts
+++ b/bublys-libs/bubbles-ui/src/lib/BubblesProcess.domain.ts
@@ -5,6 +5,7 @@ export interface BubblesProcessState {
   layers: string[][];
   // e.g.
   // [["A"], ["B", "C"], ["D"]]
+  focusedBubbleId?: string;
 }
 
 
@@ -14,13 +15,19 @@ export class BubblesProcess {
   constructor(props: BubblesProcessState) {
     const layers = props.layers;
     //空のレイヤーがあったら削除する
-    this.state = { layers: layers.filter(layer => layer.length > 0) };
+    this.state = {
+      layers: layers.filter(layer => layer.length > 0),
+      focusedBubbleId: props.focusedBubbleId,
+    };
   }
 
   /** Create from JSON with ID layers */
   static fromJSON(state: BubblesProcessState): BubblesProcess {
     // layers is string[][]
-    return new BubblesProcess({ layers: state.layers.map(layer => [...layer]) });
+    return new BubblesProcess({
+      layers: state.layers.map(layer => [...layer]),
+      focusedBubbleId: state.focusedBubbleId,
+    });
   }
 
   /** Expose layers of IDs */
@@ -34,9 +41,16 @@ export class BubblesProcess {
     return this.layers[0];
   }
 
+  get focusedId(): string | undefined {
+    return this.state.focusedBubbleId;
+  }
+
   /** Serialize to JSON */
   toJSON(): BubblesProcessState {
-    return { layers: this.layers.map(layer => [...layer]) };
+    return {
+      layers: this.layers.map(layer => [...layer]),
+      focusedBubbleId: this.state.focusedBubbleId,
+    };
   }
 
   /** Immer producer helper */
@@ -103,5 +117,9 @@ export class BubblesProcess {
         draft.layers[0].push(id);
       }
     });
+  }
+
+  focus(id: string): BubblesProcess {
+    return new BubblesProcess({ ...this.state, focusedBubbleId: id });
   }
 }

--- a/bublys-libs/bubbles-ui/src/lib/BubblesProcess.domain.ts
+++ b/bublys-libs/bubbles-ui/src/lib/BubblesProcess.domain.ts
@@ -106,6 +106,7 @@ export class BubblesProcess {
   popChild(id: string): BubblesProcess {
     return this.apply(draft => {
       draft.layers.unshift([id]);
+      draft.focusedBubbleId = id;
     });
   }
 
@@ -116,6 +117,7 @@ export class BubblesProcess {
       } else {
         draft.layers[0].push(id);
       }
+      draft.focusedBubbleId = id;
     });
   }
 

--- a/bublys-libs/bubbles-ui/src/lib/state/bubbles-focus.test.ts
+++ b/bublys-libs/bubbles-ui/src/lib/state/bubbles-focus.test.ts
@@ -1,0 +1,54 @@
+import bubblesReducer, {
+  focusBubble,
+  makeSelectFocusedBubbleId,
+  ROOT_UNIVERSE_ID,
+  BubbleStateSlice,
+} from './bubbles-slice.js';
+
+const emptyState = (): BubbleStateSlice => ({
+  universes: {
+    [ROOT_UNIVERSE_ID]: {
+      bubbles: {},
+      process: { layers: [] },
+      bubbleRelations: [],
+      globalCoordinateSystem: { origin: { x: 0, y: 0 }, scale: 1 },
+      surfaceLeftTop: { x: 0, y: 0 },
+    },
+  },
+  renderCount: 0,
+  animatingBubbleIds: [],
+});
+
+describe('focusBubble action', () => {
+  it('sets focusedBubbleId in the process', () => {
+    const state = emptyState();
+    const next = bubblesReducer(state, focusBubble('bubble-1'));
+
+    expect(next.universes[ROOT_UNIVERSE_ID].process.focusedBubbleId).toBe('bubble-1');
+  });
+
+  it('replaces previous focusedBubbleId', () => {
+    const state = emptyState();
+    const first = bubblesReducer(state, focusBubble('bubble-1'));
+    const second = bubblesReducer(first, focusBubble('bubble-2'));
+
+    expect(second.universes[ROOT_UNIVERSE_ID].process.focusedBubbleId).toBe('bubble-2');
+  });
+});
+
+describe('makeSelectFocusedBubbleId', () => {
+  const selector = makeSelectFocusedBubbleId(ROOT_UNIVERSE_ID);
+
+  it('returns undefined when no bubble is focused', () => {
+    const state = { bubbleState: emptyState() };
+    expect(selector(state)).toBeUndefined();
+  });
+
+  it('returns the focused bubble id after focusBubble', () => {
+    const raw = emptyState();
+    const next = bubblesReducer(raw, focusBubble('bubble-1'));
+    const state = { bubbleState: next };
+
+    expect(selector(state)).toBe('bubble-1');
+  });
+});

--- a/bublys-libs/bubbles-ui/src/lib/state/bubbles-listener.ts
+++ b/bublys-libs/bubbles-ui/src/lib/state/bubbles-listener.ts
@@ -219,7 +219,6 @@ bubblesListener.startListening({
 
       const moved = poppingBubble.moveTo(relativePoint);
 
-      // バブルを更新
       listenerApi.dispatch(updateBubble(moved.toJSON(), universeId));
       return;
     }

--- a/bublys-libs/bubbles-ui/src/lib/state/bubbles-slice.ts
+++ b/bublys-libs/bubbles-ui/src/lib/state/bubbles-slice.ts
@@ -235,6 +235,14 @@ export const bubblesSlice = createSlice({
       state.animatingBubbleIds = [];
     },
 
+    focusBubble: {
+      reducer: (state, action: PayloadAction<string, string, UniverseMeta>) => {
+        const u = draftUniverse(state, action.meta.universeId);
+        u.process = BubblesProcess.fromJSON(u.process).focus(action.payload).toJSON();
+      },
+      prepare: prepStr,
+    },
+
     // Entity-only actions
     addBubble: {
       reducer: (state, action: PayloadAction<BubbleJson, string, UniverseMeta>) => {
@@ -359,6 +367,7 @@ export const {
   replaceBubbleArrangement,
   finishBubbleAnimation,
   clearAllAnimations,
+  focusBubble,
 } = bubblesSlice.actions;
 
 // ============================================================================
@@ -670,6 +679,11 @@ export const makeSelectBubbleLayerIndex = (bubbleId: string): LayerIndexSelector
 // universe スコープのセレクタファクトリ（ネストした universe のレンダリング用）
 // 上の root 用 selectX は make...(ROOT) と等価。
 // ============================================================================
+
+export const makeSelectFocusedBubbleId = memoizeByUniverse(
+  (uid) => (state: { bubbleState: BubbleStateSlice }): string | undefined =>
+    universeOf(state, uid).process.focusedBubbleId,
+);
 
 export const makeSelectBubbleLayers = memoizeByUniverse((uid) =>
   createSelector([makeSelectProcessJson(uid)], (processJson): string[][] =>

--- a/bublys-libs/bubbles-ui/src/lib/ui/BubbleView.tsx
+++ b/bublys-libs/bubbles-ui/src/lib/ui/BubbleView.tsx
@@ -1,4 +1,4 @@
-import { FC, useMemo, useState, useEffect, useContext, useLayoutEffect, memo } from "react";
+import { FC, useMemo, useState, useContext, useLayoutEffect, memo } from "react";
 import styled from "styled-components";
 import { Bubble } from "../Bubble.domain.js";
 import { Point2, Vec2, CoordinateSystem, SmartRect, Layer } from "@bublys-org/bubbles-ui-util";
@@ -214,7 +214,7 @@ const BubbleViewInner: FC<BubbleProps> = ({
     setHeaderOffset(Math.max(0, -headerTopInViewport));
   };
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     if (isFocused) updateHeaderSafeZone();
   }, [isFocused]);
 
@@ -255,7 +255,9 @@ const BubbleViewInner: FC<BubbleProps> = ({
     }
   };
 
-  const handleMouseDown = () => {
+  const handleMouseDown = (e: React.MouseEvent<HTMLDivElement>) => {
+    // UrledPlace内のクリックはpopChildがフォーカスを担うためスキップ
+    if ((e.target as Element).closest('[data-url]')) return;
     dispatch(focusBubble(bubble.id, universeId));
   };
 
@@ -521,8 +523,10 @@ const StyledBubble = styled.div<StyledBubbleProp>`
   }
 
   /* キーボードフォーカス時もヘッダーを表示（アクセシビリティ）。
+     :focus-within ではなく :has(:focus-visible) を使うことで、
+     マウスクリックによる一時的なフォーカスではトリガーされない。
      transform は JS 管理（headerOffset 込み）なので上書きしない。 */
-  &:focus-within >.e-bubble-header {
+  &:has(:focus-visible) >.e-bubble-header {
     opacity: 1;
     pointer-events: auto;
   }

--- a/bublys-libs/bubbles-ui/src/lib/ui/BubbleView.tsx
+++ b/bublys-libs/bubbles-ui/src/lib/ui/BubbleView.tsx
@@ -1,4 +1,4 @@
-import { FC, useMemo, useState, useContext, useLayoutEffect, memo } from "react";
+import { FC, useMemo, useState, useEffect, useContext, useLayoutEffect, memo } from "react";
 import styled from "styled-components";
 import { Bubble } from "../Bubble.domain.js";
 import { Point2, Vec2, CoordinateSystem, SmartRect, Layer } from "@bublys-org/bubbles-ui-util";
@@ -6,7 +6,7 @@ import { useMyRectObserver } from "../hooks/useMyRect.js";
 import { useBubbleDrag } from "../hooks/useBubbleDrag.js";
 import { useBubbleResize } from "../hooks/useBubbleResize.js";
 import { useAppDispatch } from "@bublys-org/state-management";
-import { renderBubble, updateBubble, finishBubbleAnimation } from "../state/bubbles-slice.js";
+import { renderBubble, updateBubble, finishBubbleAnimation, focusBubble } from "../state/bubbles-slice.js";
 import { BubblesContext } from "../bubble-routing/BubbleRouting.js";
 import { useBubbleRefsOptional } from "../context/BubbleRefsContext.js";
 import { measureViewport } from "../utils/measure-viewport.js";
@@ -131,6 +131,8 @@ const StyledUrl: FC<{ url: string }> = memo(({ url }) => {
   );
 });
 
+const HEADER_PROXIMITY_THRESHOLD = 40;
+
 type BubbleProps = {
   bubble: Bubble;
 
@@ -139,6 +141,7 @@ type BubbleProps = {
 
   layerIndex?: number;
   zIndex?: number;
+  isFocused?: boolean;
   contentBackground?: string; // コンテンツ背景色（デフォルト: white）
   hasLeftLink?: boolean; // 左側にリンクバブルが接続されているか（左角丸を無効化）
 
@@ -159,6 +162,7 @@ const BubbleViewInner: FC<BubbleProps> = ({
   children,
   layerIndex,
   zIndex,
+  isFocused = false,
   contentBackground = "white",
   hasLeftLink = false,
   position,
@@ -196,7 +200,23 @@ const BubbleViewInner: FC<BubbleProps> = ({
   const { onDragStart } = useBubbleDrag({ bubble, ref, layerIndex, vanishingPoint });
   const { onResizeStart } = useBubbleResize({ bubble, ref });
 
-  const [isFocused, setIsFocused] = useState(false);
+  const [isMouseNearTop, setIsMouseNearTop] = useState(false);
+  const [headerOffset, setHeaderOffset] = useState(0);
+
+  const isHeaderVisible = isFocused || isMouseNearTop;
+
+  const updateHeaderSafeZone = () => {
+    const bubbleRect = ref.current?.getBoundingClientRect();
+    if (!bubbleRect) return;
+    const headerEl = ref.current?.querySelector('.e-bubble-header');
+    const headerHeight = headerEl?.getBoundingClientRect().height ?? 48;
+    const headerTopInViewport = bubbleRect.top - headerHeight;
+    setHeaderOffset(Math.max(0, -headerTopInViewport));
+  };
+
+  useEffect(() => {
+    if (isFocused) updateHeaderSafeZone();
+  }, [isFocused]);
 
   const isMaximized = bubble.isMaximized;
 
@@ -235,14 +255,25 @@ const BubbleViewInner: FC<BubbleProps> = ({
     }
   };
 
-  const handleHeaderMouseDown = (e: React.MouseEvent<HTMLHeadingElement>) => {
-    setIsFocused(true); // ヘッダークリックで最前面に
-    if (!onMove) return;
-    onDragStart(e);
+  const handleMouseDown = () => {
+    dispatch(focusBubble(bubble.id, universeId));
+  };
+
+  const handleMouseMove = (e: React.MouseEvent<HTMLDivElement>) => {
+    const rect = ref.current?.getBoundingClientRect();
+    if (!rect) return;
+    setIsMouseNearTop(e.clientY - rect.top < HEADER_PROXIMITY_THRESHOLD);
+    updateHeaderSafeZone();
   };
 
   const handleMouseLeave = () => {
-    setIsFocused(false);
+    setIsMouseNearTop(false);
+  };
+
+  const handleHeaderMouseDown = (e: React.MouseEvent<HTMLHeadingElement>) => {
+    dispatch(focusBubble(bubble.id, universeId));
+    if (!onMove) return;
+    onDragStart(e);
   };
 
   // DOM参照をContextに登録
@@ -266,7 +297,11 @@ const BubbleViewInner: FC<BubbleProps> = ({
       layerIndex={layerIndex}
       position={position}
       transformOrigin={vanishingPointRelative}
+      headerVisible={isHeaderVisible}
+      headerOffset={headerOffset}
       onClick={onClick}
+      onMouseDown={handleMouseDown}
+      onMouseMove={handleMouseMove}
       onMouseLeave={handleMouseLeave}
       onTransitionEnd={() => {
         notifyRendered();
@@ -384,6 +419,7 @@ export const BubbleView = memo(BubbleViewInner, (prevProps, nextProps) => {
   // BubbleContent内部は再レンダリングされない。
   if (prevProps.layerIndex !== nextProps.layerIndex ||
       prevProps.zIndex !== nextProps.zIndex ||
+      prevProps.isFocused !== nextProps.isFocused ||
       prevProps.contentBackground !== nextProps.contentBackground ||
       prevProps.hasLeftLink !== nextProps.hasLeftLink) {
     return false;
@@ -407,6 +443,8 @@ type StyledBubbleProp = React.HTMLAttributes<HTMLDivElement> & {
   contentBackground?: string; // コンテンツ背景色
   hasLeftLink?: boolean; // 左側にリンクバブルが接続されているか
   fillsContainer?: boolean; // 中身が自前のviewportを持つ窓型コンテンツ（スクロール抑止）
+  headerVisible?: boolean;
+  headerOffset?: number; // バブル上端がビューポート外にかかる場合のヘッダー押し下げ量(px)
 
   ref: React.RefObject<HTMLDivElement | null>;
 };
@@ -482,11 +520,33 @@ const StyledBubble = styled.div<StyledBubbleProp>`
     pointer-events: none;
   }
 
+  /* キーボードフォーカス時もヘッダーを表示（アクセシビリティ）。
+     transform は JS 管理（headerOffset 込み）なので上書きしない。 */
+  &:focus-within >.e-bubble-header {
+    opacity: 1;
+    pointer-events: auto;
+  }
+
   >.e-bubble-header {
     cursor: move;
     user-select: none;
-    position: relative;
-    padding: 12px 16px 8px;
+    position: absolute;
+    bottom: 100%;
+    left: 0;
+    right: 0;
+    z-index: 1;
+    padding: 8px 12px;
+    border-radius: 16px;
+    background: hsla(${({ colorHue }) => colorHue}, 45%, 20%, 0.7);
+    backdrop-filter: blur(8px);
+    border: 1px solid hsla(${({ colorHue }) => colorHue}, 50%, 50%, 0.35);
+    color: hsla(0, 0%, 100%, 0.9);
+
+    opacity: ${({ headerVisible }) => headerVisible ? 1 : 0};
+    pointer-events: ${({ headerVisible }) => headerVisible ? 'auto' : 'none'};
+    transform: ${({ headerVisible, headerOffset = 0 }) =>
+      headerVisible ? `translateY(${headerOffset}px)` : `translateY(${headerOffset + 6}px)`};
+    transition: opacity 0.15s ease, transform 0.15s ease;
 
     .e-header-content {
       display: flex;
@@ -686,7 +746,7 @@ const StyledBubble = styled.div<StyledBubbleProp>`
       ${({ contentBackground }) => contentBackground || "hsla(0, 0%, 98%, 0.9)"} 100%
     );
     border-radius: 16px;
-    margin: 0 12px 12px;
+    margin: 12px;
     box-shadow:
       inset 0 2px 4px hsla(0, 0%, 0%, 0.05),
       0 1px 2px hsla(0, 0%, 100%, 0.5);

--- a/bublys-libs/bubbles-ui/src/lib/ui/BubblesLayeredView.tsx
+++ b/bublys-libs/bubbles-ui/src/lib/ui/BubblesLayeredView.tsx
@@ -15,6 +15,7 @@ import {
   makeSelectUniverseDimensions,
   selectIsLayerAnimating,
   makeSelectBubbleByIdInUniverse,
+  makeSelectFocusedBubbleId,
   ROOT_UNIVERSE_ID,
 } from "../state/index.js";
 
@@ -26,6 +27,7 @@ type ConnectedBubbleViewProps = {
   bubbleId: string;
   layerIndex: number;
   zIndex: number;
+  isFocused: boolean;
   vanishingPoint: Point2;
   surfaceLayer: Layer;
   hasLeftLink?: boolean;
@@ -44,6 +46,7 @@ const ConnectedBubbleView: FC<ConnectedBubbleViewProps> = memo(function Connecte
   bubbleId,
   layerIndex,
   zIndex,
+  isFocused,
   vanishingPoint,
   surfaceLayer,
   hasLeftLink,
@@ -73,6 +76,7 @@ const ConnectedBubbleView: FC<ConnectedBubbleViewProps> = memo(function Connecte
         position={pos}
         layerIndex={layerIndex}
         zIndex={zIndex}
+        isFocused={isFocused}
         vanishingPoint={vanishingPoint}
         onClick={() => onBubbleClick?.(bubble.url)}
         onCloseClick={() => onBubbleClose?.(bubble)}
@@ -92,6 +96,7 @@ const ConnectedBubbleView: FC<ConnectedBubbleViewProps> = memo(function Connecte
       position={pos}
       layerIndex={layerIndex}
       zIndex={zIndex}
+      isFocused={isFocused}
       vanishingPoint={vanishingPoint}
       contentBackground={bubble.contentBackground ?? "white"}
       hasLeftLink={hasLeftLink}
@@ -335,6 +340,7 @@ export const BubblesLayeredView: FC<BubblesLayeredViewProps> = ({
   }, [universeId]);
 
   const [showSurfaceBorder, setShowSurfaceBorder] = useState(false);
+  const focusedBubbleId = useAppSelector(makeSelectFocusedBubbleId(universeId));
   const relationIds = useAppSelector(makeSelectValidBubbleRelationIds(universeId));
   const surfaceLeftTop = useAppSelector(makeSelectSurfaceLeftTop(universeId));
   const coordinateSystem = useAppSelector(makeSelectGlobalCoordinateSystem(universeId));
@@ -373,6 +379,7 @@ export const BubblesLayeredView: FC<BubblesLayeredViewProps> = ({
       layer.map((bubbleId) => {
         const zIndex = baseZIndex - layerIndex;
         const hasLeftLink = openeeIds.has(bubbleId);
+        const isFocused = focusedBubbleId === bubbleId;
 
         return (
           <ConnectedBubbleView
@@ -381,6 +388,7 @@ export const BubblesLayeredView: FC<BubblesLayeredViewProps> = ({
             bubbleId={bubbleId}
             layerIndex={layerIndex}
             zIndex={zIndex}
+            isFocused={isFocused}
             vanishingPoint={undergroundVanishingPoint}
             surfaceLayer={surfaceLayer}
             hasLeftLink={hasLeftLink}

--- a/bublys-libs/bubbles-ui/src/lib/ui/BubblesLayeredView.tsx
+++ b/bublys-libs/bubbles-ui/src/lib/ui/BubblesLayeredView.tsx
@@ -375,8 +375,13 @@ export const BubblesLayeredView: FC<BubblesLayeredViewProps> = ({
   );
 
   const renderedBubbles = bubbleLayers
-    .map((layer, layerIndex) =>
-      layer.map((bubbleId) => {
+    .map((layer, layerIndex) => {
+      // フォーカスされたバブルを同レイヤー内の最後尾に移動し、DOM 順で最前面に来るようにする
+      const orderedLayer =
+        focusedBubbleId && layer.includes(focusedBubbleId)
+          ? [...layer.filter((id) => id !== focusedBubbleId), focusedBubbleId]
+          : layer;
+      return orderedLayer.map((bubbleId) => {
         const zIndex = baseZIndex - layerIndex;
         const hasLeftLink = openeeIds.has(bubbleId);
         const isFocused = focusedBubbleId === bubbleId;
@@ -402,8 +407,8 @@ export const BubblesLayeredView: FC<BubblesLayeredViewProps> = ({
             onDebugRects={onDebugRects}
           />
         );
-      })
-    )
+      });
+    })
     .flat();
 
   const universeContextValue = useMemo(() => ({ universeId, universeRef }), [universeId]);

--- a/bublys-libs/bubbles-ui/src/lib/ui/UniverseBubbleView.tsx
+++ b/bublys-libs/bubbles-ui/src/lib/ui/UniverseBubbleView.tsx
@@ -1,13 +1,13 @@
 "use client";
-import { FC, useContext, useLayoutEffect, useEffect, useMemo, useState, memo } from "react";
+import { FC, useContext, useLayoutEffect, useMemo, useState, memo } from "react";
 import styled from "styled-components";
 import { Bubble } from "../Bubble.domain.js";
 import { Point2, Vec2, CoordinateSystem, SmartRect } from "@bublys-org/bubbles-ui-util";
 import { useMyRectObserver } from "../hooks/useMyRect.js";
 import { useBubbleDrag } from "../hooks/useBubbleDrag.js";
 import { useBubbleResize } from "../hooks/useBubbleResize.js";
-import { useAppDispatch } from "@bublys-org/state-management";
-import { renderBubble, updateBubble, finishBubbleAnimation, focusBubble } from "../state/bubbles-slice.js";
+import { useAppDispatch, useAppSelector } from "@bublys-org/state-management";
+import { renderBubble, updateBubble, finishBubbleAnimation, focusBubble, makeSelectFocusedBubbleId } from "../state/bubbles-slice.js";
 import { BubblesContext } from "../bubble-routing/BubbleRouting.js";
 import { useBubbleRefsOptional } from "../context/BubbleRefsContext.js";
 import { measureViewport } from "../utils/measure-viewport.js";
@@ -95,6 +95,7 @@ const UniverseBubbleViewInner: FC<UniverseBubbleViewProps> = ({
 
   const dispatch = useAppDispatch();
   const universeId = useUniverseId();
+  const focusedBubbleId = useAppSelector(makeSelectFocusedBubbleId(universeId));
   const { pageSize, surfaceLeftTop } = useContext(BubblesContext);
   const bubbleRefs = useBubbleRefsOptional();
 
@@ -124,9 +125,10 @@ const UniverseBubbleViewInner: FC<UniverseBubbleViewProps> = ({
     setHeaderOffset(Math.max(0, -headerTopInViewport));
   };
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     if (isFocused) updateHeaderSafeZone();
-  }, [isFocused]);
+    else setIsMouseNearTop(false);
+  }, [isFocused, focusedBubbleId]);
 
   const isMaximized = bubble.isMaximized;
 
@@ -345,8 +347,10 @@ const StyledWindow = styled.div<StyledWindowProps>`
   backdrop-filter: blur(10px) saturate(1.15);
 
   /* キーボードフォーカス時もヘッダーを表示（アクセシビリティ）。
+     :focus-within ではなく :has(:focus-visible) を使うことで、
+     マウスクリックによる一時的なフォーカスではトリガーされない。
      transform は JS 管理（$headerOffset 込み）なので上書きしない。 */
-  &:focus-within > .e-window-header {
+  &:has(:focus-visible) > .e-window-header {
     opacity: 1;
     pointer-events: auto;
   }

--- a/bublys-libs/bubbles-ui/src/lib/ui/UniverseBubbleView.tsx
+++ b/bublys-libs/bubbles-ui/src/lib/ui/UniverseBubbleView.tsx
@@ -1,5 +1,5 @@
 "use client";
-import { FC, useContext, useLayoutEffect, useMemo, useState, memo } from "react";
+import { FC, useContext, useLayoutEffect, useEffect, useMemo, useState, memo } from "react";
 import styled from "styled-components";
 import { Bubble } from "../Bubble.domain.js";
 import { Point2, Vec2, CoordinateSystem, SmartRect } from "@bublys-org/bubbles-ui-util";
@@ -7,7 +7,7 @@ import { useMyRectObserver } from "../hooks/useMyRect.js";
 import { useBubbleDrag } from "../hooks/useBubbleDrag.js";
 import { useBubbleResize } from "../hooks/useBubbleResize.js";
 import { useAppDispatch } from "@bublys-org/state-management";
-import { renderBubble, updateBubble, finishBubbleAnimation } from "../state/bubbles-slice.js";
+import { renderBubble, updateBubble, finishBubbleAnimation, focusBubble } from "../state/bubbles-slice.js";
 import { BubblesContext } from "../bubble-routing/BubbleRouting.js";
 import { useBubbleRefsOptional } from "../context/BubbleRefsContext.js";
 import { measureViewport } from "../utils/measure-viewport.js";
@@ -52,12 +52,15 @@ const LayerDownIcon: FC<{ size?: number }> = ({ size = 16 }) => (
   </svg>
 );
 
+const HEADER_PROXIMITY_THRESHOLD = 40;
+
 type UniverseBubbleViewProps = {
   bubble: Bubble;
   position?: Point2;
   vanishingPoint?: Point2;
   layerIndex?: number;
   zIndex?: number;
+  isFocused?: boolean;
   /** ヘッダー右側に追加で挟みたいコントロール（例: ←→ 世界線ナビ） */
   headerExtras?: React.ReactNode;
   children?: React.ReactNode;
@@ -74,6 +77,7 @@ const UniverseBubbleViewInner: FC<UniverseBubbleViewProps> = ({
   children,
   layerIndex,
   zIndex,
+  isFocused = false,
   position = { x: 0, y: 0 },
   vanishingPoint = new Vec2({ x: 0, y: 0 }),
   headerExtras,
@@ -105,7 +109,24 @@ const UniverseBubbleViewInner: FC<UniverseBubbleViewProps> = ({
   const { onDragStart } = useBubbleDrag({ bubble, ref, layerIndex, vanishingPoint });
   const { onResizeStart } = useBubbleResize({ bubble, ref });
 
-  const [isFocused, setIsFocused] = useState(false);
+  const [isMouseNearTop, setIsMouseNearTop] = useState(false);
+  const [isHeaderHovered, setIsHeaderHovered] = useState(false);
+  const [headerOffset, setHeaderOffset] = useState(0);
+
+  const isHeaderVisible = isFocused || isMouseNearTop || isHeaderHovered;
+
+  const updateHeaderSafeZone = () => {
+    const bubbleRect = ref.current?.getBoundingClientRect();
+    if (!bubbleRect) return;
+    const headerEl = ref.current?.querySelector('.e-window-header');
+    const headerHeight = headerEl?.getBoundingClientRect().height ?? 40;
+    const headerTopInViewport = bubbleRect.top - headerHeight;
+    setHeaderOffset(Math.max(0, -headerTopInViewport));
+  };
+
+  useEffect(() => {
+    if (isFocused) updateHeaderSafeZone();
+  }, [isFocused]);
 
   const isMaximized = bubble.isMaximized;
 
@@ -131,11 +152,9 @@ const UniverseBubbleViewInner: FC<UniverseBubbleViewProps> = ({
   };
 
   const handleHeaderMouseDown = (e: React.MouseEvent<HTMLElement>) => {
-    setIsFocused(true);
+    dispatch(focusBubble(bubble.id, universeId));
     onDragStart(e);
   };
-
-  const handleMouseLeave = () => setIsFocused(false);
 
   useLayoutEffect(() => {
     if (ref.current && bubbleRefs) {
@@ -158,8 +177,9 @@ const UniverseBubbleViewInner: FC<UniverseBubbleViewProps> = ({
       $layerIndex={layerIndex}
       $position={position}
       $transformOrigin={vanishingPointRelative}
+      $headerVisible={isHeaderVisible}
+      $headerOffset={headerOffset}
       onClick={onClick}
-      onMouseLeave={handleMouseLeave}
       onTransitionEnd={() => {
         notifyRendered();
         dispatch(finishBubbleAnimation(bubble.id));
@@ -168,7 +188,20 @@ const UniverseBubbleViewInner: FC<UniverseBubbleViewProps> = ({
       $height={bubble.size ? `${bubble.size.height}px` : undefined}
       $backdropColor={bubble.backdropColor}
     >
-      <header className="e-window-header" onMouseDown={handleHeaderMouseDown}>
+      {/* pointer-events: none の StyledWindow に代わりヘッダー近接を検知するホットゾーン */}
+      <div
+        className="e-window-hotzone"
+        onMouseEnter={() => { setIsMouseNearTop(true); updateHeaderSafeZone(); }}
+        onMouseLeave={() => setIsMouseNearTop(false)}
+        onMouseDown={() => dispatch(focusBubble(bubble.id, universeId))}
+      />
+
+      <header
+        className="e-window-header"
+        onMouseDown={handleHeaderMouseDown}
+        onMouseEnter={() => setIsHeaderHovered(true)}
+        onMouseLeave={() => setIsHeaderHovered(false)}
+      >
         <div className="e-window-buttons-left">
           {onCloseClick && (
             <button
@@ -248,6 +281,7 @@ export const UniverseBubbleView = memo(UniverseBubbleViewInner, (prev, next) => 
   }
   if (prev.position?.x !== next.position?.x || prev.position?.y !== next.position?.y) return false;
   if (prev.layerIndex !== next.layerIndex || prev.zIndex !== next.zIndex) return false;
+  if (prev.isFocused !== next.isFocused) return false;
   if (prev.headerExtras !== next.headerExtras) return false;
   return true;
 });
@@ -261,6 +295,8 @@ type StyledWindowProps = React.HTMLAttributes<HTMLDivElement> & {
   $width?: string;
   $height?: string;
   $backdropColor?: string;
+  $headerVisible?: boolean;
+  $headerOffset?: number;
   ref: React.RefObject<HTMLDivElement | null>;
 };
 
@@ -289,7 +325,9 @@ const StyledWindow = styled.div<StyledWindowProps>`
 
   display: flex;
   flex-direction: column;
-  overflow: hidden;
+  /* overflow: hidden は書かない。header が bottom: 100% でコンテナ外に浮くため、
+     hidden にすると header がクリップされて見えなくなる。
+     コンテンツのクリップは .e-window-content 自身の overflow: hidden に委ねる。 */
 
   /* シェル本体は backdropColor（バブリ宣言の「夜空」色）の半透明ガラスとして塗る。
      色は color-mix で 55% に薄め、backdrop-filter blur と合わせて「色付きフロスト
@@ -299,31 +337,57 @@ const StyledWindow = styled.div<StyledWindowProps>`
     $backdropColor
       ? `color-mix(in srgb, ${$backdropColor} 55%, transparent)`
       : "transparent"};
-  border: none;
+  border: 1px solid hsla(${({ $colorHue }) => $colorHue}, 50%, 60%, 0.45);
   border-radius: 14px;
   box-shadow:
     0 16px 48px hsla(0, 0%, 0%, 0.5),
     0 2px 8px hsla(0, 0%, 0%, 0.25);
   backdrop-filter: blur(10px) saturate(1.15);
 
-  > .e-window-header {
-    /* StyledWindow が none なので、操作を受けるヘッダーは explicit に auto。 */
+  /* キーボードフォーカス時もヘッダーを表示（アクセシビリティ）。
+     transform は JS 管理（$headerOffset 込み）なので上書きしない。 */
+  &:focus-within > .e-window-header {
+    opacity: 1;
     pointer-events: auto;
+  }
+
+  /* マウス近接検知用の透明ストリップ。StyledWindow が pointer-events: none のため
+     ここで明示的に auto を設定して onMouseEnter/Leave を受け取る。 */
+  > .e-window-hotzone {
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    height: ${HEADER_PROXIMITY_THRESHOLD}px;
+    pointer-events: auto;
+    z-index: 0;
+    background: transparent;
+  }
+
+  > .e-window-header {
+    position: absolute;
+    bottom: 100%;
+    left: 0;
+    right: 0;
+    z-index: 1;
     cursor: move;
     user-select: none;
-    flex: 0 0 auto;
     display: flex;
     align-items: center;
     gap: 8px;
     padding: 6px 10px;
-    background: linear-gradient(
-      180deg,
-      hsla(${({ $colorHue }) => $colorHue}, 35%, 30%, 0.65) 0%,
-      hsla(${({ $colorHue }) => $colorHue}, 30%, 22%, 0.45) 100%
-    );
-    border-bottom: 1px solid hsla(${({ $colorHue }) => $colorHue}, 40%, 70%, 0.25);
+    border-radius: 14px;
+    background: hsla(${({ $colorHue }) => $colorHue}, 45%, 20%, 0.7);
+    backdrop-filter: blur(8px);
+    border: 1px solid hsla(${({ $colorHue }) => $colorHue}, 50%, 50%, 0.35);
     color: hsla(0, 0%, 100%, 0.9);
     font-size: 0.8em;
+
+    opacity: ${({ $headerVisible }) => $headerVisible ? 1 : 0};
+    pointer-events: ${({ $headerVisible }) => $headerVisible ? 'auto' : 'none'};
+    transform: ${({ $headerVisible, $headerOffset = 0 }) =>
+      $headerVisible ? `translateY(${$headerOffset}px)` : `translateY(${$headerOffset + 6}px)`};
+    transition: opacity 0.15s ease, transform 0.15s ease;
 
     .e-window-buttons-left,
     .e-window-buttons-right {


### PR DESCRIPTION
## Summary

- ヘッダーをデフォルト非表示にし、以下の条件で表示する
  - マウスがバブル上端に近づいたとき（閾値: 40px）
  - Reduxでそのバブルがフォーカス状態のとき
  - `:focus-within` によるキーボードアクセス時
- ヘッダーは `position: absolute; bottom: 100%` でバブル外に浮かせ、表示切替でバブルサイズが変わらない設計
- バブルが画面上端付近にある場合、`headerOffset` でヘッダーが画面外に出ないよう補正
- フォーカスはRedux state (`focusedBubbleId`) で管理し、マウスが離れてもフォーカスが保持される
- バブルの枠を全面同じ背景カラーで統一（上辺も含む）

## Changes

### Domain
- `BubblesProcess`: `focusedBubbleId` フィールド追加、`focus(id)` メソッド追加

### State
- `bubbles-slice`: `focusBubble` reducer と `makeSelectFocusedBubbleId` セレクター追加

### UI
- `BubblesLayeredView`: `focusedBubbleId` をReduxから取得し `isFocused` prop を各バブルに渡す
- `BubbleView`: ヘッダー表示ロジック実装（マウス近接 / フォーカス / `:focus-within`）
- `UniverseBubbleView`: 同上（ウィンドウ型バブル向け）

### Tests
- `BubblesProcess.domain.test.ts` 追加（6テスト）
- `bubbles-focus.test.ts` 追加（4テスト）

## Test plan

- [x] バブルをホバーせずに表示したとき、ヘッダーが非表示であることを確認
- [x] バブル上端にマウスを近づけるとヘッダーが表示されることを確認
- [x] バブルをクリック後にマウスを離してもヘッダーが表示され続けることを確認
- [x] 別のバブルをクリックすると前のバブルのヘッダーが消えることを確認
- [x] バブルが画面上端付近にある場合にヘッダーが画面内に収まることを確認
- [ ] `npx nx test bublys-os` でテストが全通することを確認

Closes #59

🤖 Generated with [Claude Code](https://claude.com/claude-code)