### PR TITLE
feat: ヘッダー上のマウスホイールでレイヤー移動 (#79)

### DIFF
--- a/bublys-libs/bubbles-ui/src/lib/hooks/useWheelLayerNavigation.ts
+++ b/bublys-libs/bubbles-ui/src/lib/hooks/useWheelLayerNavigation.ts
@@ -1,0 +1,84 @@
+"use client";
+import { useRef, useCallback } from "react";
+import { Bubble } from "../Bubble.domain.js";
+import { acquireWheelLayerLock, useWheelLayerLockListener } from "./wheelLayerLock.js";
+
+// ホイールの1ノッチ相当（多くのマウスは1クリックでdeltaY=100）。
+// トラックパッドの細かいdeltaも積算し、閾値を超えるたびに1レイヤー分移動する。
+const WHEEL_LAYER_THRESHOLD = 50;
+
+type UseWheelLayerNavigationArgs = {
+  bubble: Bubble;
+  onLayerUpClick?: (bubble: Bubble) => void;
+  onLayerDownClick?: (bubble: Bubble) => void;
+};
+
+/**
+ * ヘッダー上でのマウスホイール操作でレイヤーを移動するhook。
+ * 上スクロールで手前のレイヤーへ、下スクロールで奥のレイヤーへ移動する。
+ *
+ * ReactのonWheelはpassiveリスナーとして登録されるため、その中でpreventDefault()
+ * を呼んでも無視され、背後のスクロールバーが動いてしまう。ここではcallback ref
+ * でヘッダー要素に直接 { passive: false } のネイティブリスナーを張ることで、
+ * デフォルトスクロールを確実に止める。
+ *
+ * また、ホイール操作中はレイヤー移動でバブルが拡大縮小しヘッダーがカーソル
+ * 直下から動いてしまうため、{@link acquireWheelLayerLock} でこのバブルへの
+ * 操作を一時的にロックし、カーソルがヘッダーから外れても操作を継続できるようにする。
+ */
+export function useWheelLayerNavigation({
+  bubble,
+  onLayerUpClick,
+  onLayerDownClick,
+}: UseWheelLayerNavigationArgs) {
+  useWheelLayerLockListener();
+
+  const accumulatedDeltaRef = useRef(0);
+
+  const bubbleRef = useRef(bubble);
+  bubbleRef.current = bubble;
+  const onLayerUpClickRef = useRef(onLayerUpClick);
+  onLayerUpClickRef.current = onLayerUpClick;
+  const onLayerDownClickRef = useRef(onLayerDownClick);
+  onLayerDownClickRef.current = onLayerDownClick;
+
+  const processWheelDelta = useCallback((deltaY: number) => {
+    if (!onLayerUpClickRef.current && !onLayerDownClickRef.current) return;
+
+    accumulatedDeltaRef.current += deltaY;
+
+    while (accumulatedDeltaRef.current <= -WHEEL_LAYER_THRESHOLD) {
+      onLayerUpClickRef.current?.(bubbleRef.current);
+      accumulatedDeltaRef.current += WHEEL_LAYER_THRESHOLD;
+    }
+    while (accumulatedDeltaRef.current >= WHEEL_LAYER_THRESHOLD) {
+      onLayerDownClickRef.current?.(bubbleRef.current);
+      accumulatedDeltaRef.current -= WHEEL_LAYER_THRESHOLD;
+    }
+  }, []);
+
+  const cleanupRef = useRef<(() => void) | null>(null);
+
+  const headerRef = useCallback(
+    (node: HTMLElement | null) => {
+      cleanupRef.current?.();
+      cleanupRef.current = null;
+      if (!node) return;
+
+      const onWheel = (e: WheelEvent) => {
+        if (!onLayerUpClickRef.current && !onLayerDownClickRef.current) return;
+        e.preventDefault();
+        e.stopPropagation();
+
+        acquireWheelLayerLock(processWheelDelta);
+        processWheelDelta(e.deltaY);
+      };
+
+      node.addEventListener("wheel", onWheel, { passive: false });
+      cleanupRef.current = () => node.removeEventListener("wheel", onWheel);
+    },
+    [processWheelDelta]
+  );
+
+  return { headerRef };
+}

--- a/bublys-libs/bubbles-ui/src/lib/hooks/wheelLayerLock.ts
+++ b/bublys-libs/bubbles-ui/src/lib/hooks/wheelLayerLock.ts
@@ -1,0 +1,62 @@
+"use client";
+import { useEffect } from "react";
+
+// ホイール操作を開始したバブルが無操作でこの時間(ms)続いたらロックを解除する。
+const LOCK_IDLE_MS = 300;
+
+type WheelDeltaHandler = (deltaY: number) => void;
+
+let lockedHandler: WheelDeltaHandler | null = null;
+let idleTimer: ReturnType<typeof setTimeout> | null = null;
+let listenerRefCount = 0;
+
+const resetIdleTimer = () => {
+  if (idleTimer) clearTimeout(idleTimer);
+  idleTimer = setTimeout(() => {
+    lockedHandler = null;
+    idleTimer = null;
+  }, LOCK_IDLE_MS);
+};
+
+/**
+ * ヘッダー上でホイール操作を開始したバブルに、無操作 {@link LOCK_IDLE_MS} ms の
+ * 間ホイールイベントを固定して送り続ける。
+ *
+ * レイヤー移動でバブルが拡大縮小すると、ヘッダーがカーソル直下から動いてしまい
+ * 続けてホイールを回すと違う要素に当たってしまう。ロック中はカーソルがヘッダーの
+ * 真上から外れていても同じバブルへ操作を送り続けることで、この不便さを解消する。
+ */
+const onWindowWheel = (e: WheelEvent) => {
+  if (!lockedHandler) return;
+  e.preventDefault();
+  e.stopPropagation();
+  lockedHandler(e.deltaY);
+  resetIdleTimer();
+};
+
+export function acquireWheelLayerLock(handler: WheelDeltaHandler) {
+  lockedHandler = handler;
+  resetIdleTimer();
+}
+
+/**
+ * ロック中継用の window wheel リスナーを、実体は1個だけ張る（複数バブルの
+ * useWheelLayerNavigation から呼ばれてもref countで多重登録を防ぐ）。
+ */
+export function useWheelLayerLockListener() {
+  useEffect(() => {
+    listenerRefCount += 1;
+    if (listenerRefCount === 1) {
+      window.addEventListener("wheel", onWindowWheel, { passive: false });
+    }
+    return () => {
+      listenerRefCount -= 1;
+      if (listenerRefCount === 0) {
+        window.removeEventListener("wheel", onWindowWheel);
+        if (idleTimer) clearTimeout(idleTimer);
+        idleTimer = null;
+        lockedHandler = null;
+      }
+    };
+  }, []);
+}

--- a/bublys-libs/bubbles-ui/src/lib/ui/BubbleView.tsx
+++ b/bublys-libs/bubbles-ui/src/lib/ui/BubbleView.tsx
@@ -5,6 +5,7 @@ import { Point2, Vec2, CoordinateSystem, SmartRect, Layer } from "@bublys-org/bu
 import { useMyRectObserver } from "../hooks/useMyRect.js";
 import { useBubbleDrag } from "../hooks/useBubbleDrag.js";
 import { useBubbleResize } from "../hooks/useBubbleResize.js";
+import { useWheelLayerNavigation } from "../hooks/useWheelLayerNavigation.js";
 import { useAppDispatch } from "@bublys-org/state-management";
 import { renderBubble, updateBubble, finishBubbleAnimation, focusBubble } from "../state/bubbles-slice.js";
 import { BubblesContext } from "../bubble-routing/BubbleRouting.js";
@@ -199,6 +200,7 @@ const BubbleViewInner: FC<BubbleProps> = ({
 
   const { onDragStart } = useBubbleDrag({ bubble, ref, layerIndex, vanishingPoint });
   const { onResizeStart } = useBubbleResize({ bubble, ref });
+  const { headerRef } = useWheelLayerNavigation({ bubble, onLayerUpClick, onLayerDownClick });
 
   const [isMouseNearTop, setIsMouseNearTop] = useState(false);
   const [headerOffset, setHeaderOffset] = useState(0);
@@ -315,7 +317,7 @@ const BubbleViewInner: FC<BubbleProps> = ({
       hasLeftLink={hasLeftLink}
       fillsContainer={bubble.fillsContainer}
     >
-      <header className="e-bubble-header" onMouseDown={handleHeaderMouseDown}>
+      <header className="e-bubble-header" ref={headerRef} onMouseDown={handleHeaderMouseDown}>
         <div
           className="e-address-bar"
           onClick={(e) => e.stopPropagation()}

--- a/bublys-libs/bubbles-ui/src/lib/ui/UniverseBubbleView.tsx
+++ b/bublys-libs/bubbles-ui/src/lib/ui/UniverseBubbleView.tsx
@@ -6,6 +6,7 @@ import { Point2, Vec2, CoordinateSystem, SmartRect } from "@bublys-org/bubbles-u
 import { useMyRectObserver } from "../hooks/useMyRect.js";
 import { useBubbleDrag } from "../hooks/useBubbleDrag.js";
 import { useBubbleResize } from "../hooks/useBubbleResize.js";
+import { useWheelLayerNavigation } from "../hooks/useWheelLayerNavigation.js";
 import { useAppDispatch, useAppSelector } from "@bublys-org/state-management";
 import { renderBubble, updateBubble, finishBubbleAnimation, focusBubble, makeSelectFocusedBubbleId } from "../state/bubbles-slice.js";
 import { BubblesContext } from "../bubble-routing/BubbleRouting.js";
@@ -109,6 +110,7 @@ const UniverseBubbleViewInner: FC<UniverseBubbleViewProps> = ({
 
   const { onDragStart } = useBubbleDrag({ bubble, ref, layerIndex, vanishingPoint });
   const { onResizeStart } = useBubbleResize({ bubble, ref });
+  const { headerRef } = useWheelLayerNavigation({ bubble, onLayerUpClick, onLayerDownClick });
 
   const [isMouseNearTop, setIsMouseNearTop] = useState(false);
   const [isHeaderHovered, setIsHeaderHovered] = useState(false);
@@ -200,6 +202,7 @@ const UniverseBubbleViewInner: FC<UniverseBubbleViewProps> = ({
 
       <header
         className="e-window-header"
+        ref={headerRef}
         onMouseDown={handleHeaderMouseDown}
         onMouseEnter={() => setIsHeaderHovered(true)}
         onMouseLeave={() => setIsHeaderHovered(false)}


### PR DESCRIPTION
## Summary

- ヘッダー上でマウスホイールを操作するとレイヤーを移動できるようにした（下スクロールで奥へ、上スクロールで手前へ）
- `BubbleView` / `UniverseBubbleView` 両方のヘッダーに適用（既存の `onLayerUpClick` / `onLayerDownClick` ボタンと同じアクションを再利用）
- ホイール1ノッチ相当(deltaY 50px)ごとに1レイヤー移動。トラックパッドの細かいdeltaも積算して閾値超過ごとに発火
- Reactの合成`onWheel`はpassiveリスナーとして登録されるため`preventDefault()`が無視され、背後のスクロールバーが動いてしまう問題があった → ヘッダー要素に直接 `{ passive: false }` のネイティブリスナーを張ることで解消
- レイヤー移動でバブルが拡大縮小し、ヘッダーがカーソル直下から外れて操作が続けられなくなる問題があった → ホイール開始時に操作対象のバブルを無操作300msの間ロックし、カーソルがヘッダーから外れても操作を継続できるようにした

Closes #79

## Test plan

- [x] `tsc --noEmit` (bubbles-ui) - エラーなし
- [x] `eslint` (新規/変更ファイル) - エラーなし
- [x] ヘッダー上でホイール操作 → レイヤーが移動し、バブルサイズ・z-indexが変化することを確認
- [x] ヘッダー上でホイール操作中、背後のスクロールバーが動かないことを確認
- [x] レイヤー移動でヘッダーがカーソルから外れても、連続したホイール操作が同じバブルに効き続けることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)