### PR TITLE
perf(bubbles-ui): バブル描画の軽量化・不要な再レンダリング排除

### DIFF
--- a/apps/bublys-os/app/bubble-ui/BubblesUI/feature/BubblesUI.tsx
+++ b/apps/bublys-os/app/bubble-ui/BubblesUI/feature/BubblesUI.tsx
@@ -83,7 +83,7 @@ export const BubblesUI: FC<BubblesUI> = ({ additionalButton }) => {
   const surfaceLeftTop = useAppSelector(selectSurfaceLeftTop);
 
   // Redux を使ったアクションハンドラ
-  const deleteBubble = (b: Bubble) => {
+  const deleteBubble = useCallback((b: Bubble) => {
     dispatch(deleteBubbleAction(b.id));
     dispatch(removeBubble(b.id));
 
@@ -95,15 +95,15 @@ export const BubblesUI: FC<BubblesUI> = ({ additionalButton }) => {
       console.log('[BubblesUI] Deleting shell:', { shellId, shellType });
       shellManager.removeShell(shellId);
     }
-  };
+  }, [dispatch, shellManager]);
 
-  const layerDown = (b: Bubble) => {
+  const layerDown = useCallback((b: Bubble) => {
     dispatch(layerDownAction(b.id));
-  };
+  }, [dispatch]);
 
-  const layerUp = (b: Bubble) => {
+  const layerUp = useCallback((b: Bubble) => {
     dispatch(layerUpAction(b.id));
-  };
+  }, [dispatch]);
 
 
   const popChild = useCallback((
@@ -203,8 +203,16 @@ export const BubblesUI: FC<BubblesUI> = ({ additionalButton }) => {
     openBubble: popChildOrJoinSibling,
   }), [pageSize, surfaceLeftTop, globalCoordinateSystem, popChildOrJoinSibling]);
 
+  const handleBubbleClick = useCallback((name: string) => {
+    console.log("Bubble clicked: " + name);
+  }, []);
+
+  const handleBubbleResize = useCallback((bubble: Bubble) => {
+    console.log("Bubble resized: " + bubble.url, bubble.size);
+  }, []);
+
   // Pocketのドロップハンドラー
-  const handlePocketDrop = (url: string, type: DragDataType, label?: string, objectId?: string) => {
+  const handlePocketDrop = useCallback((url: string, type: DragDataType, label?: string, objectId?: string) => {
     dispatch(addPocketItem({
       id: crypto.randomUUID(),
       url,
@@ -213,7 +221,7 @@ export const BubblesUI: FC<BubblesUI> = ({ additionalButton }) => {
       label,
       addedAt: Date.now(),
     }));
-  };
+  }, [dispatch]);
 
   // Pocketアイテムのクリックハンドラー
   const handlePocketItemClick = useCallback((url: string) => {
@@ -258,9 +266,9 @@ export const BubblesUI: FC<BubblesUI> = ({ additionalButton }) => {
                   bubbleLayers={bubbleLayers}
                   vanishingPoint={globalCoordinateSystem.vanishingPoint}
                   renderBubbleContent={renderAppsBubbleContent}
-                  onBubbleClick={(name) => console.log("Bubble clicked: " + name)}
+                  onBubbleClick={handleBubbleClick}
                   onBubbleClose={deleteBubble}
-                  onBubbleResize={(bubble) => console.log("Bubble resized: " + bubble.url, bubble.size)}
+                  onBubbleResize={handleBubbleResize}
                   onBubbleLayerDown={layerDown}
                   onBubbleLayerUp={layerUp}
                   onCoordinateSystemReady={handleCoordinateSystemReady}

--- a/bublys-libs/bubbles-ui/src/lib/bubly/BublyApp.tsx
+++ b/bublys-libs/bubbles-ui/src/lib/bubly/BublyApp.tsx
@@ -90,18 +90,18 @@ export const BublyApp: FC<BublyAppProps> = ({
   const surfaceLeftTop = useAppSelector(selectSurfaceLeftTop);
 
   // アクションハンドラ
-  const deleteBubble = (b: Bubble) => {
+  const deleteBubble = useCallback((b: Bubble) => {
     dispatch(deleteBubbleAction(b.id));
     dispatch(removeBubble(b.id));
-  };
+  }, [dispatch]);
 
-  const layerDown = (b: Bubble) => {
+  const layerDown = useCallback((b: Bubble) => {
     dispatch(layerDownAction(b.id));
-  };
+  }, [dispatch]);
 
-  const layerUp = (b: Bubble) => {
+  const layerUp = useCallback((b: Bubble) => {
     dispatch(layerUpAction(b.id));
-  };
+  }, [dispatch]);
 
   const popChild = useCallback((
     b: Bubble,

--- a/bublys-libs/bubbles-ui/src/lib/context/BubbleRefsContext.tsx
+++ b/bublys-libs/bubbles-ui/src/lib/context/BubbleRefsContext.tsx
@@ -1,5 +1,5 @@
 "use client";
-import { createContext, useContext, useRef, useCallback, ReactNode, FC } from "react";
+import { createContext, useContext, useRef, useCallback, useMemo, ReactNode, FC } from "react";
 import { SmartRect, CoordinateSystem } from "@bublys-org/bubbles-ui-util";
 import { getElementRect } from "../utils/get-origin-rect.js";
 import { measureViewportForElement } from "../utils/measure-viewport.js";
@@ -116,20 +116,30 @@ export const BubbleRefsProvider: FC<{ children: ReactNode }> = ({ children }) =>
     originRectCache.current.clear();
   }, []);
 
+  const contextValue = useMemo(() => ({
+    registerBubbleRef,
+    unregisterBubbleRef,
+    getBubbleRef,
+    registerOriginRef,
+    unregisterOriginRef,
+    getOriginRef,
+    getOriginRectCached,
+    invalidateOriginRectCache,
+    invalidateAllOriginRectCache,
+  }), [
+    registerBubbleRef,
+    unregisterBubbleRef,
+    getBubbleRef,
+    registerOriginRef,
+    unregisterOriginRef,
+    getOriginRef,
+    getOriginRectCached,
+    invalidateOriginRectCache,
+    invalidateAllOriginRectCache,
+  ]);
+
   return (
-    <BubbleRefsContext.Provider
-      value={{
-        registerBubbleRef,
-        unregisterBubbleRef,
-        getBubbleRef,
-        registerOriginRef,
-        unregisterOriginRef,
-        getOriginRef,
-        getOriginRectCached,
-        invalidateOriginRectCache,
-        invalidateAllOriginRectCache,
-      }}
-    >
+    <BubbleRefsContext.Provider value={contextValue}>
       {children}
     </BubbleRefsContext.Provider>
   );

--- a/bublys-libs/bubbles-ui/src/lib/hooks/useBubbleDrag.ts
+++ b/bublys-libs/bubbles-ui/src/lib/hooks/useBubbleDrag.ts
@@ -13,7 +13,6 @@ type UseBubbleDragArgs = {
   ref: React.RefObject<HTMLElement | null>;
   layerIndex?: number;
   vanishingPoint?: Point2;
-  onDragActivity?: () => void; // ドラッグ中・終了時に呼ばれる（deferred timer リセット用）
 };
 
 /**
@@ -25,7 +24,7 @@ type UseBubbleDragArgs = {
  *  - ドラッグ終了時に 1 回だけ updateBubble を dispatch
  *  - universe 端は createUniverse().clamp() でクランプ
  */
-export function useBubbleDrag({ bubble, ref, layerIndex, vanishingPoint, onDragActivity }: UseBubbleDragArgs) {
+export function useBubbleDrag({ bubble, ref, layerIndex, vanishingPoint }: UseBubbleDragArgs) {
   const dispatch = useAppDispatch();
   const universeId = useUniverseId();
   const { surfaceLeftTop } = useContext(BubblesContext);
@@ -38,9 +37,6 @@ export function useBubbleDrag({ bubble, ref, layerIndex, vanishingPoint, onDragA
   bubbleRef.current = bubble;
   const layerIndexRef = useRef(layerIndex);
   layerIndexRef.current = layerIndex;
-  const onDragActivityRef = useRef(onDragActivity);
-  onDragActivityRef.current = onDragActivity;
-
   const dragStartPosRef = useRef<Point2 | null>(null);
   const dragStartMouseRef = useRef<Point2 | null>(null);
   const currentDragPosRef = useRef<Point2 | null>(null);
@@ -79,19 +75,15 @@ export function useBubbleDrag({ bubble, ref, layerIndex, vanishingPoint, onDragA
     const newTransformOrigin = coordSystem.calculateTransformOrigin(screenPos);
     ref.current.style.transformOrigin = `${newTransformOrigin.x}px ${newTransformOrigin.y}px`;
 
-    onDragActivityRef.current?.();
   };
 
   const endDrag = () => {
     if (currentDragPosRef.current) {
       dispatch(updateBubble(bubbleRef.current.moveTo(currentDragPosRef.current).toJSON(), universeId));
-      onDragActivityRef.current?.();
     }
     if (ref.current) {
       ref.current.style.transition = "";
       ref.current.style.transformOrigin = "";
-      ref.current.style.left = "";
-      ref.current.style.top = "";
     }
     dragStartPosRef.current = null;
     dragStartMouseRef.current = null;

--- a/bublys-libs/bubbles-ui/src/lib/hooks/useBubbleDrag.ts
+++ b/bublys-libs/bubbles-ui/src/lib/hooks/useBubbleDrag.ts
@@ -13,6 +13,7 @@ type UseBubbleDragArgs = {
   ref: React.RefObject<HTMLElement | null>;
   layerIndex?: number;
   vanishingPoint?: Point2;
+  onDragActivity?: () => void; // ドラッグ中・終了時に呼ばれる（deferred timer リセット用）
 };
 
 /**
@@ -24,7 +25,7 @@ type UseBubbleDragArgs = {
  *  - ドラッグ終了時に 1 回だけ updateBubble を dispatch
  *  - universe 端は createUniverse().clamp() でクランプ
  */
-export function useBubbleDrag({ bubble, ref, layerIndex, vanishingPoint }: UseBubbleDragArgs) {
+export function useBubbleDrag({ bubble, ref, layerIndex, vanishingPoint, onDragActivity }: UseBubbleDragArgs) {
   const dispatch = useAppDispatch();
   const universeId = useUniverseId();
   const { surfaceLeftTop } = useContext(BubblesContext);
@@ -37,6 +38,8 @@ export function useBubbleDrag({ bubble, ref, layerIndex, vanishingPoint }: UseBu
   bubbleRef.current = bubble;
   const layerIndexRef = useRef(layerIndex);
   layerIndexRef.current = layerIndex;
+  const onDragActivityRef = useRef(onDragActivity);
+  onDragActivityRef.current = onDragActivity;
 
   const dragStartPosRef = useRef<Point2 | null>(null);
   const dragStartMouseRef = useRef<Point2 | null>(null);
@@ -75,11 +78,14 @@ export function useBubbleDrag({ bubble, ref, layerIndex, vanishingPoint }: UseBu
 
     const newTransformOrigin = coordSystem.calculateTransformOrigin(screenPos);
     ref.current.style.transformOrigin = `${newTransformOrigin.x}px ${newTransformOrigin.y}px`;
+
+    onDragActivityRef.current?.();
   };
 
   const endDrag = () => {
     if (currentDragPosRef.current) {
       dispatch(updateBubble(bubbleRef.current.moveTo(currentDragPosRef.current).toJSON(), universeId));
+      onDragActivityRef.current?.();
     }
     if (ref.current) {
       ref.current.style.transition = "";

--- a/bublys-libs/bubbles-ui/src/lib/state/bubbles-slice.ts
+++ b/bublys-libs/bubbles-ui/src/lib/state/bubbles-slice.ts
@@ -48,6 +48,7 @@ export interface UniverseState {
   bubbleRelations: BubblesRelation[];
   globalCoordinateSystem: CoordinateSystemData;
   surfaceLeftTop: Point2; // surface領域の universe 上での起点（奥のレイヤーをどれだけ覗かせるか）
+  lastActiveAt: Record<string, number>; // bubbleId → そのバブルが最後にアクティブだった時刻 (Date.now() ms)
 }
 
 /** ルート universe の ID。ネストした universe は別 ID を持つ。 */
@@ -84,6 +85,7 @@ const createEmptyUniverse = (): UniverseState => ({
   bubbleRelations: [],
   globalCoordinateSystem: CoordinateSystem.GLOBAL.toData(),
   surfaceLeftTop: { x: 100, y: 100 },
+  lastActiveAt: {},
 });
 
 // 初期状態を構築する関数（遅延評価）
@@ -109,6 +111,7 @@ const getInitialState = (): BubbleStateSlice => {
         bubbleRelations: [],
         globalCoordinateSystem: CoordinateSystem.GLOBAL.toData(),
         surfaceLeftTop: { x: 100, y: 100 },
+        lastActiveAt: {},
       },
     },
     renderCount: 0,
@@ -146,6 +149,7 @@ const prepCoord = (payload: CoordinateSystemData, universeId?: string) => withU(
 const prepPoint = (payload: Point2, universeId?: string) => withU(payload, universeId);
 const prepView = (payload: BubbleArrangementState, universeId?: string) => withU(payload, universeId);
 const prepNavigate = (payload: { id: string; url: string }, universeId?: string) => withU(payload, universeId);
+const prepActivate = (payload: { bubbleId: string; timestamp: number }, universeId?: string) => withU(payload, universeId);
 
 export const bubblesSlice = createSlice({
   name: "bubbleState",
@@ -224,6 +228,18 @@ export const bubblesSlice = createSlice({
         state.renderCount += 1;
       },
       prepare: prepStr,
+    },
+
+    // バブルがユーザーにアクティブに操作された時刻 (ms) を記録する。
+    // layerIndex > 0 のバブルが「最後にアクティブだったのが何 ms 前か」を計算でき、
+    // 長期未操作バブルの遅延描画（deferred rendering）の判定に使う。
+    activateBubble: {
+      reducer: (state, action: PayloadAction<{ bubbleId: string; timestamp: number }, string, UniverseMeta>) => {
+        const u = draftUniverse(state, action.meta.universeId);
+        if (!u.lastActiveAt) u.lastActiveAt = {};
+        u.lastActiveAt[action.payload.bubbleId] = action.payload.timestamp;
+      },
+      prepare: prepActivate,
     },
 
     finishBubbleAnimation: (state, action: PayloadAction<string>) => {
@@ -359,6 +375,7 @@ export const {
   replaceBubbleArrangement,
   finishBubbleAnimation,
   clearAllAnimations,
+  activateBubble,
 } = bubblesSlice.actions;
 
 // ============================================================================
@@ -758,6 +775,20 @@ export const makeSelectLastSiblingRenderedRect = memoizeByUniverse((uid) =>
       : undefined;
   }),
 );
+
+const EMPTY_LAST_ACTIVE_AT: Record<string, number> = {};
+
+export const makeSelectLastActiveAt = memoizeByUniverse((uid) =>
+  createSelector(
+    [(state: { bubbleState: BubbleStateSlice }) => universeOf(state, uid).lastActiveAt],
+    (at): Record<string, number> => at ?? EMPTY_LAST_ACTIVE_AT,
+  ),
+);
+
+/** 特定バブルの lastActiveAt だけを選択する。プリミティブ返却なので他バブルの activate で再レンダーしない。 */
+export const makeSelectBubbleLastActiveAt = (universeId: string, bubbleId: string) =>
+  (state: { bubbleState: BubbleStateSlice }): number =>
+    universeOf(state, universeId).lastActiveAt?.[bubbleId] ?? 0;
 
 export const makeSelectBubbleArrangementForUniverse = memoizeByUniverse((uid) =>
   createSelector(

--- a/bublys-libs/bubbles-ui/src/lib/state/bubbles-slice.ts
+++ b/bublys-libs/bubbles-ui/src/lib/state/bubbles-slice.ts
@@ -48,7 +48,6 @@ export interface UniverseState {
   bubbleRelations: BubblesRelation[];
   globalCoordinateSystem: CoordinateSystemData;
   surfaceLeftTop: Point2; // surface領域の universe 上での起点（奥のレイヤーをどれだけ覗かせるか）
-  lastActiveAt: Record<string, number>; // bubbleId → そのバブルが最後にアクティブだった時刻 (Date.now() ms)
 }
 
 /** ルート universe の ID。ネストした universe は別 ID を持つ。 */
@@ -85,7 +84,6 @@ const createEmptyUniverse = (): UniverseState => ({
   bubbleRelations: [],
   globalCoordinateSystem: CoordinateSystem.GLOBAL.toData(),
   surfaceLeftTop: { x: 100, y: 100 },
-  lastActiveAt: {},
 });
 
 // 初期状態を構築する関数（遅延評価）
@@ -111,7 +109,6 @@ const getInitialState = (): BubbleStateSlice => {
         bubbleRelations: [],
         globalCoordinateSystem: CoordinateSystem.GLOBAL.toData(),
         surfaceLeftTop: { x: 100, y: 100 },
-        lastActiveAt: {},
       },
     },
     renderCount: 0,
@@ -149,8 +146,6 @@ const prepCoord = (payload: CoordinateSystemData, universeId?: string) => withU(
 const prepPoint = (payload: Point2, universeId?: string) => withU(payload, universeId);
 const prepView = (payload: BubbleArrangementState, universeId?: string) => withU(payload, universeId);
 const prepNavigate = (payload: { id: string; url: string }, universeId?: string) => withU(payload, universeId);
-const prepActivate = (payload: { bubbleId: string; timestamp: number }, universeId?: string) => withU(payload, universeId);
-
 export const bubblesSlice = createSlice({
   name: "bubbleState",
   initialState: getInitialState,
@@ -228,18 +223,6 @@ export const bubblesSlice = createSlice({
         state.renderCount += 1;
       },
       prepare: prepStr,
-    },
-
-    // バブルがユーザーにアクティブに操作された時刻 (ms) を記録する。
-    // layerIndex > 0 のバブルが「最後にアクティブだったのが何 ms 前か」を計算でき、
-    // 長期未操作バブルの遅延描画（deferred rendering）の判定に使う。
-    activateBubble: {
-      reducer: (state, action: PayloadAction<{ bubbleId: string; timestamp: number }, string, UniverseMeta>) => {
-        const u = draftUniverse(state, action.meta.universeId);
-        if (!u.lastActiveAt) u.lastActiveAt = {};
-        u.lastActiveAt[action.payload.bubbleId] = action.payload.timestamp;
-      },
-      prepare: prepActivate,
     },
 
     finishBubbleAnimation: (state, action: PayloadAction<string>) => {
@@ -375,7 +358,6 @@ export const {
   replaceBubbleArrangement,
   finishBubbleAnimation,
   clearAllAnimations,
-  activateBubble,
 } = bubblesSlice.actions;
 
 // ============================================================================
@@ -775,20 +757,6 @@ export const makeSelectLastSiblingRenderedRect = memoizeByUniverse((uid) =>
       : undefined;
   }),
 );
-
-const EMPTY_LAST_ACTIVE_AT: Record<string, number> = {};
-
-export const makeSelectLastActiveAt = memoizeByUniverse((uid) =>
-  createSelector(
-    [(state: { bubbleState: BubbleStateSlice }) => universeOf(state, uid).lastActiveAt],
-    (at): Record<string, number> => at ?? EMPTY_LAST_ACTIVE_AT,
-  ),
-);
-
-/** 特定バブルの lastActiveAt だけを選択する。プリミティブ返却なので他バブルの activate で再レンダーしない。 */
-export const makeSelectBubbleLastActiveAt = (universeId: string, bubbleId: string) =>
-  (state: { bubbleState: BubbleStateSlice }): number =>
-    universeOf(state, universeId).lastActiveAt?.[bubbleId] ?? 0;
 
 export const makeSelectBubbleArrangementForUniverse = memoizeByUniverse((uid) =>
   createSelector(

--- a/bublys-libs/bubbles-ui/src/lib/ui/BubbleIcons.tsx
+++ b/bublys-libs/bubbles-ui/src/lib/ui/BubbleIcons.tsx
@@ -1,0 +1,34 @@
+import { FC } from "react";
+
+type IconProps = { size?: number };
+
+export const CloseIcon: FC<IconProps> = ({ size = 18 }) => (
+  <svg width={size} height={size} viewBox="0 0 24 24" fill="none">
+    <path d="M7 7L17 17M17 7L7 17" stroke="currentColor" strokeWidth="2" strokeLinecap="round" />
+  </svg>
+);
+
+export const ToggleSizeIcon: FC<IconProps & { isMaximized: boolean }> = ({ size = 18, isMaximized }) => (
+  <svg width={size} height={size} viewBox="0 0 24 24" fill="none">
+    {isMaximized ? (
+      <>
+        <path d="M8 8L10 10M16 16L14 14" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
+        <path d="M16 8L14 10M8 16L10 14" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
+      </>
+    ) : (
+      <rect x="7" y="7" width="10" height="10" rx="1.5" stroke="currentColor" strokeWidth="1.5" />
+    )}
+  </svg>
+);
+
+export const LayerUpIcon: FC<IconProps> = ({ size = 18 }) => (
+  <svg width={size} height={size} viewBox="0 0 24 24" fill="none">
+    <path d="M8 14L12 9L16 14" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
+  </svg>
+);
+
+export const LayerDownIcon: FC<IconProps> = ({ size = 18 }) => (
+  <svg width={size} height={size} viewBox="0 0 24 24" fill="none">
+    <path d="M8 10L12 15L16 10" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
+  </svg>
+);

--- a/bublys-libs/bubbles-ui/src/lib/ui/BubbleSkeleton.tsx
+++ b/bublys-libs/bubbles-ui/src/lib/ui/BubbleSkeleton.tsx
@@ -1,5 +1,5 @@
 "use client";
-import { FC } from "react";
+import { FC, memo } from "react";
 import styled from "styled-components";
 import { Bubble } from "../Bubble.domain.js";
 
@@ -7,12 +7,12 @@ type BubbleSkeletonProps = {
   bubble: Bubble;
 };
 
-export const BubbleSkeleton: FC<BubbleSkeletonProps> = ({ bubble }) => (
+export const BubbleSkeleton: FC<BubbleSkeletonProps> = memo(({ bubble }) => (
   <StyledSkeleton>
     <span className="e-type">{bubble.type}</span>
     <span className="e-url">{bubble.url}</span>
   </StyledSkeleton>
-);
+));
 
 const StyledSkeleton = styled.div`
   padding: 12px 16px;

--- a/bublys-libs/bubbles-ui/src/lib/ui/BubbleSkeleton.tsx
+++ b/bublys-libs/bubbles-ui/src/lib/ui/BubbleSkeleton.tsx
@@ -1,0 +1,39 @@
+"use client";
+import { FC } from "react";
+import styled from "styled-components";
+import { Bubble } from "../Bubble.domain.js";
+
+type BubbleSkeletonProps = {
+  bubble: Bubble;
+};
+
+export const BubbleSkeleton: FC<BubbleSkeletonProps> = ({ bubble }) => (
+  <StyledSkeleton>
+    <span className="e-type">{bubble.type}</span>
+    <span className="e-url">{bubble.url}</span>
+  </StyledSkeleton>
+);
+
+const StyledSkeleton = styled.div`
+  padding: 12px 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+
+  .e-type {
+    font-size: 0.85em;
+    font-weight: 600;
+    color: inherit;
+    opacity: 0.65;
+  }
+
+  .e-url {
+    font-size: 0.75em;
+    color: inherit;
+    opacity: 0.4;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    max-width: 200px;
+  }
+`;

--- a/bublys-libs/bubbles-ui/src/lib/ui/BubbleView.tsx
+++ b/bublys-libs/bubbles-ui/src/lib/ui/BubbleView.tsx
@@ -141,6 +141,7 @@ type BubbleProps = {
   zIndex?: number;
   contentBackground?: string; // コンテンツ背景色（デフォルト: white）
   hasLeftLink?: boolean; // 左側にリンクバブルが接続されているか（左角丸を無効化）
+  lightweightMode?: boolean; // 軽量モード: box-shadow・transition・backdrop-filter を省略
 
   children?: React.ReactNode; // Bubbleか、Layoutか、Panelか。 Panelが最もベーシック
   onClick?: (e: React.MouseEvent<HTMLDivElement>) => void; // クリックイベントハンドラ
@@ -161,6 +162,7 @@ const BubbleViewInner: FC<BubbleProps> = ({
   zIndex,
   contentBackground = "white",
   hasLeftLink = false,
+  lightweightMode = false,
   position,
   vanishingPoint,
   onClick,
@@ -277,6 +279,7 @@ const BubbleViewInner: FC<BubbleProps> = ({
       contentBackground={contentBackground}
       hasLeftLink={hasLeftLink}
       fillsContainer={bubble.fillsContainer}
+      lightweightMode={lightweightMode}
     >
       <header className="e-bubble-header" onMouseDown={handleHeaderMouseDown}>
         <div
@@ -385,7 +388,8 @@ export const BubbleView = memo(BubbleViewInner, (prevProps, nextProps) => {
   if (prevProps.layerIndex !== nextProps.layerIndex ||
       prevProps.zIndex !== nextProps.zIndex ||
       prevProps.contentBackground !== nextProps.contentBackground ||
-      prevProps.hasLeftLink !== nextProps.hasLeftLink) {
+      prevProps.hasLeftLink !== nextProps.hasLeftLink ||
+      prevProps.lightweightMode !== nextProps.lightweightMode) {
     return false;
   }
 
@@ -407,6 +411,7 @@ type StyledBubbleProp = React.HTMLAttributes<HTMLDivElement> & {
   contentBackground?: string; // コンテンツ背景色
   hasLeftLink?: boolean; // 左側にリンクバブルが接続されているか
   fillsContainer?: boolean; // 中身が自前のviewportを持つ窓型コンテンツ（スクロール抑止）
+  lightweightMode?: boolean; // 軽量モード
 
   ref: React.RefObject<HTMLDivElement | null>;
 };
@@ -427,7 +432,7 @@ const StyledBubble = styled.div<StyledBubbleProp>`
   top: ${({ position }) => (position ? `${position.y}px` : "0")};
 
   transition-property: left top transform;
-  transition: 0.3s ease-in-out;
+  transition: ${({ lightweightMode }) => lightweightMode ? 'none' : '0.3s ease-in-out'};
 
   transform-origin: ${({ transformOrigin }) =>
     transformOrigin
@@ -442,21 +447,25 @@ const StyledBubble = styled.div<StyledBubbleProp>`
 
   max-height: 90vh;//FIXME:突貫対応
 
-  // 泡っぽいグラデーション背景
-  background: linear-gradient(
-    145deg,
-    hsla(${({ colorHue }) => colorHue}, 60%, 70%, 0.6) 0%,
-    hsla(${({ colorHue }) => colorHue}, 50%, 60%, 0.5) 30%,
-    hsla(${({ colorHue }) => colorHue}, 45%, 55%, 0.45) 70%,
-    hsla(${({ colorHue }) => colorHue}, 55%, 65%, 0.55) 100%
-  );
+  // 通常モードは泡っぽいグラデーション背景、軽量モードは単色（アルファ合成コスト削減）
+  background: ${({ lightweightMode, colorHue }) => lightweightMode
+    ? `hsl(${colorHue}, 35%, 50%)`
+    : `linear-gradient(
+        145deg,
+        hsla(${colorHue}, 60%, 70%, 0.6) 0%,
+        hsla(${colorHue}, 50%, 60%, 0.5) 30%,
+        hsla(${colorHue}, 45%, 55%, 0.45) 70%,
+        hsla(${colorHue}, 55%, 65%, 0.55) 100%
+      )`
+  };
 
-  // 泡っぽいシャドウと光沢
-  box-shadow:
-    0 8px 32px hsla(${({ colorHue }) => colorHue}, 50%, 30%, 0.3),
-    0 2px 8px hsla(0, 0%, 0%, 0.1),
-    inset 0 2px 4px hsla(0, 0%, 100%, 0.4),
-    inset 0 -1px 2px hsla(${({ colorHue }) => colorHue}, 50%, 30%, 0.2);
+  box-shadow: ${({ lightweightMode, colorHue }) => lightweightMode
+    ? 'none'
+    : `0 8px 32px hsla(${colorHue}, 50%, 30%, 0.3),
+       0 2px 8px hsla(0, 0%, 0%, 0.1),
+       inset 0 2px 4px hsla(0, 0%, 100%, 0.4),
+       inset 0 -1px 2px hsla(${colorHue}, 50%, 30%, 0.2)`
+  };
 
   border: 1px solid hsla(0, 0%, 100%, 0.3);
   border-radius: ${({ hasLeftLink }) => hasLeftLink ? '0 24px 24px 0' : '24px'};

--- a/bublys-libs/bubbles-ui/src/lib/ui/BubbleView.tsx
+++ b/bublys-libs/bubbles-ui/src/lib/ui/BubbleView.tsx
@@ -1,4 +1,4 @@
-import { FC, useMemo, useState, useContext, useLayoutEffect, memo } from "react";
+import { FC, useMemo, useState, useContext, useLayoutEffect, memo, useCallback } from "react";
 import styled from "styled-components";
 import { Bubble } from "../Bubble.domain.js";
 import { Point2, Vec2, CoordinateSystem, SmartRect, Layer } from "@bublys-org/bubbles-ui-util";
@@ -12,6 +12,7 @@ import { useBubbleRefsOptional } from "../context/BubbleRefsContext.js";
 import { measureViewport } from "../utils/measure-viewport.js";
 import { useUniverseId } from "../context/UniverseContext.js";
 import { CloseIcon, ToggleSizeIcon, LayerUpIcon, LayerDownIcon } from "./BubbleIcons.js";
+import { BubbleSkeleton } from "./BubbleSkeleton.js";
 
 /**
  * 長いslug（UUIDなど）を省略表示する
@@ -194,6 +195,10 @@ const BubbleViewInner: FC<BubbleProps> = ({
     setIsFocused(false);
   };
 
+  const handleFocus = useCallback(() => {
+    setIsFocused(true);
+  }, []);
+
   // DOM参照をContextに登録
   useLayoutEffect(() => {
     if (ref.current && bubbleRefs) {
@@ -216,6 +221,7 @@ const BubbleViewInner: FC<BubbleProps> = ({
       layerIndex={layerIndex}
       transformOrigin={vanishingPointRelative}
       onClick={onClick}
+      onFocus={handleFocus}
       onMouseLeave={handleMouseLeave}
       onTransitionEnd={() => {
         notifyRendered();
@@ -286,7 +292,7 @@ const BubbleViewInner: FC<BubbleProps> = ({
       </header>
 
       <main className="e-bubble-content">
-        {children}<br />
+        {(layerIndex ?? 0) >= 3 && !isFocused ? <BubbleSkeleton bubble={bubble} /> : children}<br />
       </main>
 
       {/* 右下リサイズハンドル — ユーザーがサイズを決められる状態への入り口 */}

--- a/bublys-libs/bubbles-ui/src/lib/ui/BubbleView.tsx
+++ b/bublys-libs/bubbles-ui/src/lib/ui/BubbleView.tsx
@@ -11,60 +11,7 @@ import { BubblesContext } from "../bubble-routing/BubbleRouting.js";
 import { useBubbleRefsOptional } from "../context/BubbleRefsContext.js";
 import { measureViewport } from "../utils/measure-viewport.js";
 import { useUniverseId } from "../context/UniverseContext.js";
-
-/**
- * 泡っぽい閉じるボタンのSVGアイコン
- */
-const CloseIcon: FC<{ size?: number }> = ({ size = 18 }) => (
-  <svg width={size} height={size} viewBox="0 0 24 24" fill="none">
-    <circle cx="12" cy="12" r="10" fill="currentColor" fillOpacity="0.15" />
-    <path
-      d="M8 8L16 16M16 8L8 16"
-      stroke="currentColor"
-      strokeWidth="2"
-      strokeLinecap="round"
-    />
-  </svg>
-);
-
-/**
- * 最大化/縮小トグルボタンのSVGアイコン
- */
-const ToggleSizeIcon: FC<{ size?: number; isMaximized: boolean }> = ({ size = 18, isMaximized }) => (
-  <svg width={size} height={size} viewBox="0 0 24 24" fill="none">
-    <circle cx="12" cy="12" r="10" fill="currentColor" fillOpacity="0.15" />
-    {isMaximized ? (
-      // 縮小アイコン（内向き矢印）
-      <>
-        <path d="M8 8L10 10M16 16L14 14" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
-        <path d="M16 8L14 10M8 16L10 14" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
-      </>
-    ) : (
-      // 最大化アイコン（四角）
-      <rect x="7" y="7" width="10" height="10" rx="1" stroke="currentColor" strokeWidth="1.5" />
-    )}
-  </svg>
-);
-
-/**
- * レイヤー手前へ移動（上向き矢印）
- */
-const LayerUpIcon: FC<{ size?: number }> = ({ size = 18 }) => (
-  <svg width={size} height={size} viewBox="0 0 24 24" fill="none">
-    <circle cx="12" cy="12" r="10" fill="currentColor" fillOpacity="0.15" />
-    <path d="M8 14L12 9L16 14" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
-  </svg>
-);
-
-/**
- * レイヤー奥へ移動（下向き矢印）
- */
-const LayerDownIcon: FC<{ size?: number }> = ({ size = 18 }) => (
-  <svg width={size} height={size} viewBox="0 0 24 24" fill="none">
-    <circle cx="12" cy="12" r="10" fill="currentColor" fillOpacity="0.15" />
-    <path d="M8 10L12 15L16 10" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
-  </svg>
-);
+import { CloseIcon, ToggleSizeIcon, LayerUpIcon, LayerDownIcon } from "./BubbleIcons.js";
 
 /**
  * 長いslug（UUIDなど）を省略表示する

--- a/bublys-libs/bubbles-ui/src/lib/ui/BubbleView.tsx
+++ b/bublys-libs/bubbles-ui/src/lib/ui/BubbleView.tsx
@@ -147,7 +147,6 @@ type BubbleProps = {
   onClick?: (e: React.MouseEvent<HTMLDivElement>) => void; // クリックイベントハンドラ
   onCloseClick?: (bubble: Bubble) => void;
   onMove?: (bubble: Bubble) => void;
-  onDragActivity?: () => void; // ドラッグ中・終了時に呼ばれる（deferred timer リセット用）
   onLayerDownClick?: (bubble: Bubble) => void;
   onLayerUpClick?: (bubble: Bubble) => void;
   onResize?: (bubble: Bubble) => void;
@@ -171,7 +170,6 @@ const BubbleViewInner: FC<BubbleProps> = ({
   onLayerDownClick,
   onLayerUpClick,
   onMove,
-  onDragActivity,
   onResize,
   onDebugRects,
 }) => {
@@ -197,7 +195,7 @@ const BubbleViewInner: FC<BubbleProps> = ({
     }
   });
 
-  const { onDragStart } = useBubbleDrag({ bubble, ref, layerIndex, vanishingPoint, onDragActivity });
+  const { onDragStart } = useBubbleDrag({ bubble, ref, layerIndex, vanishingPoint });
   const { onResizeStart } = useBubbleResize({ bubble, ref });
 
   const [isFocused, setIsFocused] = useState(false);
@@ -265,10 +263,10 @@ const BubbleViewInner: FC<BubbleProps> = ({
     <StyledBubble
       ref={ref}
       data-bubble-id={bubble.id}
+      style={{ left: position ? `${position.x}px` : 0, top: position ? `${position.y}px` : 0 }}
       colorHue={bubble.colorHue}
       zIndex={isFocused ? 100 : zIndex}
       layerIndex={layerIndex}
-      position={position}
       transformOrigin={vanishingPointRelative}
       onClick={onClick}
       onMouseLeave={handleMouseLeave}
@@ -401,7 +399,6 @@ export const BubbleView = memo(BubbleViewInner, (prevProps, nextProps) => {
 
 //div のpropsに合わせて
 type StyledBubbleProp = React.HTMLAttributes<HTMLDivElement> & {
-  position?: Point2; // 位置を指定するためのオプション
   layerIndex?: number; // レイヤーのインデックス = zIndex * -1
   zIndex?: number; // = - layerIndex
 
@@ -429,9 +426,6 @@ const StyledBubble = styled.div<StyledBubbleProp>`
   height: ${({ height }) => (height ? height : "auto")};
 
   z-index: ${({ zIndex }) => (zIndex !== undefined ? zIndex : 0)};
-
-  left: ${({ position }) => (position ? `${position.x}px` : "0")};
-  top: ${({ position }) => (position ? `${position.y}px` : "0")};
 
   transition-property: left top transform;
   transition: ${({ lightweightMode }) => lightweightMode ? 'none' : '0.3s ease-in-out'};
@@ -475,9 +469,9 @@ const StyledBubble = styled.div<StyledBubbleProp>`
   display: flex;
   flex-direction: column;
 
-  // ガラスのような光沢エフェクト（疑似要素）
+  // ガラスのような光沢エフェクト（疑似要素）— 軽量モードでは非表示
   &::before {
-    content: '';
+    content: ${({ lightweightMode }) => lightweightMode ? 'none' : "''"} ;
     position: absolute;
     top: 0;
     left: 0;
@@ -563,11 +557,10 @@ const StyledBubble = styled.div<StyledBubbleProp>`
 
     .e-bubble-name {
       flex: 1;
-      background: linear-gradient(
-        135deg,
-        hsla(0, 0%, 100%, 0.5) 0%,
-        hsla(0, 0%, 100%, 0.3) 100%
-      );
+      background: ${({ lightweightMode }) => lightweightMode
+        ? 'hsla(0, 0%, 100%, 0.3)'
+        : 'linear-gradient(135deg, hsla(0, 0%, 100%, 0.5) 0%, hsla(0, 0%, 100%, 0.3) 100%)'
+      };
       padding: 6px 16px;
       border-radius: 16px;
       font-size: 1em;
@@ -575,7 +568,7 @@ const StyledBubble = styled.div<StyledBubbleProp>`
       text-align: center;
       margin: 0;
       color: hsla(0, 0%, 20%, 0.9);
-      box-shadow: inset 0 1px 2px hsla(0, 0%, 100%, 0.5);
+      box-shadow: ${({ lightweightMode }) => lightweightMode ? 'none' : 'inset 0 1px 2px hsla(0, 0%, 100%, 0.5)'};
     }
 
     .e-address-bar {
@@ -691,16 +684,21 @@ const StyledBubble = styled.div<StyledBubbleProp>`
     overflow: ${({ fillsContainer }) => (fillsContainer ? "hidden" : "auto")};
     padding: 16px;
     font-size: 1em;
-    background: linear-gradient(
-      180deg,
-      ${({ contentBackground }) => contentBackground || "hsla(0, 0%, 100%, 0.95)"} 0%,
-      ${({ contentBackground }) => contentBackground || "hsla(0, 0%, 98%, 0.9)"} 100%
-    );
+    background: ${({ lightweightMode, contentBackground }) => lightweightMode
+      ? (contentBackground || 'hsla(0, 0%, 100%, 0.95)')
+      : `linear-gradient(
+          180deg,
+          ${contentBackground || 'hsla(0, 0%, 100%, 0.95)'} 0%,
+          ${contentBackground || 'hsla(0, 0%, 98%, 0.9)'} 100%
+        )`
+    };
     border-radius: 16px;
     margin: 0 12px 12px;
-    box-shadow:
-      inset 0 2px 4px hsla(0, 0%, 0%, 0.05),
-      0 1px 2px hsla(0, 0%, 100%, 0.5);
+    box-shadow: ${({ lightweightMode }) => lightweightMode
+      ? 'none'
+      : `inset 0 2px 4px hsla(0, 0%, 0%, 0.05),
+         0 1px 2px hsla(0, 0%, 100%, 0.5)`
+    };
   }
 
   >.e-debug-rect {

--- a/bublys-libs/bubbles-ui/src/lib/ui/BubbleView.tsx
+++ b/bublys-libs/bubbles-ui/src/lib/ui/BubbleView.tsx
@@ -147,6 +147,7 @@ type BubbleProps = {
   onClick?: (e: React.MouseEvent<HTMLDivElement>) => void; // クリックイベントハンドラ
   onCloseClick?: (bubble: Bubble) => void;
   onMove?: (bubble: Bubble) => void;
+  onDragActivity?: () => void; // ドラッグ中・終了時に呼ばれる（deferred timer リセット用）
   onLayerDownClick?: (bubble: Bubble) => void;
   onLayerUpClick?: (bubble: Bubble) => void;
   onResize?: (bubble: Bubble) => void;
@@ -170,6 +171,7 @@ const BubbleViewInner: FC<BubbleProps> = ({
   onLayerDownClick,
   onLayerUpClick,
   onMove,
+  onDragActivity,
   onResize,
   onDebugRects,
 }) => {
@@ -195,7 +197,7 @@ const BubbleViewInner: FC<BubbleProps> = ({
     }
   });
 
-  const { onDragStart } = useBubbleDrag({ bubble, ref, layerIndex, vanishingPoint });
+  const { onDragStart } = useBubbleDrag({ bubble, ref, layerIndex, vanishingPoint, onDragActivity });
   const { onResizeStart } = useBubbleResize({ bubble, ref });
 
   const [isFocused, setIsFocused] = useState(false);

--- a/bublys-libs/bubbles-ui/src/lib/ui/BubblesLayeredView.tsx
+++ b/bublys-libs/bubbles-ui/src/lib/ui/BubblesLayeredView.tsx
@@ -1,4 +1,4 @@
-import React, { FC, ReactNode, useEffect, useRef, useLayoutEffect, memo, useMemo, useState, useCallback } from "react";
+import React, { FC, ReactNode, useEffect, useRef, useLayoutEffect, memo, useMemo, useState } from "react";
 import styled from "styled-components";
 import { useAppSelector, useAppDispatch, selectLightweightMode, toggleLightweightMode } from "@bublys-org/state-management";
 import { Bubble } from "../Bubble.domain.js";
@@ -19,130 +19,14 @@ import {
   ROOT_UNIVERSE_ID,
 } from "../state/index.js";
 
-/** 背面バブルを遅延描画に切り替えるまでの非アクティブ時間 (ms) */
-const DEFERRED_AFTER_MS = 1 * 60 * 1000; // 5分
-
-/**
- * 遅延描画の判定とアクティベートを担う内部コンポーネント。
- * lastActiveAt (タイムスタンプ) と Date.now() を比較し、
- * DEFERRED_AFTER_MS 以上非アクティブな背面バブルをスケルトン化する。
- */
-type DeferredBubbleGuardProps = {
-  layerIndex: number;
-  zIndex: number;
-  vanishingPoint: Point2;
-  bubble: Bubble;
-  pos: Point2;
-  hasLeftLink?: boolean;
-  lightweightMode?: boolean;
-  renderBubbleContent: (bubble: Bubble) => ReactNode;
-  onBubbleClick?: (name: string) => void;
-  onBubbleClose?: (bubble: Bubble) => void;
-  onBubbleMove?: (bubble: Bubble) => void;
-  onBubbleResize?: (bubble: Bubble) => void;
-  onBubbleLayerDown?: (bubble: Bubble) => void;
-  onBubbleLayerUp?: (bubble: Bubble) => void;
-  onDebugRects?: (rects: SmartRect[]) => void;
-};
-
-const DeferredBubbleGuard: FC<DeferredBubbleGuardProps> = memo(function DeferredBubbleGuard({
-  layerIndex,
-  zIndex,
-  vanishingPoint,
-  bubble,
-  pos,
-  hasLeftLink,
-  lightweightMode,
-  renderBubbleContent,
-  onBubbleClick,
-  onBubbleClose,
-  onBubbleMove,
-  onBubbleResize,
-  onBubbleLayerDown,
-  onBubbleLayerUp,
-  onDebugRects,
-}) {
-  // 背面に入った瞬間からタイマーを起動し、DEFERRED_AFTER_MS 後にスケルトン化する。
-  // layerIndex が変わるたびにタイマーをリセット（前面復帰で即フル表示）。
-  const [isDeferred, setIsDeferred] = useState(false);
-  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-
-  useEffect(() => {
-    setIsDeferred(false);
-    if (timerRef.current) clearTimeout(timerRef.current);
-    if (layerIndex > 0) {
-      timerRef.current = setTimeout(() => setIsDeferred(true), DEFERRED_AFTER_MS);
-    } else {
-      timerRef.current = null;
-    }
-    return () => {
-      if (timerRef.current) clearTimeout(timerRef.current);
-    };
-  }, [layerIndex]);
-
-  // ユーザーが明示的に背面バブルを操作したらタイマーをリセット（猶予を延長）
-  const handleActivate = useCallback(() => {
-    setIsDeferred(false);
-    if (timerRef.current) clearTimeout(timerRef.current);
-    timerRef.current = setTimeout(() => setIsDeferred(true), DEFERRED_AFTER_MS);
-  }, []);
-
-  // isDeferred / bubble が変わらない限り content を安定させる
-  const content = useMemo(
-    () => isDeferred ? <BubbleSkeleton bubble={bubble} /> : renderBubbleContent(bubble),
-    [isDeferred, bubble, renderBubbleContent],
-  );
-
-  if (bubble.fillsContainer) {
-    return (
-      <UniverseBubbleView
-        bubble={bubble}
-        position={pos}
-        layerIndex={layerIndex}
-        zIndex={zIndex}
-        vanishingPoint={vanishingPoint}
-        lightweightMode={lightweightMode}
-        onClick={(e) => { handleActivate(); onBubbleClick?.(bubble.url); }}
-        onCloseClick={() => { handleActivate(); onBubbleClose?.(bubble); }}
-        onDragActivity={handleActivate}
-        onResize={(updated) => { handleActivate(); onBubbleResize?.(updated); }}
-        onLayerDownClick={() => onBubbleLayerDown?.(bubble)}
-        onLayerUpClick={() => { handleActivate(); onBubbleLayerUp?.(bubble); }}
-        onDebugRects={onDebugRects}
-      >
-        {content}
-      </UniverseBubbleView>
-    );
-  }
-
-  return (
-    <BubbleView
-      bubble={bubble}
-      position={pos}
-      layerIndex={layerIndex}
-      zIndex={zIndex}
-      vanishingPoint={vanishingPoint}
-      contentBackground={bubble.contentBackground ?? "white"}
-      hasLeftLink={hasLeftLink}
-      lightweightMode={lightweightMode}
-      onClick={(e) => { handleActivate(); onBubbleClick?.(bubble.url); }}
-      onCloseClick={() => { handleActivate(); onBubbleClose?.(bubble); }}
-      onMove={(updated) => { onBubbleMove?.(updated); }}
-      onDragActivity={handleActivate}
-      onResize={(updated) => { handleActivate(); onBubbleResize?.(updated); }}
-      onLayerDownClick={() => onBubbleLayerDown?.(bubble)}
-      onLayerUpClick={() => { handleActivate(); onBubbleLayerUp?.(bubble); }}
-      onDebugRects={onDebugRects}
-    >
-      {content}
-    </BubbleView>
-  );
-});
-
 /**
  * 個別バブルを自分でReduxから取得するラッパーコンポーネント。
  * per-bubble selector のみを購読し、world-line 操作では再 render しない。
- * 遅延描画の判定は DeferredBubbleGuard に委譲する。
+ *
+ * layerIndex >= 3 のバブルは scale 0.8 以下となり内容が読めないため、
+ * コンテンツを BubbleSkeleton（見出しのみ）に差し替えてレンダリングコストを削減する。
+ * layer 0〜2 はコンテンツをそのまま維持するため、popChild 直後の親バブルは
+ * 引き続き参照できる。
  */
 type ConnectedBubbleViewProps = {
   universeId: string;
@@ -189,24 +73,52 @@ const ConnectedBubbleView: FC<ConnectedBubbleViewProps> = memo(function Connecte
   // bubble.position は layer-local 座標。surface レイヤーで universe 座標へ写す
   const pos = surfaceLayer.place(bubble.position || { x: 0, y: 0 });
 
+  // layer 3+ (scale ≤ 0.8) は内容が読めないためスケルトン表示に切り替える
+  const content = layerIndex >= 3
+    ? <BubbleSkeleton bubble={bubble} />
+    : renderBubbleContent(bubble);
+
+  if (bubble.fillsContainer) {
+    return (
+      <UniverseBubbleView
+        bubble={bubble}
+        position={pos}
+        layerIndex={layerIndex}
+        zIndex={zIndex}
+        vanishingPoint={vanishingPoint}
+        lightweightMode={lightweightMode}
+        onClick={() => onBubbleClick?.(bubble.url)}
+        onCloseClick={() => onBubbleClose?.(bubble)}
+        onResize={(updated) => onBubbleResize?.(updated)}
+        onLayerDownClick={() => onBubbleLayerDown?.(bubble)}
+        onLayerUpClick={() => onBubbleLayerUp?.(bubble)}
+        onDebugRects={onDebugRects}
+      >
+        {content}
+      </UniverseBubbleView>
+    );
+  }
+
   return (
-    <DeferredBubbleGuard
+    <BubbleView
+      bubble={bubble}
+      position={pos}
       layerIndex={layerIndex}
       zIndex={zIndex}
       vanishingPoint={vanishingPoint}
-      bubble={bubble}
-      pos={pos}
+      contentBackground={bubble.contentBackground ?? "white"}
       hasLeftLink={hasLeftLink}
       lightweightMode={lightweightMode}
-      renderBubbleContent={renderBubbleContent}
-      onBubbleClick={onBubbleClick}
-      onBubbleClose={onBubbleClose}
-      onBubbleMove={onBubbleMove}
-      onBubbleResize={onBubbleResize}
-      onBubbleLayerDown={onBubbleLayerDown}
-      onBubbleLayerUp={onBubbleLayerUp}
+      onClick={() => onBubbleClick?.(bubble.url)}
+      onCloseClick={() => onBubbleClose?.(bubble)}
+      onMove={(updated) => onBubbleMove?.(updated)}
+      onResize={(updated) => onBubbleResize?.(updated)}
+      onLayerDownClick={() => onBubbleLayerDown?.(bubble)}
+      onLayerUpClick={() => onBubbleLayerUp?.(bubble)}
       onDebugRects={onDebugRects}
-    />
+    >
+      {content}
+    </BubbleView>
   );
 });
 

--- a/bublys-libs/bubbles-ui/src/lib/ui/BubblesLayeredView.tsx
+++ b/bublys-libs/bubbles-ui/src/lib/ui/BubblesLayeredView.tsx
@@ -1,4 +1,4 @@
-import React, { FC, ReactNode, useEffect, useReducer, useRef, useLayoutEffect, memo, useMemo, useState, useCallback } from "react";
+import React, { FC, ReactNode, useEffect, useRef, useLayoutEffect, memo, useMemo, useState, useCallback } from "react";
 import styled from "styled-components";
 import { useAppSelector, useAppDispatch, selectLightweightMode, toggleLightweightMode } from "@bublys-org/state-management";
 import { Bubble } from "../Bubble.domain.js";
@@ -16,8 +16,6 @@ import {
   makeSelectUniverseDimensions,
   selectIsLayerAnimating,
   makeSelectBubbleByIdInUniverse,
-  makeSelectBubbleLastActiveAt,
-  activateBubble,
   ROOT_UNIVERSE_ID,
 } from "../state/index.js";
 
@@ -30,8 +28,6 @@ const DEFERRED_AFTER_MS = 1 * 60 * 1000; // 5分
  * DEFERRED_AFTER_MS 以上非アクティブな背面バブルをスケルトン化する。
  */
 type DeferredBubbleGuardProps = {
-  universeId: string;
-  bubbleId: string;
   layerIndex: number;
   zIndex: number;
   vanishingPoint: Point2;
@@ -50,8 +46,6 @@ type DeferredBubbleGuardProps = {
 };
 
 const DeferredBubbleGuard: FC<DeferredBubbleGuardProps> = memo(function DeferredBubbleGuard({
-  universeId,
-  bubbleId,
   layerIndex,
   zIndex,
   vanishingPoint,
@@ -68,31 +62,30 @@ const DeferredBubbleGuard: FC<DeferredBubbleGuardProps> = memo(function Deferred
   onBubbleLayerUp,
   onDebugRects,
 }) {
-  const dispatch = useAppDispatch();
+  // 背面に入った瞬間からタイマーを起動し、DEFERRED_AFTER_MS 後にスケルトン化する。
+  // layerIndex が変わるたびにタイマーをリセット（前面復帰で即フル表示）。
+  const [isDeferred, setIsDeferred] = useState(false);
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
-  // per-bubble セレクター: 他バブルの activate では再レンダーしない（プリミティブ比較）
-  const selectLastActiveAt = useMemo(
-    () => makeSelectBubbleLastActiveAt(universeId, bubbleId),
-    [universeId, bubbleId],
-  );
-  const lastActiveAt = useAppSelector(selectLastActiveAt);
-
-  // lastActiveAt === 0 は「まだ一度も明示的にアクティブにされていない」= defer しない
-  const isDeferred = layerIndex > 0 && lastActiveAt > 0 && (Date.now() - lastActiveAt) > DEFERRED_AFTER_MS;
-
-  // deferred に切り替わるべき時刻に自分だけ再レンダーする（全バブルの cascade を避ける）
-  const [, forceUpdate] = useReducer((n: number) => n + 1, 0);
   useEffect(() => {
-    if (layerIndex === 0 || lastActiveAt === 0) return;
-    const elapsed = Date.now() - lastActiveAt;
-    if (elapsed >= DEFERRED_AFTER_MS) return; // すでに deferred 対象
-    const id = setTimeout(forceUpdate, DEFERRED_AFTER_MS - elapsed + 100);
-    return () => clearTimeout(id);
-  }, [layerIndex, lastActiveAt]);
+    setIsDeferred(false);
+    if (timerRef.current) clearTimeout(timerRef.current);
+    if (layerIndex > 0) {
+      timerRef.current = setTimeout(() => setIsDeferred(true), DEFERRED_AFTER_MS);
+    } else {
+      timerRef.current = null;
+    }
+    return () => {
+      if (timerRef.current) clearTimeout(timerRef.current);
+    };
+  }, [layerIndex]);
 
+  // ユーザーが明示的に背面バブルを操作したらタイマーをリセット（猶予を延長）
   const handleActivate = useCallback(() => {
-    dispatch(activateBubble({ bubbleId, timestamp: Date.now() }, universeId));
-  }, [dispatch, bubbleId, universeId]);
+    setIsDeferred(false);
+    if (timerRef.current) clearTimeout(timerRef.current);
+    timerRef.current = setTimeout(() => setIsDeferred(true), DEFERRED_AFTER_MS);
+  }, []);
 
   // isDeferred / bubble が変わらない限り content を安定させる
   const content = useMemo(
@@ -196,8 +189,6 @@ const ConnectedBubbleView: FC<ConnectedBubbleViewProps> = memo(function Connecte
 
   return (
     <DeferredBubbleGuard
-      universeId={universeId}
-      bubbleId={bubbleId}
       layerIndex={layerIndex}
       zIndex={zIndex}
       vanishingPoint={vanishingPoint}

--- a/bublys-libs/bubbles-ui/src/lib/ui/BubblesLayeredView.tsx
+++ b/bublys-libs/bubbles-ui/src/lib/ui/BubblesLayeredView.tsx
@@ -1,4 +1,4 @@
-import React, { FC, ReactNode, useEffect, useRef, useLayoutEffect, memo, useMemo, useState } from "react";
+import React, { FC, ReactNode, useEffect, useRef, useLayoutEffect, memo, useMemo, useCallback, useState } from "react";
 import styled from "styled-components";
 import { useAppSelector, useAppDispatch, selectLightweightMode, toggleLightweightMode } from "@bublys-org/state-management";
 import { Bubble } from "../Bubble.domain.js";
@@ -180,7 +180,7 @@ const defaultRenderBubbleContent = (bubble: Bubble): ReactNode => (
   <BubbleContent bubble={bubble} />
 );
 
-export const BubblesLayeredView: FC<BubblesLayeredViewProps> = ({
+const BubblesLayeredViewInner: FC<BubblesLayeredViewProps> = ({
   bubbleLayers,
   universeId = ROOT_UNIVERSE_ID,
   vanishingPoint,
@@ -359,10 +359,10 @@ export const BubblesLayeredView: FC<BubblesLayeredViewProps> = ({
   const isLayerAnimating = useAppSelector(selectIsLayerAnimating);
   const lightweightMode = useAppSelector(selectLightweightMode);
 
-  const undergroundVanishingPoint: Point2 = vanishingPoint || {
-    x: 20,
-    y: 10,
-  };
+  const undergroundVanishingPoint: Point2 = useMemo(
+    () => vanishingPoint || { x: 20, y: 10 },
+    [vanishingPoint],
+  );
 
   const baseZIndex = 100;
 
@@ -387,38 +387,87 @@ export const BubblesLayeredView: FC<BubblesLayeredViewProps> = ({
     [surfaceLeftTop, coordinateSystem],
   );
 
-  const renderedBubbles = bubbleLayers
-    .map((layer, layerIndex) =>
-      layer.map((bubbleId) => {
-        const zIndex = baseZIndex - layerIndex;
-        const hasLeftLink = openeeIds.has(bubbleId);
+  const stableOnBubbleClick = useCallback(
+    (name: string) => onBubbleClick?.(name),
+    [onBubbleClick],
+  );
+  const stableOnBubbleClose = useCallback(
+    (bubble: Bubble) => onBubbleClose?.(bubble),
+    [onBubbleClose],
+  );
+  const stableOnBubbleMove = useCallback(
+    (bubble: Bubble) => onBubbleMove?.(bubble),
+    [onBubbleMove],
+  );
+  const stableOnBubbleResize = useCallback(
+    (bubble: Bubble) => onBubbleResize?.(bubble),
+    [onBubbleResize],
+  );
+  const stableOnBubbleLayerDown = useCallback(
+    (bubble: Bubble) => onBubbleLayerDown?.(bubble),
+    [onBubbleLayerDown],
+  );
+  const stableOnBubbleLayerUp = useCallback(
+    (bubble: Bubble) => onBubbleLayerUp?.(bubble),
+    [onBubbleLayerUp],
+  );
+  const stableOnDebugRects = useCallback(
+    (rects: SmartRect[]) => onDebugRects?.(rects),
+    [onDebugRects],
+  );
 
-        return (
-          <ConnectedBubbleView
-            key={bubbleId}
-            universeId={universeId}
-            bubbleId={bubbleId}
-            layerIndex={layerIndex}
-            zIndex={zIndex}
-            vanishingPoint={undergroundVanishingPoint}
-            surfaceLayer={surfaceLayer}
-            hasLeftLink={hasLeftLink}
-            lightweightMode={lightweightMode}
-            renderBubbleContent={renderBubbleContent}
-            onBubbleClick={onBubbleClick}
-            onBubbleClose={onBubbleClose}
-            onBubbleMove={onBubbleMove}
-            onBubbleResize={onBubbleResize}
-            onBubbleLayerDown={onBubbleLayerDown}
-            onBubbleLayerUp={onBubbleLayerUp}
-            onDebugRects={onDebugRects}
-          />
-        );
-      })
-    )
-    .flat();
+  const renderedBubbles = useMemo(
+    () =>
+      bubbleLayers
+        .map((layer, layerIndex) =>
+          layer.map((bubbleId) => {
+            const zIndex = baseZIndex - layerIndex;
+            const hasLeftLink = openeeIds.has(bubbleId);
+
+            return (
+              <ConnectedBubbleView
+                key={bubbleId}
+                universeId={universeId}
+                bubbleId={bubbleId}
+                layerIndex={layerIndex}
+                zIndex={zIndex}
+                vanishingPoint={undergroundVanishingPoint}
+                surfaceLayer={surfaceLayer}
+                hasLeftLink={hasLeftLink}
+                lightweightMode={lightweightMode}
+                renderBubbleContent={renderBubbleContent}
+                onBubbleClick={stableOnBubbleClick}
+                onBubbleClose={stableOnBubbleClose}
+                onBubbleMove={stableOnBubbleMove}
+                onBubbleResize={stableOnBubbleResize}
+                onBubbleLayerDown={stableOnBubbleLayerDown}
+                onBubbleLayerUp={stableOnBubbleLayerUp}
+                onDebugRects={stableOnDebugRects}
+              />
+            );
+          })
+        )
+        .flat(),
+    [
+      bubbleLayers,
+      openeeIds,
+      surfaceLayer,
+      lightweightMode,
+      universeId,
+      undergroundVanishingPoint,
+      renderBubbleContent,
+      stableOnBubbleClick,
+      stableOnBubbleClose,
+      stableOnBubbleMove,
+      stableOnBubbleResize,
+      stableOnBubbleLayerDown,
+      stableOnBubbleLayerUp,
+      stableOnDebugRects,
+    ],
+  );
 
   const universeContextValue = useMemo(() => ({ universeId, universeRef }), [universeId]);
+  const hudSurface = useMemo(() => ({ leftTop: surfaceLeftTop }), [surfaceLeftTop]);
 
   const isNested = universeId !== ROOT_UNIVERSE_ID;
   const universeSize = useAppSelector(makeSelectUniverseDimensions(universeId));
@@ -456,7 +505,7 @@ export const BubblesLayeredView: FC<BubblesLayeredViewProps> = ({
         </StyledViewport>
 
         <StyledHeadsUpDisplay
-          surface={{ leftTop: surfaceLeftTop }}
+          surface={hudSurface}
           surfaceZIndex={baseZIndex - 2}
         >
           <div className="e-underground-curtain"></div>
@@ -482,6 +531,8 @@ export const BubblesLayeredView: FC<BubblesLayeredViewProps> = ({
   );
 };
 
+
+export const BubblesLayeredView = memo(BubblesLayeredViewInner);
 
 type DivProps = React.HTMLAttributes<HTMLDivElement>;
 type DivPropsWithRef = DivProps & { ref: React.RefObject<HTMLDivElement | null> };

--- a/bublys-libs/bubbles-ui/src/lib/ui/BubblesLayeredView.tsx
+++ b/bublys-libs/bubbles-ui/src/lib/ui/BubblesLayeredView.tsx
@@ -7,7 +7,6 @@ import { BubbleView } from "./BubbleView.js";
 import { UniverseBubbleView } from "./UniverseBubbleView.js";
 import { LinkBubbleView } from "./LinkBubbleView.js";
 import { BubbleContent } from "./BubbleContent.js";
-import { BubbleSkeleton } from "./BubbleSkeleton.js";
 import { UniverseContext } from "../context/UniverseContext.js";
 import {
   makeSelectValidBubbleRelationIds,
@@ -23,10 +22,9 @@ import {
  * 個別バブルを自分でReduxから取得するラッパーコンポーネント。
  * per-bubble selector のみを購読し、world-line 操作では再 render しない。
  *
- * layerIndex >= 3 のバブルは scale 0.8 以下となり内容が読めないため、
- * コンテンツを BubbleSkeleton（見出しのみ）に差し替えてレンダリングコストを削減する。
- * layer 0〜2 はコンテンツをそのまま維持するため、popChild 直後の親バブルは
- * 引き続き参照できる。
+ * layerIndex >= 3 のバブルは scale 0.8 以下となり内容が読めないため BubbleSkeleton で表示する。
+ * ただしフォーカス時（ヘッダークリック・キーボードフォーカス）はスケルトンを解除してフルコンテンツを表示する。
+ * このスケルトン切り替えは BubbleView の内部状態（isFocused）で管理される。
  */
 type ConnectedBubbleViewProps = {
   universeId: string;
@@ -73,10 +71,7 @@ const ConnectedBubbleView: FC<ConnectedBubbleViewProps> = memo(function Connecte
   // bubble.position は layer-local 座標。surface レイヤーで universe 座標へ写す
   const pos = surfaceLayer.place(bubble.position || { x: 0, y: 0 });
 
-  // layer 3+ (scale ≤ 0.8) は内容が読めないためスケルトン表示に切り替える
-  const content = layerIndex >= 3
-    ? <BubbleSkeleton bubble={bubble} />
-    : renderBubbleContent(bubble);
+  const content = renderBubbleContent(bubble);
 
   if (bubble.fillsContainer) {
     return (

--- a/bublys-libs/bubbles-ui/src/lib/ui/BubblesLayeredView.tsx
+++ b/bublys-libs/bubbles-ui/src/lib/ui/BubblesLayeredView.tsx
@@ -1,12 +1,13 @@
-import React, { FC, ReactNode, useEffect, useRef, useLayoutEffect, memo, useMemo, useState } from "react";
+import React, { FC, ReactNode, useEffect, useReducer, useRef, useLayoutEffect, memo, useMemo, useState, useCallback } from "react";
 import styled from "styled-components";
-import { useAppSelector } from "@bublys-org/state-management";
+import { useAppSelector, useAppDispatch, selectLightweightMode, toggleLightweightMode } from "@bublys-org/state-management";
 import { Bubble } from "../Bubble.domain.js";
 import { Point2, Layer, CoordinateSystem, SmartRect } from "@bublys-org/bubbles-ui-util";
 import { BubbleView } from "./BubbleView.js";
 import { UniverseBubbleView } from "./UniverseBubbleView.js";
 import { LinkBubbleView } from "./LinkBubbleView.js";
 import { BubbleContent } from "./BubbleContent.js";
+import { BubbleSkeleton } from "./BubbleSkeleton.js";
 import { UniverseContext } from "../context/UniverseContext.js";
 import {
   makeSelectValidBubbleRelationIds,
@@ -15,11 +16,138 @@ import {
   makeSelectUniverseDimensions,
   selectIsLayerAnimating,
   makeSelectBubbleByIdInUniverse,
+  makeSelectBubbleLastActiveAt,
+  activateBubble,
   ROOT_UNIVERSE_ID,
 } from "../state/index.js";
 
+/** 背面バブルを遅延描画に切り替えるまでの非アクティブ時間 (ms) */
+const DEFERRED_AFTER_MS = 1 * 60 * 1000; // 5分
+
 /**
- * 個別バブルを自分でReduxから取得するラッパーコンポーネント
+ * 遅延描画の判定とアクティベートを担う内部コンポーネント。
+ * lastActiveAt (タイムスタンプ) と Date.now() を比較し、
+ * DEFERRED_AFTER_MS 以上非アクティブな背面バブルをスケルトン化する。
+ */
+type DeferredBubbleGuardProps = {
+  universeId: string;
+  bubbleId: string;
+  layerIndex: number;
+  zIndex: number;
+  vanishingPoint: Point2;
+  bubble: Bubble;
+  pos: Point2;
+  hasLeftLink?: boolean;
+  lightweightMode?: boolean;
+  renderBubbleContent: (bubble: Bubble) => ReactNode;
+  onBubbleClick?: (name: string) => void;
+  onBubbleClose?: (bubble: Bubble) => void;
+  onBubbleMove?: (bubble: Bubble) => void;
+  onBubbleResize?: (bubble: Bubble) => void;
+  onBubbleLayerDown?: (bubble: Bubble) => void;
+  onBubbleLayerUp?: (bubble: Bubble) => void;
+  onDebugRects?: (rects: SmartRect[]) => void;
+};
+
+const DeferredBubbleGuard: FC<DeferredBubbleGuardProps> = memo(function DeferredBubbleGuard({
+  universeId,
+  bubbleId,
+  layerIndex,
+  zIndex,
+  vanishingPoint,
+  bubble,
+  pos,
+  hasLeftLink,
+  lightweightMode,
+  renderBubbleContent,
+  onBubbleClick,
+  onBubbleClose,
+  onBubbleMove,
+  onBubbleResize,
+  onBubbleLayerDown,
+  onBubbleLayerUp,
+  onDebugRects,
+}) {
+  const dispatch = useAppDispatch();
+
+  // per-bubble セレクター: 他バブルの activate では再レンダーしない（プリミティブ比較）
+  const selectLastActiveAt = useMemo(
+    () => makeSelectBubbleLastActiveAt(universeId, bubbleId),
+    [universeId, bubbleId],
+  );
+  const lastActiveAt = useAppSelector(selectLastActiveAt);
+
+  // lastActiveAt === 0 は「まだ一度も明示的にアクティブにされていない」= defer しない
+  const isDeferred = layerIndex > 0 && lastActiveAt > 0 && (Date.now() - lastActiveAt) > DEFERRED_AFTER_MS;
+
+  // deferred に切り替わるべき時刻に自分だけ再レンダーする（全バブルの cascade を避ける）
+  const [, forceUpdate] = useReducer((n: number) => n + 1, 0);
+  useEffect(() => {
+    if (layerIndex === 0 || lastActiveAt === 0) return;
+    const elapsed = Date.now() - lastActiveAt;
+    if (elapsed >= DEFERRED_AFTER_MS) return; // すでに deferred 対象
+    const id = setTimeout(forceUpdate, DEFERRED_AFTER_MS - elapsed + 100);
+    return () => clearTimeout(id);
+  }, [layerIndex, lastActiveAt]);
+
+  const handleActivate = useCallback(() => {
+    dispatch(activateBubble({ bubbleId, timestamp: Date.now() }, universeId));
+  }, [dispatch, bubbleId, universeId]);
+
+  // isDeferred / bubble が変わらない限り content を安定させる
+  const content = useMemo(
+    () => isDeferred ? <BubbleSkeleton bubble={bubble} /> : renderBubbleContent(bubble),
+    [isDeferred, bubble, renderBubbleContent],
+  );
+
+  if (bubble.fillsContainer) {
+    return (
+      <UniverseBubbleView
+        bubble={bubble}
+        position={pos}
+        layerIndex={layerIndex}
+        zIndex={zIndex}
+        vanishingPoint={vanishingPoint}
+        lightweightMode={lightweightMode}
+        onClick={(e) => { handleActivate(); onBubbleClick?.(bubble.url); }}
+        onCloseClick={() => { handleActivate(); onBubbleClose?.(bubble); }}
+        onResize={(updated) => { onBubbleResize?.(updated); }}
+        onLayerDownClick={() => onBubbleLayerDown?.(bubble)}
+        onLayerUpClick={() => { handleActivate(); onBubbleLayerUp?.(bubble); }}
+        onDebugRects={onDebugRects}
+      >
+        {content}
+      </UniverseBubbleView>
+    );
+  }
+
+  return (
+    <BubbleView
+      bubble={bubble}
+      position={pos}
+      layerIndex={layerIndex}
+      zIndex={zIndex}
+      vanishingPoint={vanishingPoint}
+      contentBackground={bubble.contentBackground ?? "white"}
+      hasLeftLink={hasLeftLink}
+      lightweightMode={lightweightMode}
+      onClick={(e) => { handleActivate(); onBubbleClick?.(bubble.url); }}
+      onCloseClick={() => { handleActivate(); onBubbleClose?.(bubble); }}
+      onMove={(updated) => { onBubbleMove?.(updated); }}
+      onResize={(updated) => { onBubbleResize?.(updated); }}
+      onLayerDownClick={() => onBubbleLayerDown?.(bubble)}
+      onLayerUpClick={() => { handleActivate(); onBubbleLayerUp?.(bubble); }}
+      onDebugRects={onDebugRects}
+    >
+      {content}
+    </BubbleView>
+  );
+});
+
+/**
+ * 個別バブルを自分でReduxから取得するラッパーコンポーネント。
+ * per-bubble selector のみを購読し、world-line 操作では再 render しない。
+ * 遅延描画の判定は DeferredBubbleGuard に委譲する。
  */
 type ConnectedBubbleViewProps = {
   universeId: string;
@@ -29,6 +157,7 @@ type ConnectedBubbleViewProps = {
   vanishingPoint: Point2;
   surfaceLayer: Layer;
   hasLeftLink?: boolean;
+  lightweightMode?: boolean;
   renderBubbleContent: (bubble: Bubble) => ReactNode;
   onBubbleClick?: (name: string) => void;
   onBubbleClose?: (bubble: Bubble) => void;
@@ -47,6 +176,7 @@ const ConnectedBubbleView: FC<ConnectedBubbleViewProps> = memo(function Connecte
   vanishingPoint,
   surfaceLayer,
   hasLeftLink,
+  lightweightMode,
   renderBubbleContent,
   onBubbleClick,
   onBubbleClose,
@@ -55,7 +185,7 @@ const ConnectedBubbleView: FC<ConnectedBubbleViewProps> = memo(function Connecte
   onBubbleLayerDown,
   onBubbleLayerUp,
   onDebugRects,
-})  {
+}) {
   const selectBubble = useMemo(() => makeSelectBubbleByIdInUniverse(universeId, bubbleId), [universeId, bubbleId]);
   const bubble = useAppSelector(selectBubble);
 
@@ -64,47 +194,26 @@ const ConnectedBubbleView: FC<ConnectedBubbleViewProps> = memo(function Connecte
   // bubble.position は layer-local 座標。surface レイヤーで universe 座標へ写す
   const pos = surfaceLayer.place(bubble.position || { x: 0, y: 0 });
 
-  // fillsContainer な窓型バブル（universe / iframe / 等）は専用シェルで描く。
-  // 透明な content と窓っぽいヘッダーで「親が透けて見える窓」として表現する。
-  if (bubble.fillsContainer) {
-    return (
-      <UniverseBubbleView
-        bubble={bubble}
-        position={pos}
-        layerIndex={layerIndex}
-        zIndex={zIndex}
-        vanishingPoint={vanishingPoint}
-        onClick={() => onBubbleClick?.(bubble.url)}
-        onCloseClick={() => onBubbleClose?.(bubble)}
-        onResize={(updated) => onBubbleResize?.(updated)}
-        onLayerDownClick={() => onBubbleLayerDown?.(bubble)}
-        onLayerUpClick={() => onBubbleLayerUp?.(bubble)}
-        onDebugRects={onDebugRects}
-      >
-        {renderBubbleContent(bubble)}
-      </UniverseBubbleView>
-    );
-  }
-
   return (
-    <BubbleView
-      bubble={bubble}
-      position={pos}
+    <DeferredBubbleGuard
+      universeId={universeId}
+      bubbleId={bubbleId}
       layerIndex={layerIndex}
       zIndex={zIndex}
       vanishingPoint={vanishingPoint}
-      contentBackground={bubble.contentBackground ?? "white"}
+      bubble={bubble}
+      pos={pos}
       hasLeftLink={hasLeftLink}
-      onClick={() => onBubbleClick?.(bubble.url)}
-      onCloseClick={() => onBubbleClose?.(bubble)}
-      onMove={(updated) => onBubbleMove?.(updated)}
-      onResize={(updated) => onBubbleResize?.(updated)}
-      onLayerDownClick={() => onBubbleLayerDown?.(bubble)}
-      onLayerUpClick={() => onBubbleLayerUp?.(bubble)}
+      lightweightMode={lightweightMode}
+      renderBubbleContent={renderBubbleContent}
+      onBubbleClick={onBubbleClick}
+      onBubbleClose={onBubbleClose}
+      onBubbleMove={onBubbleMove}
+      onBubbleResize={onBubbleResize}
+      onBubbleLayerDown={onBubbleLayerDown}
+      onBubbleLayerUp={onBubbleLayerUp}
       onDebugRects={onDebugRects}
-    >
-      {renderBubbleContent(bubble)}
-    </BubbleView>
+    />
   );
 });
 
@@ -117,6 +226,7 @@ type ConnectedLinkBubbleViewProps = {
   openeeId: string;
   coordinateSystem: CoordinateSystem;
   linkZIndex: number;
+  lightweightMode?: boolean;
 };
 
 const ConnectedLinkBubbleView: FC<ConnectedLinkBubbleViewProps> = memo(function ConnectedLinkBubbleView({
@@ -125,6 +235,7 @@ const ConnectedLinkBubbleView: FC<ConnectedLinkBubbleViewProps> = memo(function 
   openeeId,
   coordinateSystem,
   linkZIndex,
+  lightweightMode,
 }) {
   const selectOpener = useMemo(() => makeSelectBubbleByIdInUniverse(universeId, openerId), [universeId, openerId]);
   const selectOpenee = useMemo(() => makeSelectBubbleByIdInUniverse(universeId, openeeId), [universeId, openeeId]);
@@ -139,6 +250,7 @@ const ConnectedLinkBubbleView: FC<ConnectedLinkBubbleViewProps> = memo(function 
       openee={openee}
       coordinateSystem={coordinateSystem}
       linkZIndex={linkZIndex}
+      lightweightMode={lightweightMode}
     />
   );
 });
@@ -334,11 +446,13 @@ export const BubblesLayeredView: FC<BubblesLayeredViewProps> = ({
     return () => window.removeEventListener('wheel', onWheel);
   }, [universeId]);
 
+  const dispatch = useAppDispatch();
   const [showSurfaceBorder, setShowSurfaceBorder] = useState(false);
   const relationIds = useAppSelector(makeSelectValidBubbleRelationIds(universeId));
   const surfaceLeftTop = useAppSelector(makeSelectSurfaceLeftTop(universeId));
   const coordinateSystem = useAppSelector(makeSelectGlobalCoordinateSystem(universeId));
   const isLayerAnimating = useAppSelector(selectIsLayerAnimating);
+  const lightweightMode = useAppSelector(selectLightweightMode);
 
   const undergroundVanishingPoint: Point2 = vanishingPoint || {
     x: 20,
@@ -384,6 +498,7 @@ export const BubblesLayeredView: FC<BubblesLayeredViewProps> = ({
             vanishingPoint={undergroundVanishingPoint}
             surfaceLayer={surfaceLayer}
             hasLeftLink={hasLeftLink}
+            lightweightMode={lightweightMode}
             renderBubbleContent={renderBubbleContent}
             onBubbleClick={onBubbleClick}
             onBubbleClose={onBubbleClose}
@@ -427,6 +542,7 @@ export const BubblesLayeredView: FC<BubblesLayeredViewProps> = ({
                     openeeId={openeeId}
                     coordinateSystem={coordinateSystem}
                     linkZIndex={linkZIndex}
+                    lightweightMode={lightweightMode}
                   />
                 );
               })
@@ -446,6 +562,13 @@ export const BubblesLayeredView: FC<BubblesLayeredViewProps> = ({
               onClick={() => setShowSurfaceBorder((v) => !v)}
             >
               {showSurfaceBorder ? '◻' : '◼'}
+            </button>
+            <button
+              className="e-lightweight-toggle"
+              onClick={() => dispatch(toggleLightweightMode())}
+              title={lightweightMode ? '通常描画モードへ' : '軽量描画モードへ'}
+            >
+              {lightweightMode ? '精' : '速'}
             </button>
           </div>
         </StyledHeadsUpDisplay>
@@ -558,6 +681,31 @@ const StyledHeadsUpDisplay = styled.div<StyledHeadsUpDisplayProps>`
       background: rgba(255, 255, 255, 0.1);
       color: rgba(255, 255, 255, 0.5);
       font-size: 12px;
+      line-height: 1;
+      cursor: pointer;
+      opacity: 0.4;
+      transition: opacity 0.2s;
+      pointer-events: auto;
+
+      &:hover {
+        opacity: 1;
+        background: rgba(255, 255, 255, 0.2);
+      }
+    }
+
+    .e-lightweight-toggle {
+      position: absolute;
+      bottom: 8px;
+      left: ${({ surface }) => surface.leftTop.x + 40}px;
+      z-index: ${({ surfaceZIndex }) => (surfaceZIndex || 0) + 1};
+      width: 24px;
+      height: 24px;
+      padding: 0;
+      border: 1px solid rgba(255, 255, 255, 0.3);
+      border-radius: 6px;
+      background: rgba(255, 255, 255, 0.1);
+      color: rgba(255, 255, 255, 0.5);
+      font-size: 11px;
       line-height: 1;
       cursor: pointer;
       opacity: 0.4;

--- a/bublys-libs/bubbles-ui/src/lib/ui/BubblesLayeredView.tsx
+++ b/bublys-libs/bubbles-ui/src/lib/ui/BubblesLayeredView.tsx
@@ -104,7 +104,7 @@ const DeferredBubbleGuard: FC<DeferredBubbleGuardProps> = memo(function Deferred
         lightweightMode={lightweightMode}
         onClick={(e) => { handleActivate(); onBubbleClick?.(bubble.url); }}
         onCloseClick={() => { handleActivate(); onBubbleClose?.(bubble); }}
-        onResize={(updated) => { onBubbleResize?.(updated); }}
+        onResize={(updated) => { handleActivate(); onBubbleResize?.(updated); }}
         onLayerDownClick={() => onBubbleLayerDown?.(bubble)}
         onLayerUpClick={() => { handleActivate(); onBubbleLayerUp?.(bubble); }}
         onDebugRects={onDebugRects}
@@ -126,8 +126,8 @@ const DeferredBubbleGuard: FC<DeferredBubbleGuardProps> = memo(function Deferred
       lightweightMode={lightweightMode}
       onClick={(e) => { handleActivate(); onBubbleClick?.(bubble.url); }}
       onCloseClick={() => { handleActivate(); onBubbleClose?.(bubble); }}
-      onMove={(updated) => { onBubbleMove?.(updated); }}
-      onResize={(updated) => { onBubbleResize?.(updated); }}
+      onMove={(updated) => { handleActivate(); onBubbleMove?.(updated); }}
+      onResize={(updated) => { handleActivate(); onBubbleResize?.(updated); }}
       onLayerDownClick={() => onBubbleLayerDown?.(bubble)}
       onLayerUpClick={() => { handleActivate(); onBubbleLayerUp?.(bubble); }}
       onDebugRects={onDebugRects}

--- a/bublys-libs/bubbles-ui/src/lib/ui/BubblesLayeredView.tsx
+++ b/bublys-libs/bubbles-ui/src/lib/ui/BubblesLayeredView.tsx
@@ -104,6 +104,7 @@ const DeferredBubbleGuard: FC<DeferredBubbleGuardProps> = memo(function Deferred
         lightweightMode={lightweightMode}
         onClick={(e) => { handleActivate(); onBubbleClick?.(bubble.url); }}
         onCloseClick={() => { handleActivate(); onBubbleClose?.(bubble); }}
+        onDragActivity={handleActivate}
         onResize={(updated) => { handleActivate(); onBubbleResize?.(updated); }}
         onLayerDownClick={() => onBubbleLayerDown?.(bubble)}
         onLayerUpClick={() => { handleActivate(); onBubbleLayerUp?.(bubble); }}
@@ -126,7 +127,8 @@ const DeferredBubbleGuard: FC<DeferredBubbleGuardProps> = memo(function Deferred
       lightweightMode={lightweightMode}
       onClick={(e) => { handleActivate(); onBubbleClick?.(bubble.url); }}
       onCloseClick={() => { handleActivate(); onBubbleClose?.(bubble); }}
-      onMove={(updated) => { handleActivate(); onBubbleMove?.(updated); }}
+      onMove={(updated) => { onBubbleMove?.(updated); }}
+      onDragActivity={handleActivate}
       onResize={(updated) => { handleActivate(); onBubbleResize?.(updated); }}
       onLayerDownClick={() => onBubbleLayerDown?.(bubble)}
       onLayerUpClick={() => { handleActivate(); onBubbleLayerUp?.(bubble); }}

--- a/bublys-libs/bubbles-ui/src/lib/ui/LinkBubbleView.tsx
+++ b/bublys-libs/bubbles-ui/src/lib/ui/LinkBubbleView.tsx
@@ -72,18 +72,6 @@ export const LinkBubbleView: FC<LinkBubbleViewProps> = ({
       }}
     >
       <svg width="100%" height="100%">
-        <defs>
-          <marker
-            id="arrowhead"
-            markerWidth="10"
-            markerHeight="7"
-            refX="0"
-            refY="3.5"
-            orient="auto"
-          >
-            <polygon points="0 0, 10 3.5, 0 7" fill="red" />
-          </marker>
-        </defs>
         <path
           d={pathData}
           fill={

--- a/bublys-libs/bubbles-ui/src/lib/ui/LinkBubbleView.tsx
+++ b/bublys-libs/bubbles-ui/src/lib/ui/LinkBubbleView.tsx
@@ -9,6 +9,7 @@ type LinkBubbleViewProps = {
   openee: Bubble;
   coordinateSystem: CoordinateSystem;
   linkZIndex: number;
+  lightweightMode?: boolean;
 };
 
 export const LinkBubbleView: FC<LinkBubbleViewProps> = ({
@@ -16,6 +17,7 @@ export const LinkBubbleView: FC<LinkBubbleViewProps> = ({
   openee,
   coordinateSystem,
   linkZIndex,
+  lightweightMode = false,
 }) => {
   const bubbleRefs = useBubbleRefsOptional();
 
@@ -84,13 +86,21 @@ export const LinkBubbleView: FC<LinkBubbleViewProps> = ({
         </defs>
         <path
           d={pathData}
-          stroke="none"
-          strokeWidth="2"
           fill={
-            opener.colorHue === undefined
-              ? "rgba(255,0,0,0.5)"
-              : `hsla(${opener.colorHue}, 50%, 50%, 0.3)`
+            lightweightMode
+              ? "none"
+              : opener.colorHue === undefined
+                ? "rgba(255,0,0,0.5)"
+                : `hsla(${opener.colorHue}, 50%, 50%, 0.3)`
           }
+          stroke={
+            lightweightMode
+              ? opener.colorHue === undefined
+                ? "rgba(255,0,0,0.7)"
+                : `hsla(${opener.colorHue}, 50%, 50%, 0.7)`
+              : "none"
+          }
+          strokeWidth={lightweightMode ? "1.5" : "0"}
         />
       </svg>
     </div>

--- a/bublys-libs/bubbles-ui/src/lib/ui/UniverseBubbleView.tsx
+++ b/bublys-libs/bubbles-ui/src/lib/ui/UniverseBubbleView.tsx
@@ -64,6 +64,7 @@ type UniverseBubbleViewProps = {
   children?: React.ReactNode;
   onClick?: (e: React.MouseEvent<HTMLDivElement>) => void;
   onCloseClick?: (bubble: Bubble) => void;
+  onDragActivity?: () => void; // ドラッグ中・終了時に呼ばれる（deferred timer リセット用）
   onLayerDownClick?: (bubble: Bubble) => void;
   onLayerUpClick?: (bubble: Bubble) => void;
   onResize?: (bubble: Bubble) => void;
@@ -81,6 +82,7 @@ const UniverseBubbleViewInner: FC<UniverseBubbleViewProps> = ({
   lightweightMode = false,
   onClick,
   onCloseClick,
+  onDragActivity,
   onLayerDownClick,
   onLayerUpClick,
   onResize,
@@ -104,7 +106,7 @@ const UniverseBubbleViewInner: FC<UniverseBubbleViewProps> = ({
     },
   });
 
-  const { onDragStart } = useBubbleDrag({ bubble, ref, layerIndex, vanishingPoint });
+  const { onDragStart } = useBubbleDrag({ bubble, ref, layerIndex, vanishingPoint, onDragActivity });
   const { onResizeStart } = useBubbleResize({ bubble, ref });
 
   const [isFocused, setIsFocused] = useState(false);

--- a/bublys-libs/bubbles-ui/src/lib/ui/UniverseBubbleView.tsx
+++ b/bublys-libs/bubbles-ui/src/lib/ui/UniverseBubbleView.tsx
@@ -2,7 +2,7 @@
 import { FC, useContext, useLayoutEffect, useMemo, useState, memo } from "react";
 import styled from "styled-components";
 import { Bubble } from "../Bubble.domain.js";
-import { Point2, Vec2, CoordinateSystem, SmartRect } from "@bublys-org/bubbles-ui-util";
+import { Point2, Vec2, CoordinateSystem, SmartRect, Layer } from "@bublys-org/bubbles-ui-util";
 import { useMyRectObserver } from "../hooks/useMyRect.js";
 import { useBubbleDrag } from "../hooks/useBubbleDrag.js";
 import { useBubbleResize } from "../hooks/useBubbleResize.js";
@@ -12,7 +12,7 @@ import { BubblesContext } from "../bubble-routing/BubbleRouting.js";
 import { useBubbleRefsOptional } from "../context/BubbleRefsContext.js";
 import { measureViewport } from "../utils/measure-viewport.js";
 import { useUniverseId } from "../context/UniverseContext.js";
-import { Layer } from "@bublys-org/bubbles-ui-util";
+import { CloseIcon, ToggleSizeIcon, LayerUpIcon, LayerDownIcon } from "./BubbleIcons.js";
 
 /**
  * Universe（window 型）バブルの専用シェル。
@@ -20,37 +20,6 @@ import { Layer } from "@bublys-org/bubbles-ui-util";
  * 「窓」として扱う。コンテンツ領域は透明で、中の universe / iframe / 等が
  * そのまま見える。
  */
-
-const CloseIcon: FC<{ size?: number }> = ({ size = 16 }) => (
-  <svg width={size} height={size} viewBox="0 0 24 24" fill="none">
-    <path d="M7 7L17 17M17 7L7 17" stroke="currentColor" strokeWidth="2" strokeLinecap="round" />
-  </svg>
-);
-
-const MaximizeIcon: FC<{ size?: number; isMaximized: boolean }> = ({ size = 16, isMaximized }) => (
-  <svg width={size} height={size} viewBox="0 0 24 24" fill="none">
-    {isMaximized ? (
-      <>
-        <path d="M8 8L10 10M16 16L14 14" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
-        <path d="M16 8L14 10M8 16L10 14" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
-      </>
-    ) : (
-      <rect x="7" y="7" width="10" height="10" rx="1.5" stroke="currentColor" strokeWidth="1.5" />
-    )}
-  </svg>
-);
-
-const LayerUpIcon: FC<{ size?: number }> = ({ size = 16 }) => (
-  <svg width={size} height={size} viewBox="0 0 24 24" fill="none">
-    <path d="M8 14L12 9L16 14" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
-  </svg>
-);
-
-const LayerDownIcon: FC<{ size?: number }> = ({ size = 16 }) => (
-  <svg width={size} height={size} viewBox="0 0 24 24" fill="none">
-    <path d="M8 10L12 15L16 10" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
-  </svg>
-);
 
 type UniverseBubbleViewProps = {
   bubble: Bubble;
@@ -190,7 +159,7 @@ const UniverseBubbleViewInner: FC<UniverseBubbleViewProps> = ({
             onClick={handleToggleSize}
             title={isMaximized ? "フィット" : "最大化"}
           >
-            <MaximizeIcon isMaximized={isMaximized} />
+            <ToggleSizeIcon isMaximized={isMaximized} />
           </button>
         </div>
         <div className="e-window-title">{bubble.type}</div>

--- a/bublys-libs/bubbles-ui/src/lib/ui/UniverseBubbleView.tsx
+++ b/bublys-libs/bubbles-ui/src/lib/ui/UniverseBubbleView.tsx
@@ -64,7 +64,6 @@ type UniverseBubbleViewProps = {
   children?: React.ReactNode;
   onClick?: (e: React.MouseEvent<HTMLDivElement>) => void;
   onCloseClick?: (bubble: Bubble) => void;
-  onDragActivity?: () => void; // ドラッグ中・終了時に呼ばれる（deferred timer リセット用）
   onLayerDownClick?: (bubble: Bubble) => void;
   onLayerUpClick?: (bubble: Bubble) => void;
   onResize?: (bubble: Bubble) => void;
@@ -82,7 +81,6 @@ const UniverseBubbleViewInner: FC<UniverseBubbleViewProps> = ({
   lightweightMode = false,
   onClick,
   onCloseClick,
-  onDragActivity,
   onLayerDownClick,
   onLayerUpClick,
   onResize,
@@ -106,7 +104,7 @@ const UniverseBubbleViewInner: FC<UniverseBubbleViewProps> = ({
     },
   });
 
-  const { onDragStart } = useBubbleDrag({ bubble, ref, layerIndex, vanishingPoint, onDragActivity });
+  const { onDragStart } = useBubbleDrag({ bubble, ref, layerIndex, vanishingPoint });
   const { onResizeStart } = useBubbleResize({ bubble, ref });
 
   const [isFocused, setIsFocused] = useState(false);
@@ -157,10 +155,10 @@ const UniverseBubbleViewInner: FC<UniverseBubbleViewProps> = ({
       ref={ref}
       data-bubble-id={bubble.id}
       data-window-style="universe"
+      style={{ left: position ? `${position.x}px` : 0, top: position ? `${position.y}px` : 0 }}
       $colorHue={bubble.colorHue}
       $zIndex={isFocused ? 100 : zIndex}
       $layerIndex={layerIndex}
-      $position={position}
       $transformOrigin={vanishingPointRelative}
       onClick={onClick}
       onMouseLeave={handleMouseLeave}
@@ -259,7 +257,6 @@ export const UniverseBubbleView = memo(UniverseBubbleViewInner, (prev, next) => 
 });
 
 type StyledWindowProps = React.HTMLAttributes<HTMLDivElement> & {
-  $position?: Point2;
   $layerIndex?: number;
   $zIndex?: number;
   $transformOrigin?: Vec2;
@@ -282,8 +279,6 @@ const StyledWindow = styled.div<StyledWindowProps>`
   width: ${({ $width }) => $width || "fit-content"};
   height: ${({ $height }) => $height || "auto"};
   z-index: ${({ $zIndex }) => ($zIndex !== undefined ? $zIndex : 0)};
-  left: ${({ $position }) => ($position ? `${$position.x}px` : "0")};
-  top: ${({ $position }) => ($position ? `${$position.y}px` : "0")};
 
   transition-property: left top transform;
   transition: ${({ $lightweightMode }) => $lightweightMode ? 'none' : '0.3s ease-in-out'};

--- a/bublys-libs/bubbles-ui/src/lib/ui/UniverseBubbleView.tsx
+++ b/bublys-libs/bubbles-ui/src/lib/ui/UniverseBubbleView.tsx
@@ -60,6 +60,7 @@ type UniverseBubbleViewProps = {
   zIndex?: number;
   /** ヘッダー右側に追加で挟みたいコントロール（例: ←→ 世界線ナビ） */
   headerExtras?: React.ReactNode;
+  lightweightMode?: boolean;
   children?: React.ReactNode;
   onClick?: (e: React.MouseEvent<HTMLDivElement>) => void;
   onCloseClick?: (bubble: Bubble) => void;
@@ -77,6 +78,7 @@ const UniverseBubbleViewInner: FC<UniverseBubbleViewProps> = ({
   position = { x: 0, y: 0 },
   vanishingPoint = new Vec2({ x: 0, y: 0 }),
   headerExtras,
+  lightweightMode = false,
   onClick,
   onCloseClick,
   onLayerDownClick,
@@ -167,6 +169,7 @@ const UniverseBubbleViewInner: FC<UniverseBubbleViewProps> = ({
       $width={bubble.size ? `${bubble.size.width}px` : undefined}
       $height={bubble.size ? `${bubble.size.height}px` : undefined}
       $backdropColor={bubble.backdropColor}
+      $lightweightMode={lightweightMode}
     >
       <header className="e-window-header" onMouseDown={handleHeaderMouseDown}>
         <div className="e-window-buttons-left">
@@ -249,6 +252,7 @@ export const UniverseBubbleView = memo(UniverseBubbleViewInner, (prev, next) => 
   if (prev.position?.x !== next.position?.x || prev.position?.y !== next.position?.y) return false;
   if (prev.layerIndex !== next.layerIndex || prev.zIndex !== next.zIndex) return false;
   if (prev.headerExtras !== next.headerExtras) return false;
+  if (prev.lightweightMode !== next.lightweightMode) return false;
   return true;
 });
 
@@ -261,6 +265,7 @@ type StyledWindowProps = React.HTMLAttributes<HTMLDivElement> & {
   $width?: string;
   $height?: string;
   $backdropColor?: string;
+  $lightweightMode?: boolean;
   ref: React.RefObject<HTMLDivElement | null>;
 };
 
@@ -279,7 +284,7 @@ const StyledWindow = styled.div<StyledWindowProps>`
   top: ${({ $position }) => ($position ? `${$position.y}px` : "0")};
 
   transition-property: left top transform;
-  transition: 0.3s ease-in-out;
+  transition: ${({ $lightweightMode }) => $lightweightMode ? 'none' : '0.3s ease-in-out'};
 
   transform-origin: ${({ $transformOrigin }) =>
     $transformOrigin ? `${$transformOrigin.x}px ${$transformOrigin.y}px` : "center center"};
@@ -301,10 +306,10 @@ const StyledWindow = styled.div<StyledWindowProps>`
       : "transparent"};
   border: none;
   border-radius: 14px;
-  box-shadow:
-    0 16px 48px hsla(0, 0%, 0%, 0.5),
-    0 2px 8px hsla(0, 0%, 0%, 0.25);
-  backdrop-filter: blur(10px) saturate(1.15);
+  box-shadow: ${({ $lightweightMode }) => $lightweightMode
+    ? 'none'
+    : '0 16px 48px hsla(0, 0%, 0%, 0.5), 0 2px 8px hsla(0, 0%, 0%, 0.25)'};
+  backdrop-filter: ${({ $lightweightMode }) => $lightweightMode ? 'none' : 'blur(10px) saturate(1.15)'};
 
   > .e-window-header {
     /* StyledWindow が none なので、操作を受けるヘッダーは explicit に auto。 */

--- a/bublys-libs/state-management/src/lib/slices/environment-slice.ts
+++ b/bublys-libs/state-management/src/lib/slices/environment-slice.ts
@@ -5,10 +5,12 @@ import type { Size2 } from "@bublys-org/bubbles-ui-util";
 
 export interface EnvironmentState {
   windowSize: Size2;
+  lightweightMode: boolean;
 }
 
 const initialState: EnvironmentState = {
   windowSize: { width: 0, height: 0 },
+  lightweightMode: false,
 };
 
 export const environmentSlice = createSlice({
@@ -18,11 +20,17 @@ export const environmentSlice = createSlice({
     setWindowSize: (state, action: PayloadAction<Size2>) => {
       state.windowSize = action.payload;
     },
+    toggleLightweightMode: (state) => {
+      state.lightweightMode = !state.lightweightMode;
+    },
   },
 });
 
-export const { setWindowSize } = environmentSlice.actions;
+export const { setWindowSize, toggleLightweightMode } = environmentSlice.actions;
 
 export const selectWindowSize = (state: RootState) =>
   state.environment.windowSize;
+
+export const selectLightweightMode = (state: RootState) =>
+  state.environment.lightweightMode;
 

--- a/bublys-libs/state-management/src/lib/slices/world-slice.ts
+++ b/bublys-libs/state-management/src/lib/slices/world-slice.ts
@@ -84,3 +84,13 @@ export const selectAllWorldLineObjectIds = createSelector(
   [selectWorldLines],
   (worldLines) => Object.keys(worldLines)
 );
+
+// 全operationHistoryの総操作数（論理クロック）。
+// バブルの「最終アクティブ時の seq」と比較することで、
+// 長期間未操作かどうかを判定できる。
+const selectOperationHistoryMap = (state: RootState) => state.worldLine.operationHistory;
+export const selectGlobalOperationSeq = createSelector(
+  [selectOperationHistoryMap],
+  (operationHistory) =>
+    Object.values(operationHistory).reduce((sum, ops) => sum + ops.length, 0),
+);


### PR DESCRIPTION
## 関連

- https://github.com/fumicode/bublys-org/issues/61

## Summary

- **layer 3+ バブルをスケルトン化**: scale ≤ 0.8 で内容が読めないバブルは `BubbleSkeleton`（見出しのみ）に差し替え、最大 ~2000 DOM ノード/バブルを削減
- **軽量描画モード（速/精トグル）を追加**: `lightweightMode` で gradient・box-shadow・backdrop-filter・`::before` を一括省略（対象 CSS プロパティ 3→9 に拡張）
- **position を inline style に移動**: `left`/`top` を styled-components テンプレートから外し、バブル移動ごとの CSS クラス生成を排除
- **SVG アイコン共通化・circle 要素削除**: `BubbleIcons.tsx` に集約、各バブルのボタンから冗長な `<circle>` ノードを除去（最大 4 ノード/バブル削減）
- **不要な再レンダリング排除**:
  - `BubbleRefsContext.Provider` の value を `useMemo` 化（Context 変化による全バブル強制再レンダリングを解消）
  - `BubblesLayeredView` を `memo` 化
  - `renderedBubbles` を `useMemo` 化、コールバック 6 つを `useCallback` 化
  - 呼び出し元（`BublyApp`・`BubblesUI`）のコールバックも `useCallback` 化
  - `BubbleSkeleton` を `memo` 化

## 変更ファイル（主要）

| ファイル | 変更内容 |
|---|---|
| `BubblesLayeredView.tsx` | DeferredBubbleGuard 廃止・layer 3+ スケルトン化・useMemo/useCallback 最適化・BubblesLayeredView memo 化 |
| `BubbleView.tsx` | position inline style 化・lightweightMode 拡張（::before, .e-bubble-name, .e-bubble-content）|
| `UniverseBubbleView.tsx` | position inline style 化・onDragActivity 削除 |
| `BubbleRefsContext.tsx` | Context value を useMemo 化 |
| `BubbleIcons.tsx` | 新規作成（アイコン共通化） |
| `BubbleSkeleton.tsx` | 新規作成 + memo 化 |
| `LinkBubbleView.tsx` | lightweightMode 対応（fill→stroke 切替）・未使用 defs 削除 |
| `BublyApp.tsx` / `BubblesUI.tsx` | コールバック useCallback 化 |

## Test plan

- [x] バブルを3つ以上 popChild して layer 3+ でスケルトン表示になることを確認
- [x] 軽量化モード（速）トグルで gradient/shadow が消えることを確認
- [x] バブルをドラッグして位置が正常に更新されることを確認
- [x] LinkBubble が表示・更新されることを確認
- [ ] ポケット開閉・スライダー操作でバブルが不要に再レンダリングされないことを確認（React DevTools Profiler）

🤖 Generated with [Claude Code](https://claude.com/claude-code)